### PR TITLE
Feature: Add language auto-detection and GUI selector

### DIFF
--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -33,8 +33,8 @@ def parse_arguments():
     parser.add_argument(
         "--language",
         type=str,
-        choices=["en-us", "fr", "de", "ru"],
-        help="Speech recognition language (en-us, fr, de, ru)",
+        choices=["auto", "en-us", "fr", "de", "ru"],
+        help="Speech recognition language (auto for Whisper auto-detect, en-us, fr, de, ru)",
     )
     parser.add_argument(
         "--engine",

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -301,10 +301,13 @@ class SpeechRecognitionManager:
 
     def _init_vosk(self):
         """Initialize the VOSK speech recognition engine."""
+        # VOSK doesn't support auto-detection, fall back to en-us for "auto"
+        vosk_language = "en-us" if self.language == "auto" else self.language
+
         self.vosk_model_map = {
-            "small": VOSK_MODEL_INFO["small"]["languages"].get(self.language),
-            "medium": VOSK_MODEL_INFO["medium"]["languages"].get(self.language),
-            "large": VOSK_MODEL_INFO["large"]["languages"].get(self.language),
+            "small": VOSK_MODEL_INFO["small"]["languages"].get(vosk_language),
+            "medium": VOSK_MODEL_INFO["medium"]["languages"].get(vosk_language),
+            "large": VOSK_MODEL_INFO["large"]["languages"].get(vosk_language),
         }
 
         try:
@@ -449,9 +452,12 @@ class SpeechRecognitionManager:
                 import torch
             use_fp16 = self.model.device != torch.device("cpu")
 
+            # Handle language parameter - "auto" enables Whisper's auto-detection
             lang = self.language
             if self.language == "en-us":
                 lang = "en"
+            elif self.language == "auto":
+                lang = None  # None enables Whisper's auto language detection
 
             # Transcribe with Whisper (handles variable length audio automatically)
             result = self.model.transcribe(

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -19,7 +19,7 @@ CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
 DEFAULT_CONFIG = {
     "speech_recognition": {  # Changed section name
         "engine": "whisper",  # "vosk" or "whisper" - whisper is default for better accuracy
-        "language": "en-us",  # "en-us", "fr", "de" or "ru"
+        "language": "en-us",  # "auto" for Whisper auto-detect, "en-us", "fr", "de", or "ru"
         "model_size": "tiny",  # Current model size (for backward compatibility)
         "vosk_model_size": "small",  # Default model for VOSK engine
         "whisper_model_size": "tiny",  # Default model for Whisper engine


### PR DESCRIPTION
This PR implements the enhancements suggested during review of PRs #52 and #68.

## Changes

### 1. Auto-detection for Whisper (`"auto"` language option)
- Adds `"auto"` as a language option for Whisper's automatic language detection
- CLI: `--language auto`
- VOSK falls back to `"en-us"` when auto is selected (VOSK doesn't support auto-detect)
- In `recognition_manager.py`: `language=None` enables Whisper's auto-detection

### 2. GUI Language Selector
- Adds dropdown in Settings dialog for language selection
- Options: Auto-detect (Whisper only), English (US), French, German, Russian
- Properly integrated with existing settings system
- Removes TODO comment about language GUI selection

### 3. Updated Documentation
- Config comments updated to mention `"auto"` option
- CLI help text updated

## Related PRs

- Builds on PR #71 (multi-language support)
- Addresses suggestions from PR #52 review
- Addresses suggestions from PR #68 review

## Testing

- [ ] Test language dropdown in Settings
- [ ] Test auto-detection with Whisper
- [ ] Test VOSK falls back to en-us with auto selected
- [ ] Test CLI `--language auto` flag