### PR TITLE
fix(install): allow --interactive flag to bypass TTY check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,6 +32,7 @@ WHISPER_CPU="no"
 NO_WHISPER_EXPLICIT="no"
 NON_INTERACTIVE="no"
 INTERACTIVE_MODE="yes"  # Default to interactive mode
+INTERACTIVE_MODE_EXPLICIT="no"  # Track if user explicitly requested interactive mode
 AUTO_MODE="no"
 HAS_NVIDIA_GPU="unknown"
 GPU_NAME=""
@@ -71,6 +72,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --interactive|-i)
             INTERACTIVE_MODE="yes"
+            INTERACTIVE_MODE_EXPLICIT="yes"
             shift
             ;;
         --tag=*)
@@ -544,7 +546,9 @@ fi
 # Run interactive installation if selected
 if [[ "$INTERACTIVE_MODE" == "yes" ]]; then
     # Check if we have a TTY (required for interactive mode)
-    if [ ! -t 0 ]; then
+    # If user explicitly requested interactive mode with --interactive, trust them
+    # even if stdin is not a TTY (e.g., curl | bash pipe)
+    if [ ! -t 0 ] && [[ "$INTERACTIVE_MODE_EXPLICIT" != "yes" ]]; then
         print_error "Interactive mode requires a terminal (TTY)."
         print_error "Please run from a terminal, or use automatic mode:"
         print_error "  curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash -s -- --auto"


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes #189 

### Problem
When running the installer via curl pipe (e.g., `curl ... | bash -s -- --interactive`), the script would fail with:
```
[ERROR] Interactive mode requires a terminal (TTY).
```

This happened because:
1. When using `curl | bash`, stdin (file descriptor 0) is connected to the curl pipe, not the terminal
2. The TTY check `[ ! -t 0 ]` was too strict and failed even when the user explicitly passed `--interactive`
3. The script didn't differentiate between auto-detected mode and user-explicit requests

### Solution
- Added `INTERACTIVE_MODE_EXPLICIT` variable to track when the user explicitly requests interactive mode via `--interactive` or `-i` flag
- Modified the TTY check to only error if:
  - stdin is not a TTY **AND**
  - the user didn't explicitly request interactive mode

### Changes
- `install.sh`: Added `INTERACTIVE_MODE_EXPLICIT` tracking and updated TTY check logic

### Testing
This fix allows these commands to work correctly from a terminal:
```bash
# Explicit interactive mode with curl pipe - now works
curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash -s -- --interactive

# Short form - also works
curl -fsSL https://raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh | bash -s -- -i
```

### Backwards Compatibility
- Running without flags from a terminal still defaults to interactive mode
- Running via curl pipe without `--interactive` still prompts the user to choose between interactive/auto mode (if stdout is a TTY)
- `--auto` mode continues to work as before
