### PR TITLE
feat(speech): auto-stop microphone after inactivity

### DIFF
--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -389,6 +389,7 @@ class SpeechRecognitionManager:
         self.silence_timeout = kwargs.get("silence_timeout", 2.0)
         self.session_timeout = kwargs.get("session_timeout", 10.0)
         self.enable_session_timeout = kwargs.get("enable_session_timeout", True)
+        self._session_timeout_lock = threading.Lock()
         self._last_speech_time = None
 
         # Audio device selection (None means use system default)
@@ -1358,7 +1359,7 @@ class SpeechRecognitionManager:
         # Set recording flag
         self.should_record = True
         self.audio_buffer = []
-        self._last_speech_time = None  # Reset session timeout tracking
+        self._set_last_speech_time(None)  # Reset session timeout tracking
 
         # Start the audio recording thread
         self.audio_thread = threading.Thread(target=self._record_audio)
@@ -1574,28 +1575,26 @@ class SpeechRecognitionManager:
                             silence_counter = 0
 
                             # Check session timeout (auto-stop after inactivity)
-                            if (
-                                self.enable_session_timeout
-                                and self._last_speech_time is not None
-                                and speech_detected_in_session
-                            ):
-                                idle_time = time.time() - self._last_speech_time
-                                if idle_time >= self.session_timeout:
-                                    logger.info(
-                                        f"Session timeout reached ({idle_time:.1f}s idle). Auto-stopping recognition."
-                                    )
-                                    _show_notification(
-                                        "Voice Recognition Stopped",
-                                        "Microphone stopped due to inactivity",
-                                        "audio-input-microphone-symbolic",
-                                    )
-                                    play_stop_sound()
-                                    break  # Exit the recording loop
+                            if self._session_timeout_reached(speech_detected_in_session):
+                                last_speech_time = self._get_last_speech_time()
+                                if last_speech_time is not None:
+                                    idle_time = time.time() - last_speech_time
+                                    if idle_time >= self.session_timeout:
+                                        logger.info(
+                                            f"Session timeout reached ({idle_time:.1f}s idle). Auto-stopping recognition."
+                                        )
+                                        _show_notification(
+                                            "Voice Recognition Stopped",
+                                            "Microphone stopped due to inactivity",
+                                            "audio-input-microphone-symbolic",
+                                        )
+                                        play_stop_sound()
+                                        break  # Exit the recording loop
 
                             self._update_state(RecognitionState.LISTENING)
                     else:  # Speech
                         # Update last speech time for session timeout tracking
-                        self._last_speech_time = time.time()
+                        self._set_last_speech_time(time.time())
                         if not speech_detected_in_session:
                             logger.debug(
                                 f"Speech detected (level={normalized_level:.1f}%, "
@@ -1711,6 +1710,25 @@ class SpeechRecognitionManager:
         while self.should_record:
             # The real work is done in _record_audio and _process_final_buffer
             time.sleep(0.1)
+
+    def _set_last_speech_time(self, timestamp: Optional[float]) -> None:
+        with self._session_timeout_lock:
+            self._last_speech_time = timestamp
+
+    def _get_last_speech_time(self) -> Optional[float]:
+        with self._session_timeout_lock:
+            return self._last_speech_time
+
+    def _session_timeout_reached(self, speech_detected_in_session: bool) -> bool:
+        if not self.enable_session_timeout or not speech_detected_in_session:
+            return False
+
+        last_speech_time = self._get_last_speech_time()
+        if last_speech_time is None:
+            return False
+
+        idle_time = time.time() - last_speech_time
+        return idle_time >= self.session_timeout
 
     def reconfigure(
         self,

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -387,6 +387,9 @@ class SpeechRecognitionManager:
         # Speech detection parameters (load defaults, will be overridden by configure)
         self.vad_sensitivity = kwargs.get("vad_sensitivity", 3)
         self.silence_timeout = kwargs.get("silence_timeout", 2.0)
+        self.session_timeout = kwargs.get("session_timeout", 10.0)
+        self.enable_session_timeout = kwargs.get("enable_session_timeout", True)
+        self._last_speech_time = None
 
         # Audio device selection (None means use system default)
         self.audio_device_index = kwargs.get("audio_device_index", None)
@@ -1355,6 +1358,7 @@ class SpeechRecognitionManager:
         # Set recording flag
         self.should_record = True
         self.audio_buffer = []
+        self._last_speech_time = None  # Reset session timeout tracking
 
         # Start the audio recording thread
         self.audio_thread = threading.Thread(target=self._record_audio)
@@ -1568,8 +1572,30 @@ class SpeechRecognitionManager:
                                 # Reset for next utterance
                                 self.audio_buffer = []
                             silence_counter = 0
+
+                            # Check session timeout (auto-stop after inactivity)
+                            if (
+                                self.enable_session_timeout
+                                and self._last_speech_time is not None
+                                and speech_detected_in_session
+                            ):
+                                idle_time = time.time() - self._last_speech_time
+                                if idle_time >= self.session_timeout:
+                                    logger.info(
+                                        f"Session timeout reached ({idle_time:.1f}s idle). Auto-stopping recognition."
+                                    )
+                                    _show_notification(
+                                        "Voice Recognition Stopped",
+                                        "Microphone stopped due to inactivity",
+                                        "audio-input-microphone-symbolic",
+                                    )
+                                    play_stop_sound()
+                                    break  # Exit the recording loop
+
                             self._update_state(RecognitionState.LISTENING)
                     else:  # Speech
+                        # Update last speech time for session timeout tracking
+                        self._last_speech_time = time.time()
                         if not speech_detected_in_session:
                             logger.debug(
                                 f"Speech detected (level={normalized_level:.1f}%, "
@@ -1693,6 +1719,8 @@ class SpeechRecognitionManager:
         language: Optional[str] = None,
         vad_sensitivity: Optional[int] = None,
         silence_timeout: Optional[float] = None,
+        session_timeout: Optional[float] = None,
+        enable_session_timeout: Optional[bool] = None,
         audio_device_index: Optional[int] = None,
         force_download: bool = True,
         **kwargs,  # Allow for future expansion
@@ -1706,11 +1734,13 @@ class SpeechRecognitionManager:
             language: The new language code (e.g., "en-us", "hi", "auto").
             vad_sensitivity: New VAD sensitivity (for VOSK).
             silence_timeout: New silence timeout (for VOSK).
+            session_timeout: New session timeout for auto-stop after inactivity.
+            enable_session_timeout: Enable/disable session timeout feature.
             audio_device_index: Audio input device index (None for default, -1 to clear).
             force_download: If True, download missing models (default: True for UI-triggered reconfigures).
         """
         logger.info(
-            f"Reconfiguring speech engine. New settings: engine={engine}, model_size={model_size}, language={language}, vad={vad_sensitivity}, silence={silence_timeout}, audio_device={audio_device_index}"
+            f"Reconfiguring speech engine. New settings: engine={engine}, model_size={model_size}, language={language}, vad={vad_sensitivity}, silence={silence_timeout}, session={session_timeout}, session_enabled={enable_session_timeout}, audio_device={audio_device_index}"
         )
 
         restart_needed = False
@@ -1734,6 +1764,10 @@ class SpeechRecognitionManager:
             self.vad_sensitivity = max(1, min(5, int(vad_sensitivity)))
         if silence_timeout is not None:
             self.silence_timeout = max(0.5, min(5.0, float(silence_timeout)))
+        if session_timeout is not None:
+            self.session_timeout = max(1.0, min(60.0, float(session_timeout)))
+        if enable_session_timeout is not None:
+            self.enable_session_timeout = bool(enable_session_timeout)
 
         # Handle audio device index (-1 means use default/clear selection)
         if audio_device_index is not None:

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -1580,15 +1580,7 @@ class SpeechRecognitionManager:
                                 if last_speech_time is not None:
                                     idle_time = time.time() - last_speech_time
                                     if idle_time >= self.session_timeout:
-                                        logger.info(
-                                            f"Session timeout reached ({idle_time:.1f}s idle). Auto-stopping recognition."
-                                        )
-                                        _show_notification(
-                                            "Voice Recognition Stopped",
-                                            "Microphone stopped due to inactivity",
-                                            "audio-input-microphone-symbolic",
-                                        )
-                                        play_stop_sound()
+                                        self._auto_stop_for_inactivity(idle_time)
                                         break  # Exit the recording loop
 
                             self._update_state(RecognitionState.LISTENING)
@@ -1729,6 +1721,17 @@ class SpeechRecognitionManager:
 
         idle_time = time.time() - last_speech_time
         return idle_time >= self.session_timeout
+
+    def _auto_stop_for_inactivity(self, idle_time: float) -> None:
+        logger.info(f"Session timeout reached ({idle_time:.1f}s idle). Auto-stopping recognition.")
+        self.should_record = False
+        _show_notification(
+            "Voice Recognition Stopped",
+            "Microphone stopped due to inactivity",
+            "audio-input-microphone-symbolic",
+        )
+        play_stop_sound()
+        self._update_state(RecognitionState.IDLE)
 
     def reconfigure(
         self,

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -26,6 +26,8 @@ DEFAULT_CONFIG = {
         "whisper_cpp_model_size": "tiny",  # Default model for whisper.cpp engine
         "vad_sensitivity": 3,  # Voice Activity Detection sensitivity (1-5)
         "silence_timeout": 2.0,  # Seconds of silence before stopping
+        "session_timeout": 10.0,  # Seconds of inactivity before auto-stop
+        "enable_session_timeout": True,  # Enable auto-stop after inactivity
     },
     "audio": {
         "device_index": None,  # Audio input device index (None for system default)

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -52,6 +52,9 @@ DEFAULT_CONFIG = {
     },
 }
 
+MIN_SESSION_TIMEOUT = 1.0
+MAX_SESSION_TIMEOUT = 60.0
+
 
 class ConfigManager:
     """
@@ -92,6 +95,7 @@ class ConfigManager:
 
             # Update the default config with user settings
             self._update_dict_recursive(self.config, user_config)
+            self._validate_session_timeout_config()
             logger.info(f"Loaded configuration from {CONFIG_FILE}")
 
             # Migrate old config format if needed
@@ -100,6 +104,29 @@ class ConfigManager:
 
         except Exception as e:
             logger.error(f"Failed to load config: {e}")
+
+    def _validate_session_timeout_config(self):
+        sr_config = self.config.setdefault("speech_recognition", {})
+        raw_value = sr_config.get(
+            "session_timeout", DEFAULT_CONFIG["speech_recognition"]["session_timeout"]
+        )
+
+        try:
+            timeout_value = float(raw_value)
+        except (TypeError, ValueError):
+            timeout_value = DEFAULT_CONFIG["speech_recognition"]["session_timeout"]
+            logger.warning(
+                f"Invalid session_timeout value {raw_value!r} in config; using default {timeout_value:.1f}s"
+            )
+
+        clamped_value = max(MIN_SESSION_TIMEOUT, min(MAX_SESSION_TIMEOUT, timeout_value))
+        if clamped_value != timeout_value:
+            logger.warning(
+                f"session_timeout value {timeout_value:.1f}s is outside valid range "
+                f"[{MIN_SESSION_TIMEOUT:.1f}, {MAX_SESSION_TIMEOUT:.1f}]; clamped to {clamped_value:.1f}s"
+            )
+
+        sr_config["session_timeout"] = clamped_value
 
     def _check_needs_migration(self, user_config: Dict) -> bool:
         """Check if the user config needs migration to add per-engine model sizes."""

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1081,11 +1081,39 @@ class SettingsDialog(Gtk.Dialog):
         )
         group.add_row(silence_row)
 
+        # Session Timeout (Auto-stop after inactivity)
+        self.session_timeout_spin = Gtk.SpinButton.new_with_range(1.0, 60.0, 1.0)
+        self.session_timeout_spin.set_digits(1)
+        self.session_timeout_spin.set_tooltip_text(
+            "Auto-stop microphone after this many seconds of inactivity"
+        )
+        _prevent_scroll_on_hover(self.session_timeout_spin)
+        session_timeout_row = PreferenceRow(
+            title="Session Timeout",
+            subtitle="Seconds of inactivity before auto-stop",
+            widget=self.session_timeout_spin,
+        )
+        group.add_row(session_timeout_row)
+
+        # Enable Session Timeout toggle
+        self.session_timeout_switch = Gtk.Switch()
+        self.session_timeout_switch.set_tooltip_text(
+            "Automatically stop microphone after inactivity timeout"
+        )
+        session_timeout_enable_row = PreferenceRow(
+            title="Auto-Stop on Inactivity",
+            subtitle="Enable automatic stop after session timeout",
+            widget=self.session_timeout_switch,
+        )
+        group.add_row(session_timeout_enable_row)
+
         self.recognition_settings_tab.pack_start(group, False, False, 0)
 
         # Connect signals
         self.vad_spin.connect("value-changed", self._on_vad_changed)
         self.silence_spin.connect("value-changed", self._on_silence_changed)
+        self.session_timeout_spin.connect("value-changed", self._on_session_timeout_changed)
+        self.session_timeout_switch.connect("state-set", self._on_session_timeout_toggled)
 
     def _build_shortcuts_section(self):
         """Build the Keyboard Shortcuts section."""
@@ -1267,6 +1295,8 @@ class SettingsDialog(Gtk.Dialog):
         self.current_model_size = settings["model_size"]
         self.current_vad = settings.get("vad_sensitivity", 3)
         self.current_silence = settings.get("silence_timeout", 2.0)
+        self.current_session_timeout = settings.get("session_timeout", 10.0)
+        self.current_enable_session_timeout = settings.get("enable_session_timeout", True)
 
         logger.info(
             f"Starting dialog with settings: engine={self.current_engine}, model={self.current_model_size}"
@@ -1340,6 +1370,8 @@ class SettingsDialog(Gtk.Dialog):
         # Set spin button values
         self.vad_spin.set_value(self.current_vad)
         self.silence_spin.set_value(self.current_silence)
+        self.session_timeout_spin.set_value(self.current_session_timeout)
+        self.session_timeout_switch.set_active(self.current_enable_session_timeout)
 
     def _get_current_settings(self):
         """Get current settings from config manager."""
@@ -1352,10 +1384,13 @@ class SettingsDialog(Gtk.Dialog):
         model_size = self.config_manager.get_model_size_for_engine(engine)
         vad_sensitivity = sr_settings.get("vad_sensitivity", 3)
         silence_timeout = sr_settings.get("silence_timeout", 2.0)
+        session_timeout = sr_settings.get("session_timeout", 10.0)
+        enable_session_timeout = sr_settings.get("enable_session_timeout", True)
 
         logger.info(
             f"Loaded current settings: engine={engine}, language={language}, model_size={model_size}, "
-            f"vad={vad_sensitivity}, silence={silence_timeout}"
+            f"vad={vad_sensitivity}, silence={silence_timeout}, session={session_timeout}, "
+            f"session_enabled={enable_session_timeout}"
         )
 
         return {
@@ -1364,6 +1399,8 @@ class SettingsDialog(Gtk.Dialog):
             "model_size": model_size,
             "vad_sensitivity": vad_sensitivity,
             "silence_timeout": silence_timeout,
+            "session_timeout": session_timeout,
+            "enable_session_timeout": enable_session_timeout,
         }
 
     def _populate_model_options(self):
@@ -1483,6 +1520,14 @@ class SettingsDialog(Gtk.Dialog):
 
     def _on_silence_changed(self, widget):
         """Handle changes in silence timeout."""
+        self._auto_apply_settings()
+
+    def _on_session_timeout_changed(self, widget):
+        """Handle changes in session timeout."""
+        self._auto_apply_settings()
+
+    def _on_session_timeout_toggled(self, widget, state):
+        """Handle session timeout toggle."""
         self._auto_apply_settings()
 
     def _populate_language_options(self):
@@ -1735,6 +1780,8 @@ class SettingsDialog(Gtk.Dialog):
             "language": language,
             "vad_sensitivity": vad,
             "silence_timeout": silence,
+            "session_timeout": self.session_timeout_spin.get_value(),
+            "enable_session_timeout": self.session_timeout_switch.get_active(),
         }
 
     def _on_test_clicked(self, widget):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -6,6 +6,7 @@ import json
 import os
 import tempfile
 import unittest
+from typing import Any, cast
 from unittest.mock import patch
 
 # Update import path to use the new package structure
@@ -91,6 +92,45 @@ class TestConfigManager(unittest.TestCase):
         )  # From defaults
         self.assertEqual(config_manager.config["ui"]["start_minimized"], True)
         self.assertEqual(config_manager.config["ui"]["show_notifications"], True)  # From defaults
+
+    def test_load_config_clamps_session_timeout_below_min(self):
+        test_config = {"speech_recognition": {"session_timeout": 0.25}}
+
+        with open(self.temp_config_file, "w") as f:
+            json.dump(test_config, f)
+
+        config_manager = ConfigManager()
+
+        self.assertEqual(config_manager.config["speech_recognition"]["session_timeout"], 1.0)
+        self.mock_logger.warning.assert_called_with(
+            "session_timeout value 0.2s is outside valid range [1.0, 60.0]; clamped to 1.0s"
+        )
+
+    def test_load_config_clamps_session_timeout_above_max(self):
+        test_config = {"speech_recognition": {"session_timeout": 99.0}}
+
+        with open(self.temp_config_file, "w") as f:
+            json.dump(test_config, f)
+
+        config_manager = ConfigManager()
+
+        self.assertEqual(config_manager.config["speech_recognition"]["session_timeout"], 60.0)
+        self.mock_logger.warning.assert_called_with(
+            "session_timeout value 99.0s is outside valid range [1.0, 60.0]; clamped to 60.0s"
+        )
+
+    def test_load_config_uses_default_for_invalid_session_timeout(self):
+        test_config = {"speech_recognition": {"session_timeout": "invalid"}}
+
+        with open(self.temp_config_file, "w") as f:
+            json.dump(test_config, f)
+
+        config_manager = ConfigManager()
+
+        self.assertEqual(config_manager.config["speech_recognition"]["session_timeout"], 10.0)
+        self.mock_logger.warning.assert_any_call(
+            "Invalid session_timeout value 'invalid' in config; using default 10.0s"
+        )
 
     def test_load_config_file_error(self):
         """Test handling of errors when loading config file."""
@@ -180,7 +220,7 @@ class TestConfigManager(unittest.TestCase):
     def test_set_error(self):
         """Test handling of errors when setting a value."""
         config_manager = ConfigManager()
-        config_manager.config = 1  # Not a dict, will cause error
+        config_manager.config = cast(Any, 1)  # Not a dict, will cause error
         result = config_manager.set("section", "key", "value")
         self.assertFalse(result)
         self.mock_logger.error.assert_called()

--- a/tests/test_recognition_manager.py
+++ b/tests/test_recognition_manager.py
@@ -217,6 +217,70 @@ class TestSpeechRecognition(unittest.TestCase):
         mock_audio_feedback.play_stop_sound.assert_called_once()
         self.threadInstance.join.assert_called()
 
+    def test_session_timeout_triggers_auto_stop_after_inactivity(self):
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.reconfigure(enable_session_timeout=True, session_timeout=10.0)
+        getattr(manager, "_set_last_speech_time")(100.0)
+
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.time.time", return_value=111.0
+        ):
+            self.assertTrue(
+                getattr(manager, "_session_timeout_reached")(speech_detected_in_session=True)
+            )
+
+    def test_session_timeout_enable_disable_toggle(self):
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.reconfigure(session_timeout=5.0)
+        getattr(manager, "_set_last_speech_time")(100.0)
+
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.time.time", return_value=110.0
+        ):
+            manager.reconfigure(enable_session_timeout=False)
+            self.assertFalse(
+                getattr(manager, "_session_timeout_reached")(speech_detected_in_session=True)
+            )
+
+            manager.reconfigure(enable_session_timeout=True)
+            self.assertTrue(
+                getattr(manager, "_session_timeout_reached")(speech_detected_in_session=True)
+            )
+
+    def test_session_timeout_clamps_to_valid_range(self):
+        manager = SpeechRecognitionManager(engine="vosk")
+
+        manager.reconfigure(session_timeout=0.25)
+        self.assertEqual(getattr(manager, "session_timeout"), 1.0)
+
+        manager.reconfigure(session_timeout=120.0)
+        self.assertEqual(getattr(manager, "session_timeout"), 60.0)
+
+    def test_session_timeout_timer_resets_on_new_speech(self):
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.reconfigure(enable_session_timeout=True, session_timeout=10.0)
+        getattr(manager, "_set_last_speech_time")(100.0)
+        getattr(manager, "_set_last_speech_time")(106.0)
+
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.time.time", return_value=114.0
+        ):
+            self.assertFalse(
+                getattr(manager, "_session_timeout_reached")(speech_detected_in_session=True)
+            )
+
+    def test_session_timeout_does_not_trigger_without_speech_in_session(self):
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.reconfigure(enable_session_timeout=True, session_timeout=1.0)
+        getattr(manager, "_set_last_speech_time")(100.0)
+
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.time.time", return_value=200.0
+        ):
+            self.assertFalse(
+                getattr(manager, "_session_timeout_reached")(speech_detected_in_session=False)
+            )
+
     def test_whisper_engine(self):
         """Test initialization and usage with Whisper engine."""
         # Setup Whisper and torch mocks

--- a/tests/test_recognition_manager.py
+++ b/tests/test_recognition_manager.py
@@ -281,6 +281,28 @@ class TestSpeechRecognition(unittest.TestCase):
                 getattr(manager, "_session_timeout_reached")(speech_detected_in_session=False)
             )
 
+    def test_auto_stop_for_inactivity_sets_idle_and_stops_recording(self):
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.should_record = True
+        manager._update_state(RecognitionState.LISTENING)
+
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager._show_notification"
+        ) as mock_notify:
+            with patch(
+                "vocalinux.speech_recognition.recognition_manager.play_stop_sound"
+            ) as mock_stop_sound:
+                getattr(manager, "_auto_stop_for_inactivity")(12.5)
+
+        self.assertFalse(manager.should_record)
+        self.assertEqual(manager.state, RecognitionState.IDLE)
+        mock_notify.assert_called_once_with(
+            "Voice Recognition Stopped",
+            "Microphone stopped due to inactivity",
+            "audio-input-microphone-symbolic",
+        )
+        mock_stop_sound.assert_called_once()
+
     def test_whisper_engine(self):
         """Test initialization and usage with Whisper engine."""
         # Setup Whisper and torch mocks


### PR DESCRIPTION
## Summary

- Add `session_timeout` config option (default 10.0 seconds) for auto-stopping microphone after inactivity
- Add `enable_session_timeout` toggle to enable/disable the feature
- Track last speech detection timestamp in recognition_manager
- Auto-stop mic after inactivity timeout following speech detection
- Play sound and show notification when auto-stopping
- Add UI controls in settings dialog for session timeout and toggle

This feature prevents accidental transcription when the user forgets to stop voice recognition after being done dictating.

Closes #185