### PR TITLE
fix: handle German umlauts in text injection

### DIFF
--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -11,13 +11,9 @@ import shutil
 import subprocess
 import time
 from enum import Enum
-from typing import List, Optional, Tuple  # noqa: F401
+from typing import Dict, List, Optional, Tuple  # noqa: F401
 
-from .ibus_engine import (
-    IBusTextInjector,
-    is_ibus_available,
-    is_ibus_daemon_running,
-)
+from .ibus_engine import IBusTextInjector, is_ibus_available, is_ibus_daemon_running
 
 logger = logging.getLogger(__name__)
 
@@ -51,13 +47,13 @@ def split_text_by_ascii(text: str) -> List[Tuple[str, bool]]:
             current_segment.append(char)
         else:
             # Save the current segment and start a new one
-            segments.append((''.join(current_segment), current_is_ascii))
+            segments.append(("".join(current_segment), current_is_ascii))
             current_segment = [char]
             current_is_ascii = char_is_ascii
 
     # Don't forget the last segment
     if current_segment:
-        segments.append((''.join(current_segment), current_is_ascii))
+        segments.append(("".join(current_segment), current_is_ascii))
 
     return segments
 
@@ -72,7 +68,7 @@ def get_unicode_hex(char: str) -> str:
     Returns:
         The hex code in lowercase (e.g., '00e4' for 'ä')
     """
-    return format(ord(char), '04x')
+    return format(ord(char), "04x")
 
 
 class DesktopEnvironment(Enum):
@@ -428,10 +424,14 @@ class TextInjector:
                     for segment_idx, (segment, is_ascii) in enumerate(segments):
                         if is_ascii:
                             # ASCII text can be typed directly
-                            self._inject_ascii_with_xdotool(segment, env, segment_idx, len(segments))
+                            self._inject_ascii_with_xdotool(
+                                segment, env, segment_idx, len(segments)
+                            )
                         else:
                             # Non-ASCII text needs Unicode input sequence
-                            self._inject_unicode_with_xdotool(segment, env, segment_idx, len(segments))
+                            self._inject_unicode_with_xdotool(
+                                segment, env, segment_idx, len(segments)
+                            )
 
                     logger.info(
                         f"Text injected using xdotool: '{text[:20]}...' ({len(text)} chars)"
@@ -472,7 +472,9 @@ class TextInjector:
             logger.error(f"xdotool error: {e.stderr}")
             raise
 
-    def _inject_ascii_with_xdotool(self, text: str, env: dict, segment_idx: int, total_segments: int):
+    def _inject_ascii_with_xdotool(
+        self, text: str, env: Dict[str, str], segment_idx: int, total_segments: int
+    ):
         """
         Inject ASCII text using xdotool type command.
 
@@ -510,7 +512,9 @@ class TextInjector:
             if i + chunk_size < len(text):
                 time.sleep(0.05)
 
-    def _inject_unicode_with_xdotool(self, text: str, env: dict, segment_idx: int, total_segments: int):
+    def _inject_unicode_with_xdotool(
+        self, text: str, env: Dict[str, str], segment_idx: int, total_segments: int
+    ):
         """
         Inject Unicode text using xdotool with Ctrl+Shift+U Unicode input sequence.
 
@@ -542,8 +546,7 @@ class TextInjector:
                 # Type the Unicode sequence using keydown/keyup for modifiers
                 # Ctrl+Shift+U, then hex code, then space
                 subprocess.run(
-                    ["xdotool", "key", "--clearmodifiers",
-                     "Ctrl+Shift+u", "space"],  # Some systems need space after U
+                    ["xdotool", "key", "--clearmodifiers", "Ctrl+Shift+u"],
                     env=env,
                     check=True,
                     stderr=subprocess.PIPE,
@@ -606,9 +609,7 @@ class TextInjector:
                     e.returncode, e.cmd, output=e.output, stderr=e.stderr
                 ) from e
 
-            logger.info(
-                f"Text injected using wtype: '{text[:20]}...' ({len(text)} chars)"
-            )
+            logger.info(f"Text injected using wtype: '{text[:20]}...' ({len(text)} chars)")
         else:  # ydotool
             # ydotool needs special handling for Unicode characters
             self._inject_with_ydotool(text)
@@ -651,9 +652,7 @@ class TextInjector:
                 for char in segment:
                     self._inject_unicode_with_ydotool(char)
 
-        logger.info(
-            f"Text injected using ydotool: '{text[:20]}...' ({len(text)} chars)"
-        )
+        logger.info(f"Text injected using ydotool: '{text[:20]}...' ({len(text)} chars)")
 
     def _inject_unicode_with_ydotool(self, char: str):
         """

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -11,7 +11,7 @@ import shutil
 import subprocess
 import time
 from enum import Enum
-from typing import Optional  # noqa: F401
+from typing import List, Optional, Tuple  # noqa: F401
 
 from .ibus_engine import (
     IBusTextInjector,
@@ -20,6 +20,59 @@ from .ibus_engine import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def split_text_by_ascii(text: str) -> List[Tuple[str, bool]]:
+    """
+    Split text into segments of ASCII and non-ASCII characters.
+
+    This is used to handle Unicode characters that can't be typed with
+    the current keyboard layout. Non-ASCII characters need to be typed
+    using Unicode input sequences (Ctrl+Shift+U + hex code).
+
+    Args:
+        text: The text to split
+
+    Returns:
+        A list of tuples (segment, is_ascii) where is_ascii indicates
+        whether the segment contains only ASCII characters
+    """
+    if not text:
+        return []
+
+    segments: List[Tuple[str, bool]] = []
+    current_segment = []
+    current_is_ascii = ord(text[0]) < 128
+
+    for char in text:
+        char_is_ascii = ord(char) < 128
+
+        if char_is_ascii == current_is_ascii:
+            current_segment.append(char)
+        else:
+            # Save the current segment and start a new one
+            segments.append((''.join(current_segment), current_is_ascii))
+            current_segment = [char]
+            current_is_ascii = char_is_ascii
+
+    # Don't forget the last segment
+    if current_segment:
+        segments.append((''.join(current_segment), current_is_ascii))
+
+    return segments
+
+
+def get_unicode_hex(char: str) -> str:
+    """
+    Get the Unicode hex code for a character (without U+ prefix).
+
+    Args:
+        char: A single Unicode character
+
+    Returns:
+        The hex code in lowercase (e.g., '00e4' for 'ä')
+    """
+    return format(ord(char), '04x')
 
 
 class DesktopEnvironment(Enum):
@@ -310,6 +363,11 @@ class TextInjector:
         """
         Inject text using xdotool for X11 environments.
 
+        This method handles both ASCII and Unicode characters. For Unicode
+        characters (like German umlauts), it uses the Ctrl+Shift+U Unicode
+        input sequence to type characters not available on the current
+        keyboard layout.
+
         Args:
             text: The text to inject
         """
@@ -363,33 +421,17 @@ class TextInjector:
 
             for retry in range(max_retries + 1):
                 try:
-                    # Inject in smaller chunks to avoid issues with very long text
-                    chunk_size = 20  # Reduced chunk size for better reliability
-                    total_chunks = (len(text) + chunk_size - 1) // chunk_size
-                    logger.debug(
-                        f"Splitting text into {total_chunks} chunks of max {chunk_size} chars"
-                    )
+                    # Split text into ASCII and non-ASCII segments for proper Unicode handling
+                    segments = split_text_by_ascii(text)
+                    logger.debug(f"Text split into {len(segments)} segments")
 
-                    for i in range(0, len(text), chunk_size):
-                        chunk = text[i : i + chunk_size]
-                        chunk_num = (i // chunk_size) + 1
-
-                        # First try with clearmodifiers
-                        cmd = ["xdotool", "type", "--clearmodifiers", chunk]
-                        logger.debug(f"Injecting chunk {chunk_num}/{total_chunks}: '{chunk}'")
-
-                        subprocess.run(
-                            cmd,
-                            env=env,
-                            check=True,
-                            stderr=subprocess.PIPE,
-                            text=True,
-                            timeout=5,
-                        )
-
-                        # Add a larger delay between chunks
-                        if i + chunk_size < len(text):
-                            time.sleep(0.1)
+                    for segment_idx, (segment, is_ascii) in enumerate(segments):
+                        if is_ascii:
+                            # ASCII text can be typed directly
+                            self._inject_ascii_with_xdotool(segment, env, segment_idx, len(segments))
+                        else:
+                            # Non-ASCII text needs Unicode input sequence
+                            self._inject_unicode_with_xdotool(segment, env, segment_idx, len(segments))
 
                     logger.info(
                         f"Text injected using xdotool: '{text[:20]}...' ({len(text)} chars)"
@@ -430,9 +472,123 @@ class TextInjector:
             logger.error(f"xdotool error: {e.stderr}")
             raise
 
+    def _inject_ascii_with_xdotool(self, text: str, env: dict, segment_idx: int, total_segments: int):
+        """
+        Inject ASCII text using xdotool type command.
+
+        Args:
+            text: ASCII text to inject
+            env: Environment variables for subprocess
+            segment_idx: Current segment index (for logging)
+            total_segments: Total number of segments (for logging)
+        """
+        # Inject in smaller chunks to avoid issues with very long text
+        chunk_size = 20  # Reduced chunk size for better reliability
+        total_chunks = (len(text) + chunk_size - 1) // chunk_size
+        logger.debug(
+            f"Injecting ASCII segment {segment_idx + 1}/{total_segments} "
+            f"in {total_chunks} chunks"
+        )
+
+        for i in range(0, len(text), chunk_size):
+            chunk = text[i : i + chunk_size]
+            chunk_num = (i // chunk_size) + 1
+
+            cmd = ["xdotool", "type", "--clearmodifiers", chunk]
+            logger.debug(f"Injecting ASCII chunk {chunk_num}/{total_chunks}: '{chunk}'")
+
+            subprocess.run(
+                cmd,
+                env=env,
+                check=True,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=5,
+            )
+
+            # Add a small delay between chunks
+            if i + chunk_size < len(text):
+                time.sleep(0.05)
+
+    def _inject_unicode_with_xdotool(self, text: str, env: dict, segment_idx: int, total_segments: int):
+        """
+        Inject Unicode text using xdotool with Ctrl+Shift+U Unicode input sequence.
+
+        This method types Unicode characters by using the Linux Unicode input
+        sequence: Ctrl+Shift+U followed by the hex code, then Space.
+
+        Args:
+            text: Unicode text to inject (non-ASCII characters)
+            env: Environment variables for subprocess
+            segment_idx: Current segment index (for logging)
+            total_segments: Total number of segments (for logging)
+        """
+        logger.debug(
+            f"Injecting Unicode segment {segment_idx + 1}/{total_segments}: "
+            f"{len(text)} characters"
+        )
+
+        for char in text:
+            hex_code = get_unicode_hex(char)
+            logger.debug(f"Typing Unicode char '{char}' as U+{hex_code}")
+
+            # Use xdotool to type the Unicode sequence:
+            # 1. Press and hold Ctrl+Shift
+            # 2. Press and release U
+            # 3. Release Ctrl+Shift
+            # 4. Type the hex code
+            # 5. Press Space to commit the character
+            try:
+                # Type the Unicode sequence using keydown/keyup for modifiers
+                # Ctrl+Shift+U, then hex code, then space
+                subprocess.run(
+                    ["xdotool", "key", "--clearmodifiers",
+                     "Ctrl+Shift+u", "space"],  # Some systems need space after U
+                    env=env,
+                    check=True,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=2,
+                )
+
+                # Small delay to ensure the Unicode input mode is ready
+                time.sleep(0.02)
+
+                # Type the hex code
+                subprocess.run(
+                    ["xdotool", "type", "--clearmodifiers", hex_code],
+                    env=env,
+                    check=True,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=2,
+                )
+
+                # Press space to commit the character
+                subprocess.run(
+                    ["xdotool", "key", "--clearmodifiers", "space"],
+                    env=env,
+                    check=True,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=2,
+                )
+
+                # Small delay between characters for reliability
+                time.sleep(0.02)
+
+            except subprocess.CalledProcessError as e:
+                logger.warning(f"Failed to type Unicode char '{char}': {e.stderr}")
+                raise
+
     def _inject_with_wayland_tool(self, text: str):
         """
         Inject text using a Wayland-compatible tool (wtype or ydotool).
+
+        For wtype: Unicode is supported natively - text is passed directly.
+        For ydotool: Non-ASCII characters require Unicode input sequences
+        (Ctrl+Shift+U + hex code) since ydotool simulates keypresses based
+        on the current keyboard layout.
 
         Args:
             text: The text to inject
@@ -441,21 +597,119 @@ class TextInjector:
             subprocess.CalledProcessError: If the tool fails, with stderr captured
         """
         if self.wayland_tool == "wtype":
+            # wtype supports Unicode natively - just pass the text
             cmd = ["wtype", text]
-        else:  # ydotool
-            cmd = ["ydotool", "type", text]
+            try:
+                subprocess.run(cmd, check=True, stderr=subprocess.PIPE, text=True)
+            except subprocess.CalledProcessError as e:
+                raise subprocess.CalledProcessError(
+                    e.returncode, e.cmd, output=e.output, stderr=e.stderr
+                ) from e
 
-        try:
-            subprocess.run(cmd, check=True, stderr=subprocess.PIPE, text=True)
-        except subprocess.CalledProcessError as e:
-            # Re-raise with stderr preserved for better diagnostics
-            raise subprocess.CalledProcessError(
-                e.returncode, e.cmd, output=e.output, stderr=e.stderr
-            ) from e
+            logger.info(
+                f"Text injected using wtype: '{text[:20]}...' ({len(text)} chars)"
+            )
+        else:  # ydotool
+            # ydotool needs special handling for Unicode characters
+            self._inject_with_ydotool(text)
+
+    def _inject_with_ydotool(self, text: str):
+        """
+        Inject text using ydotool with proper Unicode handling.
+
+        For ASCII characters, uses ydotool type directly.
+        For non-ASCII characters (like German umlauts), uses Unicode input
+        sequence: Ctrl+Shift+U + hex code + Space.
+
+        Args:
+            text: The text to inject
+
+        Raises:
+            subprocess.CalledProcessError: If the tool fails
+        """
+        # Split text into ASCII and non-ASCII segments
+        segments = split_text_by_ascii(text)
+        logger.debug(f"ydotool: Text split into {len(segments)} segments")
+
+        for segment_idx, (segment, is_ascii) in enumerate(segments):
+            if is_ascii:
+                # ASCII text can be typed directly with ydotool
+                cmd = ["ydotool", "type", segment]
+                logger.debug(f"ydotool typing ASCII segment {segment_idx + 1}: '{segment}'")
+                try:
+                    subprocess.run(cmd, check=True, stderr=subprocess.PIPE, text=True)
+                except subprocess.CalledProcessError as e:
+                    raise subprocess.CalledProcessError(
+                        e.returncode, e.cmd, output=e.output, stderr=e.stderr
+                    ) from e
+            else:
+                # Non-ASCII text needs Unicode input sequence
+                logger.debug(
+                    f"ydotool typing Unicode segment {segment_idx + 1}: "
+                    f"{len(segment)} characters"
+                )
+                for char in segment:
+                    self._inject_unicode_with_ydotool(char)
 
         logger.info(
-            f"Text injected using {self.wayland_tool}: '{text[:20]}...' ({len(text)} chars)"
+            f"Text injected using ydotool: '{text[:20]}...' ({len(text)} chars)"
         )
+
+    def _inject_unicode_with_ydotool(self, char: str):
+        """
+        Inject a single Unicode character using ydotool with Unicode input sequence.
+
+        Uses the Linux Unicode input sequence: Ctrl+Shift+U + hex code + Space.
+
+        Args:
+            char: A single Unicode character to inject
+
+        Raises:
+            subprocess.CalledProcessError: If the tool fails
+        """
+        hex_code = get_unicode_hex(char)
+        logger.debug(f"ydotool typing Unicode char '{char}' as U+{hex_code}")
+
+        try:
+            # Press Ctrl+Shift+U to initiate Unicode input
+            # ydotool uses key codes: 29=Ctrl, 42=Shift, 22=U
+            # Format: key_code:1 (press), key_code:0 (release)
+            subprocess.run(
+                ["ydotool", "key", "29:1", "42:1", "22:1", "22:0", "42:0", "29:0"],
+                check=True,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=2,
+            )
+
+            # Small delay to ensure Unicode input mode is ready
+            time.sleep(0.02)
+
+            # Type the hex code
+            subprocess.run(
+                ["ydotool", "type", hex_code],
+                check=True,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=2,
+            )
+
+            # Press Space to commit the character
+            # Space key code is 57
+            subprocess.run(
+                ["ydotool", "key", "57:1", "57:0"],
+                check=True,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=2,
+            )
+
+            # Small delay between characters for reliability
+            time.sleep(0.02)
+
+        except subprocess.CalledProcessError as e:
+            logger.warning(f"Failed to type Unicode char '{char}' with ydotool: {e.stderr}")
+            raise
 
     def _inject_keyboard_shortcut(self, shortcut: str) -> bool:
         """

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -9,7 +9,12 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 # Update import path to use the new package structure
-from vocalinux.text_injection.text_injector import DesktopEnvironment, TextInjector
+from vocalinux.text_injection.text_injector import (
+    DesktopEnvironment,
+    TextInjector,
+    get_unicode_hex,
+    split_text_by_ascii,
+)
 
 # Create a mock for audio feedback module
 mock_audio_feedback = MagicMock()
@@ -17,6 +22,86 @@ mock_audio_feedback.play_error_sound = MagicMock()
 
 # Add the mock to sys.modules
 sys.modules["vocalinux.ui.audio_feedback"] = mock_audio_feedback
+
+
+class TestUnicodeHelpers(unittest.TestCase):
+    """Test cases for Unicode helper functions."""
+
+    def test_split_text_by_ascii_empty(self):
+        """Test splitting empty text."""
+        result = split_text_by_ascii("")
+        self.assertEqual(result, [])
+
+    def test_split_text_by_ascii_ascii_only(self):
+        """Test splitting ASCII-only text."""
+        result = split_text_by_ascii("Hello World")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], ("Hello World", True))
+
+    def test_split_text_by_ascii_unicode_only(self):
+        """Test splitting Unicode-only text."""
+        result = split_text_by_ascii("äöüß")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0], ("äöüß", False))
+
+    def test_split_text_by_ascii_mixed(self):
+        """Test splitting mixed ASCII and Unicode text."""
+        # "Sprachänderung" = "Sprach" (ASCII) + "ä" (Unicode) + "nderung" (ASCII)
+        result = split_text_by_ascii("Sprachänderung")
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0], ("Sprach", True))
+        self.assertEqual(result[1], ("ä", False))
+        self.assertEqual(result[2], ("nderung", True))
+
+    def test_split_text_by_ascii_german_umlauts(self):
+        """Test splitting text with German umlauts."""
+        # "Größe" = "Gr" (ASCII) + "öß" (Unicode, both chars) + "e" (ASCII)
+        result = split_text_by_ascii("Größe")
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0], ("Gr", True))
+        self.assertEqual(result[1], ("öß", False))  # Both ö and ß are non-ASCII
+        self.assertEqual(result[2], ("e", True))
+
+    def test_split_text_by_ascii_multiple_unicode_segments(self):
+        """Test splitting text with multiple Unicode segments."""
+        # "Häusör" = "H" + "ä" + "us" + "ö" + "r"
+        result = split_text_by_ascii("Häusör")
+        self.assertEqual(len(result), 5)
+        self.assertEqual(result[0], ("H", True))
+        self.assertEqual(result[1], ("ä", False))
+        self.assertEqual(result[2], ("us", True))
+        self.assertEqual(result[3], ("ö", False))
+        self.assertEqual(result[4], ("r", True))
+
+    def test_get_unicode_hex_umlaut_a(self):
+        """Test getting hex code for ä."""
+        result = get_unicode_hex("ä")
+        self.assertEqual(result, "00e4")
+
+    def test_get_unicode_hex_umlaut_o(self):
+        """Test getting hex code for ö."""
+        result = get_unicode_hex("ö")
+        self.assertEqual(result, "00f6")
+
+    def test_get_unicode_hex_umlaut_u(self):
+        """Test getting hex code for ü."""
+        result = get_unicode_hex("ü")
+        self.assertEqual(result, "00fc")
+
+    def test_get_unicode_hex_sharp_s(self):
+        """Test getting hex code for ß."""
+        result = get_unicode_hex("ß")
+        self.assertEqual(result, "00df")
+
+    def test_get_unicode_hex_uppercase_umlaut(self):
+        """Test getting hex code for Ä."""
+        result = get_unicode_hex("Ä")
+        self.assertEqual(result, "00c4")
+
+    def test_get_unicode_hex_euro(self):
+        """Test getting hex code for €."""
+        result = get_unicode_hex("€")
+        self.assertEqual(result, "20ac")
 
 
 class TestTextInjector(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Fixes issue #266 where German umlauts (ä, ö, ü) and other Unicode characters were not being typed correctly
- Text like "Sprachänderung" would only output "Sprach" because the umlaut "ä" couldn't be typed with US keyboard layout
- Adds Unicode input sequence support (Ctrl+Shift+U + hex code) for xdotool and ydotool

## Changes
- Added `split_text_by_ascii()` function to separate ASCII from non-ASCII text segments
- Added `get_unicode_hex()` function to get Unicode hex codes for characters
- Updated `_inject_with_xdotool()` to use Unicode input sequences for non-ASCII characters
- Updated `_inject_with_wayland_tool()` with proper Unicode handling:
  - **wtype**: supports Unicode natively (no changes needed)
  - **ydotool**: uses Unicode input sequences for non-ASCII chars
- Added comprehensive unit tests for Unicode helper functions

## Technical Details
The issue occurred because tools like `xdotool` and `ydotool` simulate keyboard keypresses based on the current keyboard layout. Characters like German umlauts don't exist on a US keyboard layout, so they couldn't be typed.

The fix uses the Linux Unicode input sequence:
1. Press `Ctrl+Shift+U` to enter Unicode input mode
2. Type the hex code (e.g., `00e4` for `ä`)
3. Press Space to commit the character

Note: The IBus text injection method already handles Unicode correctly by sending text directly via `commit_text()`, so this fix primarily benefits users on systems where IBus is not available or not configured.

## Test Plan
- [x] All existing tests pass (65 tests)
- [x] New unit tests for `split_text_by_ascii()` function
- [x] New unit tests for `get_unicode_hex()` function
- [x] Tests cover German umlauts (ä, ö, ü, ß), uppercase variants, and other Unicode chars (€)

Fixes #266