### PR TITLE
fix: pass shortcut mode to KeyboardShortcutManager at initialization

### DIFF
--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -79,11 +79,13 @@ class TrayIndicator:
         self.config_manager = ConfigManager()  # Added: Initialize ConfigManager
         self._syncing_autostart_menu = False
 
-        # Get configured shortcut from config
+        # Get configured shortcut and mode from config
         shortcut = self.config_manager.get("shortcuts", "toggle_recognition", "ctrl+ctrl")
+        mode = self.config_manager.get("shortcuts", "mode", "toggle")
 
-        # Initialize keyboard shortcut manager with configured shortcut
-        self.shortcut_manager = KeyboardShortcutManager(shortcut=shortcut)
+        # Initialize keyboard shortcut manager with configured shortcut and mode
+        # IMPORTANT: Pass mode here to ensure correct binding on startup
+        self.shortcut_manager = KeyboardShortcutManager(shortcut=shortcut, mode=mode)
 
         # Ensure icon directory exists
         os.makedirs(ICON_DIR, exist_ok=True)


### PR DESCRIPTION
Fixes #296

## Problem
When shortcut mode is set to Push-To-Talk, it doesn't bind to the key until the "Shortcut key" setting is changed.

## Root Cause
In `tray_indicator.py` line 86, `KeyboardShortcutManager` was initialized with only the `shortcut` parameter, NOT the `mode` parameter. The mode defaulted to `toggle`, then `_setup_keyboard_shortcuts()` tried to change it later, but the backend had already initialized with incorrect callbacks.

## Fix
Load the mode from config at initialization and pass it to the `KeyboardShortcutManager` constructor:

```python
# Before
self.shortcut_manager = KeyboardShortcutManager(shortcut=shortcut)

# After  
mode = self.config_manager.get("shortcuts", "mode", "toggle")
self.shortcut_manager = KeyboardShortcutManager(shortcut=shortcut, mode=mode)
```

## Testing
1. Set shortcut mode to Push-To-Talk in settings
2. Restart Vocalinux
3. Hold the configured key - it should now work immediately without needing to re-save settings