### PR TITLE
feat(injection): add selectable text injection backends

### DIFF
--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -288,10 +288,12 @@ def main():
     logger.info("Logging system initialized")
 
     config_manager = ConfigManager()
-    saved_settings = config_manager.get_settings().get("speech_recognition", {})
-    audio_settings = config_manager.get_settings().get("audio", {})
+    all_settings = config_manager.get_settings()
+    saved_settings = all_settings.get("speech_recognition", {})
+    audio_settings = all_settings.get("audio", {})
+    text_injection_settings = all_settings.get("text_injection", {})
 
-    general_settings = config_manager.get_settings().get("general", {})
+    general_settings = all_settings.get("general", {})
     first_run = general_settings.get("first_run", True)
     should_prompt_first_run = first_run and not args.start_minimized
 
@@ -349,6 +351,7 @@ def main():
     silence_timeout = saved_settings.get("silence_timeout", 2.0)
     voice_commands_enabled = saved_settings.get("voice_commands_enabled")  # None = auto
     audio_device_index = audio_settings.get("device_index", None)
+    text_injection_backend = text_injection_settings.get("backend", "auto")
 
     logger.info(f"Final settings: engine={engine}, language={language}, model={model_size}")
     if audio_device_index is not None:
@@ -370,7 +373,10 @@ def main():
         )
 
         # Initialize text injection system
-        text_system = text_injector.TextInjector(wayland_mode=args.wayland)
+        text_system = text_injector.TextInjector(
+            wayland_mode=args.wayland,
+            preferred_backend=text_injection_backend,
+        )
 
         # Initialize action handler
         action_handler = ActionHandler(text_system)

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -43,14 +43,18 @@ class TextInjector:
     application window, supporting both X11 and Wayland environments.
     """
 
-    def __init__(self, wayland_mode: bool = False):
+    VALID_BACKENDS = {"auto", "ibus", "xdotool", "wtype", "ydotool"}
+
+    def __init__(self, wayland_mode: bool = False, preferred_backend: str = "auto"):
         """
         Initialize the text injector.
 
         Args:
             wayland_mode: Force Wayland compatibility mode
+            preferred_backend: Preferred text injection backend
         """
         self._ibus_injector: Optional[IBusTextInjector] = None
+        self.preferred_backend = self._normalize_backend(preferred_backend)
         self.environment = self._detect_environment()
 
         # Force Wayland mode if requested
@@ -58,7 +62,11 @@ class TextInjector:
             logger.info("Forcing Wayland compatibility mode")
             self.environment = DesktopEnvironment.WAYLAND
 
-        logger.info(f"Using text injection for {self.environment.value} environment")
+        logger.info(
+            "Using text injection for %s environment with backend preference '%s'",
+            self.environment.value,
+            self.preferred_backend,
+        )
 
         # Check for required tools
         self._check_dependencies()
@@ -110,6 +118,13 @@ class TextInjector:
             self._ibus_injector.stop()
             self._ibus_injector = None
 
+    def _normalize_backend(self, preferred_backend: str) -> str:
+        backend = (preferred_backend or "auto").strip().lower()
+        if backend not in self.VALID_BACKENDS:
+            logger.warning("Unknown text injection backend '%s', using auto", preferred_backend)
+            return "auto"
+        return backend
+
     def _detect_environment(self) -> DesktopEnvironment:
         """
         Detect the current desktop environment (X11 or Wayland).
@@ -134,75 +149,36 @@ class TextInjector:
 
     def _check_dependencies(self):
         """Check for the required tools for text injection."""
+        preferred_backend = getattr(self, "preferred_backend", "auto")
+
+        if preferred_backend == "ibus":
+            self._configure_ibus(required=True)
+            return
+
+        if preferred_backend == "xdotool":
+            self._configure_xdotool(required=True)
+            return
+
+        if preferred_backend == "wtype":
+            self._configure_wayland_tool("wtype", required=True)
+            return
+
+        if preferred_backend == "ydotool":
+            self._configure_wayland_tool("ydotool", required=True)
+            return
+
         # Prefer IBus on both X11 and Wayland - it sends Unicode directly,
         # bypassing keyboard layout issues entirely
-        if is_ibus_available():
-            # Check if IBus is the active input method (not just installed)
-            # This is important because IBus may be installed but not being used,
-            # e.g., when the user has configured ydotool or Fcitx instead
-            if not is_ibus_active_input_method():
-                logger.info(
-                    "IBus is installed but not the active input method. "
-                    "Falling back to alternative text injection method."
-                )
-            # Check if ibus-daemon is running before attempting setup
-            elif not is_ibus_daemon_running():
-                logger.info(
-                    "IBus daemon not running. This is normal on some desktop environments "
-                    "(e.g., KDE Plasma). Using alternative text injection method. "
-                    "For IBus setup, see: https://github.com/jatinkrmalik/vocalinux/wiki/IBus-Setup"
-                )
-            else:
-                try:
-                    self._ibus_injector = IBusTextInjector(auto_activate=True)
-                    if self.environment == DesktopEnvironment.X11:
-                        self.environment = DesktopEnvironment.X11_IBUS
-                    else:
-                        self.environment = DesktopEnvironment.WAYLAND_IBUS
-                    logger.info(
-                        f"Using IBus for {self.environment.value} text injection (best compatibility)"
-                    )
-                    return
-                except Exception as e:
-                    logger.warning(f"IBus initialization failed: {e}, trying alternatives")
+        if self._configure_ibus(required=False):
+            return
         if self.environment == DesktopEnvironment.X11:
-            # Check for xdotool
-            if not shutil.which("xdotool"):
-                logger.error("xdotool not found. Please install it with: sudo apt install xdotool")
-                raise RuntimeError("Missing required dependency: xdotool")
+            self._configure_xdotool(required=True)
         else:
-            # Fallback: Check for wtype or ydotool for Wayland
-            wtype_available = shutil.which("wtype") is not None
-            ydotool_available = shutil.which("ydotool") is not None
-            xdotool_available = shutil.which("xdotool") is not None
-
-            if ydotool_available:
-                # Verify ydotoold daemon is running before selecting ydotool
-                try:
-                    subprocess.run(
-                        ["ydotool", "type", ""],
-                        check=True,
-                        stderr=subprocess.PIPE,
-                        timeout=2,
-                    )
-                    self.wayland_tool = "ydotool"
-                    logger.info(f"Using {self.wayland_tool} for Wayland text injection")
-                except (
-                    subprocess.CalledProcessError,
-                    subprocess.TimeoutExpired,
-                    FileNotFoundError,
-                ):
-                    if wtype_available:
-                        self.wayland_tool = "wtype"
-                        logger.info(
-                            f"Using {self.wayland_tool} for Wayland text injection (ydotoold not running)"
-                        )
-                    else:
-                        logger.warning("ydotool found but ydotoold daemon not running")
-            elif wtype_available:
-                self.wayland_tool = "wtype"
-                logger.info(f"Using {self.wayland_tool} for Wayland text injection")
-            elif xdotool_available:
+            if self._configure_wayland_tool("ydotool", required=False):
+                return
+            if self._configure_wayland_tool("wtype", required=False):
+                return
+            if shutil.which("xdotool") is not None:
                 # Fallback to xdotool with XWayland
                 self.environment = DesktopEnvironment.WAYLAND_XDOTOOL
                 logger.info(
@@ -223,6 +199,110 @@ class TextInjector:
                     "Or for clipboard fallback: sudo apt install wl-copy"
                 )
                 raise RuntimeError("Missing required dependencies for text injection")
+
+    def _configure_ibus(self, required: bool) -> bool:
+        if not is_ibus_available():
+            if required:
+                raise RuntimeError("IBus backend selected but IBus is not installed")
+            return False
+
+        if not is_ibus_active_input_method():
+            message = (
+                "IBus backend selected but IBus is not the active input method"
+                if required
+                else "IBus is installed but not the active input method. "
+                "Falling back to alternative text injection method."
+            )
+            if required:
+                logger.error(message)
+                raise RuntimeError(message)
+            logger.info(message)
+            return False
+
+        if not is_ibus_daemon_running():
+            message = (
+                "IBus backend selected but ibus-daemon is not running"
+                if required
+                else "IBus daemon not running. This is normal on some desktop environments "
+                "(e.g., KDE Plasma). Using alternative text injection method. "
+                "For IBus setup, see: https://github.com/jatinkrmalik/vocalinux/wiki/IBus-Setup"
+            )
+            if required:
+                logger.error(message)
+                raise RuntimeError(message)
+            logger.info(message)
+            return False
+
+        try:
+            self._ibus_injector = IBusTextInjector(auto_activate=True)
+            if self.environment == DesktopEnvironment.X11:
+                self.environment = DesktopEnvironment.X11_IBUS
+            else:
+                self.environment = DesktopEnvironment.WAYLAND_IBUS
+            logger.info(
+                f"Using IBus for {self.environment.value} text injection (best compatibility)"
+            )
+            return True
+        except Exception as e:
+            if required:
+                raise RuntimeError(f"IBus initialization failed: {e}") from e
+            logger.warning(f"IBus initialization failed: {e}, trying alternatives")
+            return False
+
+    def _configure_xdotool(self, required: bool) -> bool:
+        if self.environment == DesktopEnvironment.WAYLAND:
+            logger.error("xdotool backend requires an X11 session")
+            if required:
+                raise RuntimeError("xdotool backend requires an X11 session")
+            return False
+
+        if not shutil.which("xdotool"):
+            logger.error("xdotool not found. Please install it with: sudo apt install xdotool")
+            if required:
+                raise RuntimeError("Missing required dependency: xdotool")
+            return False
+
+        if self.environment != DesktopEnvironment.X11:
+            self.environment = DesktopEnvironment.WAYLAND_XDOTOOL
+        logger.info("Using xdotool for text injection")
+        return True
+
+    def _configure_wayland_tool(self, tool: str, required: bool) -> bool:
+        if self.environment == DesktopEnvironment.X11:
+            logger.error("%s backend requires a Wayland session", tool)
+            if required:
+                raise RuntimeError(f"{tool} backend requires a Wayland session")
+            return False
+
+        if tool == "wtype":
+            if shutil.which("wtype") is None:
+                if required:
+                    raise RuntimeError("Missing required dependency: wtype")
+                return False
+            self.wayland_tool = "wtype"
+            logger.info("Using wtype for Wayland text injection")
+            return True
+
+        if shutil.which("ydotool") is None:
+            if required:
+                raise RuntimeError("Missing required dependency: ydotool")
+            return False
+
+        try:
+            subprocess.run(
+                ["ydotool", "type", ""],
+                check=True,
+                stderr=subprocess.PIPE,
+                timeout=2,
+            )
+            self.wayland_tool = "ydotool"
+            logger.info("Using ydotool for Wayland text injection")
+            return True
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+            if required:
+                raise RuntimeError("ydotool backend selected but ydotoold daemon is not running") from e
+            logger.warning("ydotool found but ydotoold daemon not running")
+            return False
 
     def _test_xdotool_fallback(self):
         """Test if xdotool is working correctly with XWayland."""

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -51,6 +51,7 @@ DEFAULT_CONFIG = {
         "first_run": True,
     },
     "text_injection": {
+        "backend": "auto",  # auto, ibus, xdotool, wtype, or ydotool
         "copy_to_clipboard": False,  # Disabled by default; users can enable in Settings
     },
     "advanced": {

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -73,6 +73,14 @@ ENGINE_MODELS = {
     ],  # whisper.cpp models (ggml format)
 }
 
+TEXT_INJECTION_BACKENDS = {
+    "auto": "Auto",
+    "ibus": "IBus",
+    "xdotool": "xdotool",
+    "wtype": "wtype",
+    "ydotool": "ydotool",
+}
+
 # Whisper model metadata for display
 WHISPER_MODEL_INFO = {
     "tiny": {"size_mb": 75, "desc": "Fastest, lowest accuracy", "params": "39M"},
@@ -724,6 +732,7 @@ class SettingsDialog(Gtk.Dialog):
         config_manager: "ConfigManager",
         speech_engine: "SpeechRecognitionManager",
         shortcut_update_callback: callable = None,
+        text_injection_backend_update_callback: callable = None,
     ):
         super().__init__(title="Vocalinux Settings", transient_for=parent, flags=0)
         self.set_decorated(True)  # Force window decorations (close button) on all WMs
@@ -735,6 +744,7 @@ class SettingsDialog(Gtk.Dialog):
         self.config_manager = config_manager
         self.speech_engine = speech_engine
         self.shortcut_update_callback = shortcut_update_callback
+        self.text_injection_backend_update_callback = text_injection_backend_update_callback
         self._test_active = False
         self._test_result = ""
         self._initializing = True  # Flag to prevent auto-apply during initialization
@@ -976,11 +986,28 @@ class SettingsDialog(Gtk.Dialog):
         )
         group.add_row(copy_to_clipboard_row)
 
+        self.text_injection_backend_combo = Gtk.ComboBoxText()
+        self.text_injection_backend_combo.set_size_request(220, -1)
+        self.text_injection_backend_combo.set_tooltip_text(
+            "Choose the text injection backend. xdotool is usually best on X11; "
+            "wtype and ydotool require Wayland."
+        )
+        _prevent_scroll_on_hover(self.text_injection_backend_combo)
+        for backend_id, label in TEXT_INJECTION_BACKENDS.items():
+            self.text_injection_backend_combo.append(backend_id, label)
+        text_injection_backend_row = PreferenceRow(
+            title="Text Injection Backend",
+            subtitle="Choose how recognized text is inserted into the focused application",
+            widget=self.text_injection_backend_combo,
+        )
+        group.add_row(text_injection_backend_row)
+
         self.general_tab.pack_start(group, False, False, 0)
 
         self.autostart_switch.connect("state-set", self._on_autostart_toggled)
         self.start_minimized_switch.connect("state-set", self._on_start_minimized_toggled)
         self.copy_to_clipboard_switch.connect("state-set", self._on_copy_to_clipboard_toggled)
+        self.text_injection_backend_combo.connect("changed", self._on_text_injection_backend_changed)
 
     def _on_autostart_toggled(self, widget, state):
         """Handle toggle of the autostart switch."""
@@ -1023,6 +1050,21 @@ class SettingsDialog(Gtk.Dialog):
         self.config_manager.save_settings()
         logger.info(f"Copy to clipboard {'enabled' if enabled else 'disabled'}")
         return False
+
+    def _on_text_injection_backend_changed(self, widget):
+        """Handle changes to the preferred text injection backend."""
+        if self._initializing or self._applying_settings:
+            return
+
+        backend = widget.get_active_id()
+        if not backend:
+            return
+
+        logger.info(f"Text injection backend changed: {backend}")
+        self.config_manager.set("text_injection", "backend", backend)
+        self.config_manager.save_settings()
+        if self.text_injection_backend_update_callback is not None:
+            self.text_injection_backend_update_callback(backend)
 
     def _on_sound_effects_toggled(self, widget, state):
         if self._initializing or self._applying_settings:
@@ -1456,10 +1498,12 @@ class SettingsDialog(Gtk.Dialog):
         autostart_enabled = general_settings.get("autostart", False)
         start_minimized = ui_settings.get("start_minimized", False)
         copy_to_clipboard = text_injection_settings.get("copy_to_clipboard", False)
+        text_injection_backend = text_injection_settings.get("backend", "auto")
 
         self.autostart_switch.set_active(autostart_enabled)
         self.start_minimized_switch.set_active(start_minimized)
         self.copy_to_clipboard_switch.set_active(copy_to_clipboard)
+        self.text_injection_backend_combo.set_active_id(text_injection_backend)
         self.sound_effects_switch.set_active(self.config_manager.is_sound_effects_enabled())
 
         # Populate engine combo with only available engines

--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -30,6 +30,7 @@ from gi.repository import GdkPixbuf, Gio, GLib, GObject, Gtk
 # Import local modules - Use protocols to avoid circular imports
 from ..common_types import RecognitionState, SpeechRecognitionManagerProtocol, TextInjectorProtocol
 from ..suspend_handler import SuspendHandler
+from ..text_injection.text_injector import TextInjector
 from ..utils.resource_manager import ResourceManager
 from .config_manager import ConfigManager
 from .keyboard_shortcuts import KeyboardShortcutManager
@@ -470,6 +471,7 @@ class TrayIndicator:
             config_manager=self.config_manager,
             speech_engine=self.speech_engine,
             shortcut_update_callback=self.update_shortcut,
+            text_injection_backend_update_callback=self.update_text_injection_backend,
         )
 
         # Connect to the response signal
@@ -531,6 +533,21 @@ class TrayIndicator:
 
         logger.debug("No changes needed - shortcut and mode unchanged")
         return True
+
+    def update_text_injection_backend(self, backend: str) -> bool:
+        """Reinitialize the text injector with a newly selected backend."""
+        try:
+            logger.info("Updating text injection backend to: %s", backend)
+            new_injector = TextInjector(preferred_backend=backend)
+            old_injector = self.text_injector
+            self.text_injector = new_injector
+            if hasattr(old_injector, "stop"):
+                old_injector.stop()
+            logger.info("Text injection backend updated successfully")
+            return True
+        except Exception as e:
+            logger.error("Failed to update text injection backend to %s: %s", backend, e)
+            return False
 
     def _on_about_clicked(self, widget):
         """Handle click on the About menu item."""

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -49,6 +49,7 @@ class TestConfigManager(unittest.TestCase):
         """Test initialization with default configuration."""
         config_manager = ConfigManager()
         self.assertEqual(config_manager.config, DEFAULT_CONFIG)
+        self.assertEqual(config_manager.config["text_injection"]["backend"], "auto")
         self.mock_logger.info.assert_called_with(
             f"Config file not found at {self.temp_config_file}. Using defaults."
         )
@@ -91,6 +92,7 @@ class TestConfigManager(unittest.TestCase):
         )  # From defaults
         self.assertEqual(config_manager.config["ui"]["start_minimized"], True)
         self.assertEqual(config_manager.config["ui"]["show_notifications"], True)  # From defaults
+        self.assertEqual(config_manager.config["text_injection"]["backend"], "auto")
 
     def test_load_config_file_error(self):
         """Test handling of errors when loading config file."""

--- a/tests/test_main_args_deps.py
+++ b/tests/test_main_args_deps.py
@@ -372,6 +372,7 @@ class TestMainFunction(unittest.TestCase):
                 "language": "en-us",
             },
             "audio": {},
+            "text_injection": {"backend": "xdotool"},
             "general": {"first_run": False},
         }
 
@@ -447,6 +448,7 @@ class TestMainFunction(unittest.TestCase):
         mock_config_manager.return_value.get_settings.return_value = {
             "speech_recognition": {},
             "audio": {},
+            "text_injection": {"backend": "auto"},
             "general": {"first_run": False},
         }
 
@@ -479,6 +481,25 @@ class TestMainFunction(unittest.TestCase):
                 )
                 mock_logger.warning.assert_any_call("The system tray icon may not appear.")
                 mock_speech_manager_ctor.assert_called_once()
+
+
+class TestTrayIndicatorBackendReload:
+    def test_source_contains_backend_reload_hook(self):
+        import os
+
+        source_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "src",
+            "vocalinux",
+            "ui",
+            "tray_indicator.py",
+        )
+        with open(source_path, "r") as f:
+            source_code = f.read()
+
+        assert "def update_text_injection_backend" in source_code
+        assert "text_injection_backend_update_callback=self.update_text_injection_backend" in source_code
 
     @patch("vocalinux.main.logging")
     @patch("vocalinux.main.check_dependencies")

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -358,5 +358,34 @@ class TestSettingsDialogHelperFunctions(unittest.TestCase):
         self.assertTrue(callable(_get_recommended_vosk_model))
 
 
+class TestTextInjectionBackendSetting(unittest.TestCase):
+    def test_backend_options_constant_exists(self):
+        from vocalinux.ui.settings_dialog import TEXT_INJECTION_BACKENDS
+
+        self.assertEqual(
+            set(TEXT_INJECTION_BACKENDS.keys()),
+            {"auto", "ibus", "xdotool", "wtype", "ydotool"},
+        )
+
+    def test_source_contains_backend_combo_and_handler(self):
+        import os
+
+        source_path = os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "src",
+            "vocalinux",
+            "ui",
+            "settings_dialog.py",
+        )
+        with open(source_path, "r") as f:
+            source_code = f.read()
+
+        self.assertIn("Text Injection Backend", source_code)
+        self.assertIn("def _on_text_injection_backend_changed", source_code)
+        self.assertIn('self.config_manager.set("text_injection", "backend", backend)', source_code)
+        self.assertIn("text_injection_backend_update_callback", source_code)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_text_injector_ext.py
+++ b/tests/test_text_injector_ext.py
@@ -169,6 +169,37 @@ class TestInjectText(unittest.TestCase):
             self.assertTrue(result)
 
 
+class TestPreferredBackend(unittest.TestCase):
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    @patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False)
+    def test_xdotool_backend_on_x11(self, _mock_ibus, mock_which):
+        from vocalinux.text_injection.text_injector import DesktopEnvironment, TextInjector
+
+        mock_which.side_effect = lambda cmd: "/usr/bin/xdotool" if cmd == "xdotool" else None
+        with patch.dict(os.environ, {"XDG_SESSION_TYPE": "x11", "DISPLAY": ":0"}):
+            injector = TextInjector(preferred_backend="xdotool")
+        self.assertEqual(injector.environment, DesktopEnvironment.X11)
+
+    def test_wtype_backend_fails_on_x11(self):
+        from vocalinux.text_injection.text_injector import TextInjector
+
+        with patch.dict(os.environ, {"XDG_SESSION_TYPE": "x11", "DISPLAY": ":0"}):
+            with self.assertRaises(RuntimeError):
+                TextInjector(preferred_backend="wtype")
+
+    @patch("vocalinux.text_injection.text_injector.subprocess.run")
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    @patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False)
+    def test_ydotool_backend_on_wayland(self, _mock_ibus, mock_which, mock_run):
+        from vocalinux.text_injection.text_injector import TextInjector
+
+        mock_which.side_effect = lambda cmd: "/usr/bin/ydotool" if cmd == "ydotool" else None
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        with patch.dict(os.environ, {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "wayland-0"}):
+            injector = TextInjector(preferred_backend="ydotool")
+        self.assertEqual(injector.wayland_tool, "ydotool")
+
+
 class TestLogWindowInfo(unittest.TestCase):
     def test_log_x11(self):
         from vocalinux.text_injection.text_injector import DesktopEnvironment


### PR DESCRIPTION
## Summary
- add a configurable text injection backend setting in the GTK settings dialog
- expose the existing backend choices: `auto`, `ibus`, `xdotool`, `wtype`, and `ydotool`
- apply backend changes immediately by rebuilding the active injector at runtime

## Motivation
On X11, text injection could still route through IBus whenever it initialized successfully, even in applications where IBus was not reliable in practice, such as VS Code and some terminal contexts. This made injection behavior hard to control and hard to debug, especially because an accepted IBus request did not necessarily mean that text was actually inserted in the focused application.

## Notes
- explicit backend selections now fail clearly when they are incompatible with the current session type
- this is especially useful on X11 setups where `xdotool` works better than IBus in some apps