### PR TITLE
feat(flatpak): add Flatpak packaging support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,30 @@ jobs:
         run: |
           twine upload dist/* --skip-existing
 
+  build-flatpak:
+    name: Build Flatpak
+    needs: build-and-release
+    runs-on: ubuntu-latest
+    container:
+      image: bilelmoussaoui/flatpak-github-actions:gnome-46
+      options: --privileged
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Flatpak
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: vocalinux.flatpak
+          manifest-path: packaging/flatpak/com.vocalinux.Vocalinux.yml
+          cache-key: flatpak-${{ github.sha }}
+
+      - name: Upload Flatpak bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: vocalinux-flatpak
+          path: vocalinux.flatpak
+
   deploy-website:
     name: Deploy Website
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
     needs: build-and-release
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-46
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
       options: --privileged
     steps:
       - name: Checkout code
@@ -157,6 +157,7 @@ jobs:
           bundle: vocalinux.flatpak
           manifest-path: packaging/flatpak/com.vocalinux.Vocalinux.yml
           cache-key: flatpak-${{ github.sha }}
+          mirror-screenshots-url: https://dl.flathub.org/media
 
       - name: Upload Flatpak bundle
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ out/
 .nuxt/
 dist/
 build/
+.flatpak-builder/
+build-dir/
+repo/
 
 # Environment variables
 .env

--- a/README.md
+++ b/README.md
@@ -116,11 +116,43 @@ Here are some screenshots showcasing Vocalinux in action:
   </tr>
 </table>
 
-## 🚀 Quick Install
+## 🚀 Installation
 
-### Interactive Install (Recommended)
+### Flatpak (Recommended — All Linux Distributions)
 
-Our new interactive installer guides you through setup with intelligent hardware detection:
+One command for any Linux distro. Also available in GNOME Software and KDE Discover.
+
+```bash
+flatpak install flathub com.vocalinux.Vocalinux
+```
+
+> **Note**: Speech models are downloaded on first run (~39MB for whisper.cpp tiny).
+
+### Ubuntu / Debian (PPA)
+
+```bash
+sudo add-apt-repository ppa:vocalinux/vocalinux
+sudo apt update
+sudo apt install vocalinux
+```
+
+### Arch Linux (AUR)
+
+```bash
+yay -S vocalinux
+# or
+paru -S vocalinux
+```
+
+### Snap Store (Ubuntu)
+
+```bash
+sudo snap install vocalinux
+```
+
+### Interactive Installer (Any Distribution)
+
+Our interactive installer guides you through setup with intelligent hardware detection:
 
 ```bash
 curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh
@@ -139,27 +171,7 @@ The installer will:
 
 > **Note**: Always installs the latest release. For a specific version, check [GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases).
 
-### Installation Options
-
-**Default (whisper.cpp - recommended):**
-```bash
-curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh
-```
-Fastest installation (~1-2 min), universal GPU support via Vulkan.
-
-**Whisper (OpenAI) - if you prefer PyTorch:**
-```bash
-curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --engine=whisper
-```
-NVIDIA GPU only (~5-10 min, downloads PyTorch + CUDA).
-
-**VOSK only - for low-RAM systems:**
-```bash
-curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --engine=vosk
-```
-Lightweight option (~40MB), works on systems with 4GB RAM.
-
-### Alternative: Install from Source
+### Install from Source
 
 ```bash
 # Clone the repository
@@ -359,6 +371,7 @@ This script generates all three sounds using the same smooth glide algorithm. Yo
 - [x] ~~Vulkan GPU support~~ ✅
 - [ ] In-app update mechanism
 - [ ] Application-specific commands
+- [x] ~~Flatpak packaging~~ ✅
 - [ ] Debian/Ubuntu package (.deb)
 - [x] ~~Wayland support via IBus~~ ✅
 - [ ] Voice command customization

--- a/README.md
+++ b/README.md
@@ -116,41 +116,9 @@ Here are some screenshots showcasing Vocalinux in action:
   </tr>
 </table>
 
-## 🚀 Installation
+## 🚀 Quick Install
 
-### Flatpak (Recommended — All Linux Distributions)
-
-One command for any Linux distro. Also available in GNOME Software and KDE Discover.
-
-```bash
-flatpak install flathub com.vocalinux.Vocalinux
-```
-
-> **Note**: Speech models are downloaded on first run (~39MB for whisper.cpp tiny).
-
-### Ubuntu / Debian (PPA)
-
-```bash
-sudo add-apt-repository ppa:vocalinux/vocalinux
-sudo apt update
-sudo apt install vocalinux
-```
-
-### Arch Linux (AUR)
-
-```bash
-yay -S vocalinux
-# or
-paru -S vocalinux
-```
-
-### Snap Store (Ubuntu)
-
-```bash
-sudo snap install vocalinux
-```
-
-### Interactive Installer (Any Distribution)
+### Interactive Install (Recommended)
 
 Our interactive installer guides you through setup with intelligent hardware detection:
 
@@ -171,7 +139,33 @@ The installer will:
 
 > **Note**: Always installs the latest release. For a specific version, check [GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases).
 
-### Install from Source
+### Installation Options
+
+**Default (whisper.cpp - recommended):**
+```bash
+curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh
+```
+Fastest installation (~1-2 min), universal GPU support via Vulkan.
+
+**Whisper (OpenAI) - if you prefer PyTorch:**
+```bash
+curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --engine=whisper
+```
+NVIDIA GPU only (~5-10 min, downloads PyTorch + CUDA).
+
+**VOSK only - for low-RAM systems:**
+```bash
+curl -fsSL raw.githubusercontent.com/jatinkrmalik/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --engine=vosk
+```
+Lightweight option (~40MB), works on systems with 4GB RAM.
+
+**Flatpak test build:**
+```bash
+flatpak-builder --user --install --force-clean build-dir packaging/flatpak/com.vocalinux.Vocalinux.yml
+```
+Flatpak packaging is in progress for Flathub submission. See `packaging/flatpak/README.md`.
+
+### Alternative: Install from Source
 
 ```bash
 # Clone the repository
@@ -371,7 +365,7 @@ This script generates all three sounds using the same smooth glide algorithm. Yo
 - [x] ~~Vulkan GPU support~~ ✅
 - [ ] In-app update mechanism
 - [ ] Application-specific commands
-- [x] ~~Flatpak packaging~~ ✅
+- [ ] Flatpak packaging
 - [ ] Debian/Ubuntu package (.deb)
 - [x] ~~Wayland support via IBus~~ ✅
 - [ ] Voice command customization

--- a/docs/DISTRO_COMPATIBILITY.md
+++ b/docs/DISTRO_COMPATIBILITY.md
@@ -12,7 +12,7 @@ The cross-distribution compatibility improvements have been implemented in phase
 | Phase 4 | ✅ Complete | CI test matrix, pkg-config as core dependency |
 | **Phase 5** | ✅ **Complete** | **Fixed remaining hardcoded GI_TYPELIB_PATH values in install.sh and CI workflow** |
 | **Phase 6** | ✅ **Complete** | **Added wrapper script verification tests, updated documentation** |
-| Phase 7 | 📋 Planned | Flatpak packaging for universal distribution support |
+| Phase 7 | ✅ Complete | Flatpak packaging for universal distribution support |
 | Phase 8 | 📋 Planned | Snap packaging for Ubuntu Software Store |
 
 ## Technical Implementation

--- a/docs/DISTRO_COMPATIBILITY.md
+++ b/docs/DISTRO_COMPATIBILITY.md
@@ -12,7 +12,7 @@ The cross-distribution compatibility improvements have been implemented in phase
 | Phase 4 | ✅ Complete | CI test matrix, pkg-config as core dependency |
 | **Phase 5** | ✅ **Complete** | **Fixed remaining hardcoded GI_TYPELIB_PATH values in install.sh and CI workflow** |
 | **Phase 6** | ✅ **Complete** | **Added wrapper script verification tests, updated documentation** |
-| Phase 7 | ✅ Complete | Flatpak packaging for universal distribution support |
+| Phase 7 | 🚧 In Progress | Flatpak packaging for universal distribution support |
 | Phase 8 | 📋 Planned | Snap packaging for Ubuntu Software Store |
 
 ## Technical Implementation

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -1,0 +1,145 @@
+# Vocalinux Flatpak Packaging
+
+This directory contains the Flatpak manifest and metadata for distributing
+Vocalinux via [Flathub](https://flathub.org).
+
+## Quick Start (Local Build)
+
+### Prerequisites
+
+Install the Flatpak runtime and SDK:
+
+```bash
+flatpak install flathub org.gnome.Platform//46 org.gnome.Sdk//46
+```
+
+### Build
+
+The manifest is configured for **local testing** (`type: dir` with `path: .`) so it
+builds from your current checkout rather than cloning from GitHub. It also enables
+`network: true` during build so `pip` can download Python dependencies from PyPI.
+
+From the repository root:
+
+```bash
+flatpak-builder \
+  --force-clean \
+  build-dir \
+  packaging/flatpak/com.vocalinux.Vocalinux.yml
+```
+
+### Run (without installing)
+
+```bash
+flatpak-builder --run build-dir packaging/flatpak/com.vocalinux.Vocalinux.yml vocalinux
+```
+
+### Install locally
+
+```bash
+flatpak-builder \
+  --user \
+  --install \
+  --force-clean \
+  build-dir \
+  packaging/flatpak/com.vocalinux.Vocalinux.yml
+```
+
+Then launch:
+
+```bash
+flatpak run com.vocalinux.Vocalinux
+```
+
+## Flathub Submission
+
+To publish on Flathub, follow the official
+[Flathub Submission Documentation](https://docs.flathub.org/docs/for-app-authors/submission/).
+
+### Step 1: Fork the Flathub repository
+
+```bash
+git clone https://github.com/flathub/flathub.git
+cd flathub
+git checkout -b com.vocalinux.Vocalinux
+```
+
+### Step 2: Copy and adapt the manifest
+
+Copy `com.vocalinux.Vocalinux.yml` into the forked repo root, then make these
+changes for Flathub:
+
+1. **Change the source** from local directory to Git tag:
+   ```yaml
+   sources:
+     - type: git
+       url: https://github.com/jatinkrmalik/vocalinux.git
+       tag: v0.10.2-beta
+   ```
+
+2. **Remove `network: true`** from `build-options` (Flathub builders do not
+   allow network access during build). Instead, pre-download all Python
+   wheels and use `--no-index --find-links`:
+   ```yaml
+   build-commands:
+     - pip3 install --no-build-isolation --no-index --find-links=./wheels --prefix=/app .
+   ```
+   Or use `flatpak-pip-generator` to generate a dependencies module.
+
+3. **Keep the rest** of the manifest unchanged.
+
+### Step 3: Open a Pull Request
+
+Push the branch and open a PR against `flathub/flathub`. Flathub maintainers
+will review the manifest, test the build, and provide feedback.
+
+### Step 4: After merge
+
+Once merged, Flathub will:
+- Build the app on their CI infrastructure
+- Sign and publish the bundle
+- The app will appear in GNOME Software, KDE Discover, and other app stores
+
+## Manifest Details
+
+### Runtime
+
+- **Runtime**: `org.gnome.Platform` version `46`
+- **SDK**: `org.gnome.Sdk` version `46`
+
+The GNOME runtime provides GTK3, PyGObject, and AppIndicator libraries out of
+the box.
+
+### Permissions
+
+| Permission | Purpose |
+|------------|---------|
+| `--share=network` | Download speech models on first run |
+| `--socket=pulseaudio` | Microphone capture (works with PipeWire too) |
+| `--device=all` | Microphone access, Vulkan GPU, keyboard events |
+| `--filesystem=xdg-config/vocalinux` | Configuration storage |
+| `--filesystem=xdg-data/vocalinux` | Speech model storage |
+| `--talk-name=org.freedesktop.IBus` | IBus text injection engine |
+| `--talk-name=org.kde.StatusNotifierWatcher` | System tray icon (KDE) |
+| `--talk-name=org.gnome.Shell` | System tray icon (GNOME) |
+
+### Known Limitations
+
+- **Global keyboard shortcuts** via `evdev` may have reduced functionality inside
+the Flatpak sandbox. The app falls back to `pynput` which works through X11/Wayland.
+- **IBus engine** is the preferred text injection method on Wayland and works
+fully within the sandbox.
+- **GPU acceleration**: Vulkan support is available via `--device=all`. CUDA is
+not available inside the Flatpak sandbox; whisper.cpp will use Vulkan or CPU.
+
+## Maintenance
+
+When releasing a new version:
+
+1. Update the `tag` in `com.vocalinux.Vocalinux.yml`
+2. Update the `<releases>` section in `com.vocalinux.Vocalinux.metainfo.xml`
+3. Test the local build
+4. Open a PR to the Flathub repository with the updated manifest
+
+The CI workflow `.github/workflows/release.yml` includes a `build-flatpak` job
+that automatically builds the Flatpak on every release tag.

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -11,9 +11,14 @@ platform wheels, not a source distribution. A Flathub-ready VOSK module will nee
 to build VOSK and its native dependencies from source, or VOSK support should be
 made an optional non-Flatpak feature.
 
-Global keyboard shortcuts are also limited inside the sandbox. The Flatpak does
-not request direct `/dev/input` access, so Wayland users should expect tray/menu
-control and IBus text injection rather than evdev-based push-to-talk shortcuts.
+The Flatpak intentionally uses the X11 socket so it runs under XWayland on
+Wayland sessions. Native Wayland input injection is compositor-dependent and is
+not available on GNOME without privileged protocols, while the XWayland path lets
+the packaged `xdotool` backend work wherever X11/XWayland injection is possible.
+
+Global keyboard shortcuts are limited inside the sandbox. The Flatpak does not
+request direct `/dev/input` access, so users should expect tray/menu control
+rather than evdev-based push-to-talk shortcuts.
 
 ## Local Build
 
@@ -119,7 +124,8 @@ For a Flathub PR:
 - Microphone access: `--socket=pulseaudio`
 - GPU access: `--device=dri`
 - Model downloads: `--share=network`
-- Text injection: `--talk-name=org.freedesktop.IBus`
+- Text injection: `--socket=x11` with packaged `xdotool` and `xsel`
+- IBus D-Bus access: `--talk-name=org.freedesktop.IBus`
 - Tray/status notifier: `--talk-name=org.kde.StatusNotifierWatcher`
 
 Configuration and model data use the standard Flatpak XDG directories under

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -47,12 +47,6 @@ flatpak run --command=flatpak-builder-lint org.flatpak.Builder builddir build-di
 flatpak run --command=flatpak-builder-lint org.flatpak.Builder repo repo
 ```
 
-Run without installing:
-
-```bash
-flatpak-builder --run build-dir packaging/flatpak/com.vocalinux.Vocalinux.yml vocalinux --debug
-```
-
 Install locally:
 
 ```bash
@@ -68,6 +62,15 @@ Launch after installing:
 
 ```bash
 flatpak run com.vocalinux.Vocalinux --debug
+```
+
+Prefer the installed launch path for GUI testing. On GNOME runtimes that use
+glycin image loaders, `flatpak-builder --run` can fail to load themed SVG icons
+for an uninstalled stable app ID. `flatpak-builder --run` is still useful for
+non-GUI smoke tests:
+
+```bash
+flatpak-builder --run build-dir packaging/flatpak/com.vocalinux.Vocalinux.yml python3 -c 'from pywhispercpp.model import Model; print("pywhispercpp ok")'
 ```
 
 ## Python Dependencies

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -1,25 +1,29 @@
 # Vocalinux Flatpak Packaging
 
-This directory contains the Flatpak manifest and metadata for distributing
-Vocalinux via [Flathub](https://flathub.org).
+This directory contains the Flatpak manifest and AppStream metadata for building
+Vocalinux as a Flatpak.
 
-## Quick Start (Local Build)
+## Current Scope
 
-### Prerequisites
+The manifest targets the default `whisper_cpp` engine. The VOSK engine is not
+included in this Flatpak yet because the PyPI `vosk` package only publishes
+platform wheels, not a source distribution. A Flathub-ready VOSK module will need
+to build VOSK and its native dependencies from source, or VOSK support should be
+made an optional non-Flatpak feature.
 
-Install the Flatpak runtime and SDK:
+Global keyboard shortcuts are also limited inside the sandbox. The Flatpak does
+not request direct `/dev/input` access, so Wayland users should expect tray/menu
+control and IBus text injection rather than evdev-based push-to-talk shortcuts.
+
+## Local Build
+
+Install the current GNOME runtime and SDK:
 
 ```bash
-flatpak install flathub org.gnome.Platform//46 org.gnome.Sdk//46
+flatpak install flathub org.gnome.Platform//50 org.gnome.Sdk//50
 ```
 
-### Build
-
-The manifest is configured for **local testing** (`type: dir` with `path: .`) so it
-builds from your current checkout rather than cloning from GitHub. It also enables
-`network: true` during build so `pip` can download Python dependencies from PyPI.
-
-From the repository root:
+Build from the repository root:
 
 ```bash
 flatpak-builder \
@@ -28,13 +32,28 @@ flatpak-builder \
   packaging/flatpak/com.vocalinux.Vocalinux.yml
 ```
 
-### Run (without installing)
+For a Flathub-style local build with screenshot mirroring and linter inputs:
 
 ```bash
-flatpak-builder --run build-dir packaging/flatpak/com.vocalinux.Vocalinux.yml vocalinux
+flatpak-builder \
+  --force-clean \
+  --repo=repo \
+  --compose-url-policy=full \
+  --mirror-screenshots-url=https://dl.flathub.org/media \
+  build-dir \
+  packaging/flatpak/com.vocalinux.Vocalinux.yml
+flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest packaging/flatpak/com.vocalinux.Vocalinux.yml
+flatpak run --command=flatpak-builder-lint org.flatpak.Builder builddir build-dir
+flatpak run --command=flatpak-builder-lint org.flatpak.Builder repo repo
 ```
 
-### Install locally
+Run without installing:
+
+```bash
+flatpak-builder --run build-dir packaging/flatpak/com.vocalinux.Vocalinux.yml vocalinux --debug
+```
+
+Install locally:
 
 ```bash
 flatpak-builder \
@@ -45,101 +64,60 @@ flatpak-builder \
   packaging/flatpak/com.vocalinux.Vocalinux.yml
 ```
 
-Then launch:
+Launch after installing:
 
 ```bash
-flatpak run com.vocalinux.Vocalinux
+flatpak run com.vocalinux.Vocalinux --debug
 ```
 
-## Flathub Submission
+## Python Dependencies
 
-To publish on Flathub, follow the official
-[Flathub Submission Documentation](https://docs.flathub.org/docs/for-app-authors/submission/).
-
-### Step 1: Fork the Flathub repository
+`python3-dependencies.yaml` is generated with `flatpak-pip-generator` and keeps
+the build itself offline. Regenerate it when `pyproject.toml` dependencies change:
 
 ```bash
-git clone https://github.com/flathub/flathub.git
-cd flathub
-git checkout -b com.vocalinux.Vocalinux
+pipx run flatpak-pip-generator \
+  --runtime org.gnome.Sdk//50 \
+  --yaml \
+  --ignore-pkg 'vosk>=0.3.45' "PyGObject; sys_platform == 'linux'" \
+  --output packaging/flatpak/python3-dependencies \
+  pywhispercpp pydub pynput evdev requests tqdm numpy pyaudio python-xlib psutil lxml \
+  meson-python pyproject-metadata
 ```
 
-### Step 2: Copy and adapt the manifest
+`python3-build-dependencies.yaml` is kept as a small hand-maintained helper so
+source builds that use `--no-build-isolation` can import `mesonpy` before NumPy
+is built.
 
-Copy `com.vocalinux.Vocalinux.yml` into the forked repo root, then make these
-changes for Flathub:
+## Flathub Submission Notes
 
-1. **Change the source** from local directory to Git tag:
+For a Flathub PR:
+
+1. Change the `vocalinux` module source from `type: dir` to a tagged release:
+
    ```yaml
    sources:
      - type: git
        url: https://github.com/jatinkrmalik/vocalinux.git
        tag: v0.10.2-beta
+       commit: <release-commit-sha>
    ```
 
-2. **Remove `network: true`** from `build-options` (Flathub builders do not
-   allow network access during build). Instead, pre-download all Python
-   wheels and use `--no-index --find-links`:
-   ```yaml
-   build-commands:
-     - pip3 install --no-build-isolation --no-index --find-links=./wheels --prefix=/app .
-   ```
-   Or use `flatpak-pip-generator` to generate a dependencies module.
-
-3. **Keep the rest** of the manifest unchanged.
-
-### Step 3: Open a Pull Request
-
-Push the branch and open a PR against `flathub/flathub`. Flathub maintainers
-will review the manifest, test the build, and provide feedback.
-
-### Step 4: After merge
-
-Once merged, Flathub will:
-- Build the app on their CI infrastructure
-- Sign and publish the bundle
-- The app will appear in GNOME Software, KDE Discover, and other app stores
+2. Keep build-time network access disabled. The manifest should only download
+   declared sources before the build starts.
+3. Re-run AppStream validation and `flatpak-builder` locally.
+4. Be ready to justify the sandbox permissions, especially D-Bus access for IBus
+   and status notifier support.
 
 ## Manifest Details
 
-### Runtime
+- Runtime: `org.gnome.Platform//50`
+- SDK: `org.gnome.Sdk//50`
+- Microphone access: `--socket=pulseaudio`
+- GPU access: `--device=dri`
+- Model downloads: `--share=network`
+- Text injection: `--talk-name=org.freedesktop.IBus`
+- Tray/status notifier: `--talk-name=org.kde.StatusNotifierWatcher`
 
-- **Runtime**: `org.gnome.Platform` version `46`
-- **SDK**: `org.gnome.Sdk` version `46`
-
-The GNOME runtime provides GTK3, PyGObject, and AppIndicator libraries out of
-the box.
-
-### Permissions
-
-| Permission | Purpose |
-|------------|---------|
-| `--share=network` | Download speech models on first run |
-| `--socket=pulseaudio` | Microphone capture (works with PipeWire too) |
-| `--device=all` | Microphone access, Vulkan GPU, keyboard events |
-| `--filesystem=xdg-config/vocalinux` | Configuration storage |
-| `--filesystem=xdg-data/vocalinux` | Speech model storage |
-| `--talk-name=org.freedesktop.IBus` | IBus text injection engine |
-| `--talk-name=org.kde.StatusNotifierWatcher` | System tray icon (KDE) |
-| `--talk-name=org.gnome.Shell` | System tray icon (GNOME) |
-
-### Known Limitations
-
-- **Global keyboard shortcuts** via `evdev` may have reduced functionality inside
-the Flatpak sandbox. The app falls back to `pynput` which works through X11/Wayland.
-- **IBus engine** is the preferred text injection method on Wayland and works
-fully within the sandbox.
-- **GPU acceleration**: Vulkan support is available via `--device=all`. CUDA is
-not available inside the Flatpak sandbox; whisper.cpp will use Vulkan or CPU.
-
-## Maintenance
-
-When releasing a new version:
-
-1. Update the `tag` in `com.vocalinux.Vocalinux.yml`
-2. Update the `<releases>` section in `com.vocalinux.Vocalinux.metainfo.xml`
-3. Test the local build
-4. Open a PR to the Flathub repository with the updated manifest
-
-The CI workflow `.github/workflows/release.yml` includes a `build-flatpak` job
-that automatically builds the Flatpak on every release tag.
+Configuration and model data use the standard Flatpak XDG directories under
+`~/.var/app/com.vocalinux.Vocalinux/`.

--- a/packaging/flatpak/com.vocalinux.Vocalinux.desktop
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.desktop
@@ -1,0 +1,14 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Vocalinux
+Comment=Free, offline voice dictation for Linux
+GenericName=Voice Typing
+Exec=vocalinux
+Icon=com.vocalinux.Vocalinux
+Terminal=false
+Categories=Utility;Accessibility;AudioVideo;
+Keywords=voice;typing;dictation;speech;recognition;transcription;accessibility;
+StartupNotify=true
+StartupWMClass=com.vocalinux.Vocalinux
+X-GNOME-UsesNotifications=true

--- a/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.vocalinux.Vocalinux</id>
+
+  <name>Vocalinux</name>
+  <summary>Free, offline voice dictation for Linux</summary>
+  <developer id="com.vocalinux">
+    <name>Jatin K Malik</name>
+  </developer>
+
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+
+  <description>
+    <p>
+      Vocalinux is a privacy-first, fully offline voice dictation system for Linux.
+      Speak naturally and your words appear in any application — on X11 or Wayland —
+      using local speech recognition. No cloud, no data leaves your machine.
+      Speech recognition models are downloaded on first run.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Toggle or push-to-talk activation modes</li>
+      <li>Real-time transcription with minimal latency</li>
+      <li>Universal compatibility across all Linux applications</li>
+      <li>100% offline operation for privacy and reliability</li>
+      <li>whisper.cpp by default — high-performance C++ speech recognition</li>
+      <li>Universal GPU support via Vulkan (AMD, Intel, NVIDIA)</li>
+      <li>System tray integration with visual status indicators</li>
+      <li>Start on login support via XDG autostart</li>
+      <li>Pleasant audio feedback with smooth gliding tones</li>
+      <li>Graphical settings dialog for easy configuration</li>
+      <li>Three engine choices: whisper.cpp, OpenAI Whisper, or VOSK</li>
+    </ul>
+  </description>
+
+  <launchable type="desktop-id">com.vocalinux.Vocalinux.desktop</launchable>
+
+  <categories>
+    <category>Utility</category>
+    <category>Accessibility</category>
+    <category>AudioVideo</category>
+  </categories>
+
+  <keywords>
+    <keyword>voice</keyword>
+    <keyword>typing</keyword>
+    <keyword>dictation</keyword>
+    <keyword>speech</keyword>
+    <keyword>recognition</keyword>
+    <keyword>transcription</keyword>
+    <keyword>accessibility</keyword>
+  </keywords>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>Real-time voice-to-text transcription</caption>
+      <image>https://github.com/user-attachments/assets/e3d8dd16-3d4f-408c-b899-93d85e98b107</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://vocalinux.com</url>
+  <url type="bugtracker">https://github.com/jatinkrmalik/vocalinux/issues</url>
+  <url type="vcs-browser">https://github.com/jatinkrmalik/vocalinux</url>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="violence-desecration">none</content_attribute>
+    <content_attribute id="violence-slavery">none</content_attribute>
+    <content_attribute id="violence-worship">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="sex-homosexuality">none</content_attribute>
+    <content_attribute id="sex-prostitution">none</content_attribute>
+    <content_attribute id="sex-adultery">none</content_attribute>
+    <content_attribute id="sex-appearance">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">none</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">none</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">none</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+  </content_rating>
+
+  <releases>
+    <release version="0.10.2-beta" date="2026-04-08">
+      <description>
+        <p>Non-ASCII text injection, IBus Wayland detection fixes, Pop!_OS dependency support, and code quality improvements.</p>
+      </description>
+    </release>
+    <release version="0.10.1-beta" date="2026-03-27">
+      <description>
+        <p>Stability patch: tray resource bundling, engine-switch segfault prevention, settings close action, XKB layout preservation.</p>
+      </description>
+    </release>
+    <release version="0.10.0-beta" date="2026-03-25">
+      <description>
+        <p>Keyboard and audio reliability hardening, IBus and tray stability fixes, CI and test coverage improvements.</p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/packaging/flatpak/com.vocalinux.Vocalinux.yml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.yml
@@ -1,0 +1,56 @@
+app-id: com.vocalinux.Vocalinux
+runtime: org.gnome.Platform
+runtime-version: "46"
+sdk: org.gnome.Sdk
+command: vocalinux
+
+build-options:
+  build-args:
+    - --share=network
+
+finish-args:
+  - --share=network
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --socket=pulseaudio
+  - --device=dri
+  - --device=input
+  - --filesystem=xdg-config/vocalinux:create
+  - --filesystem=xdg-data/vocalinux:create
+  - --talk-name=org.freedesktop.IBus
+  - --talk-name=org.freedesktop.Notifications
+  - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.gnome.Shell
+  - --env=GI_TYPELIB_PATH=/app/lib/girepository-1.0
+
+modules:
+  - name: portaudio
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DCMAKE_INSTALL_PREFIX=/app
+    cleanup:
+      - /include
+      - /lib/cmake
+      - /lib/pkgconfig
+      - "*.a"
+      - "*.la"
+    sources:
+      - type: archive
+        url: https://github.com/PortAudio/portaudio/archive/refs/tags/v19.7.0.tar.gz
+        sha256: 5af29ba58bbdbb7bbcefaaecc77ec8fc413f0db6f4c4e286c40c3e1b83174fa0
+
+  - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
+
+  - name: vocalinux
+    buildsystem: simple
+    build-commands:
+      - pip3 install --ignore-installed --prefix=/app setuptools wheel meson-python
+      - pip3 install --ignore-installed --no-build-isolation --prefix=/app .
+      - install -Dm644 packaging/flatpak/com.vocalinux.Vocalinux.desktop -t /app/share/applications/
+      - install -Dm644 resources/icons/scalable/vocalinux.svg /app/share/icons/hicolor/scalable/apps/com.vocalinux.Vocalinux.svg
+      - install -Dm644 packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml -t /app/share/metainfo/
+    sources:
+      - type: dir
+        path: ../..

--- a/packaging/flatpak/com.vocalinux.Vocalinux.yml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.yml
@@ -43,6 +43,36 @@ modules:
 
   - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
 
+  - name: wtype
+    buildsystem: meson
+    config-opts:
+      - --prefix=/app
+    sources:
+      - type: archive
+        url: https://github.com/atx/wtype/archive/refs/tags/v0.4.tar.gz
+        sha256: da91786d828b6a6e29b884bc510473939eda052658ebef87d7bdeafa6a8746f9
+
+  - name: wl-clipboard
+    buildsystem: meson
+    config-opts:
+      - --prefix=/app
+      - -Dfishcompletiondir=no
+      - -Dzshcompletiondir=no
+    sources:
+      - type: archive
+        url: https://github.com/bugaevc/wl-clipboard/archive/refs/tags/v2.2.1.tar.gz
+        sha256: 6eb8081207fb5581d1d82c4bcd9587205a31a3d47bea3ebeb7f41aa1143783eb
+
+  - name: xdotool
+    buildsystem: simple
+    build-commands:
+      - make
+      - make install PREFIX=/app
+    sources:
+      - type: archive
+        url: https://github.com/jordansissel/xdotool/archive/refs/tags/v3.20211022.1.tar.gz
+        sha256: 82b15a944a5e82fee15e0f6116bd9f642bc3d0bb6989fc0ca5ad9dfe35de0847
+
   - name: vocalinux
     buildsystem: simple
     build-commands:

--- a/packaging/flatpak/com.vocalinux.Vocalinux.yml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.yml
@@ -11,7 +11,7 @@ build-options:
 finish-args:
   - --share=network
   - --share=ipc
-  - --socket=fallback-x11
+  - --socket=x11
   - --socket=wayland
   - --socket=pulseaudio
   - --device=dri

--- a/packaging/flatpak/com.vocalinux.Vocalinux.yml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.yml
@@ -12,8 +12,7 @@ build-options:
 finish-args:
   - --share=network
   - --share=ipc
-  - --socket=fallback-x11
-  - --socket=wayland
+  - --socket=x11
   - --socket=pulseaudio
   - --device=dri
   - --talk-name=org.freedesktop.IBus
@@ -42,25 +41,19 @@ modules:
 
   - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
 
-  - name: wtype
-    buildsystem: meson
-    config-opts:
-      - --prefix=/app
+  - name: xsel
+    buildsystem: simple
+    build-commands:
+      - autoreconf -fi
+      - ./configure --prefix=/app
+      - make
+      - make install
+    cleanup:
+      - /share/man
     sources:
       - type: archive
-        url: https://github.com/atx/wtype/archive/refs/tags/v0.4.tar.gz
-        sha256: da91786d828b6a6e29b884bc510473939eda052658ebef87d7bdeafa6a8746f9
-
-  - name: wl-clipboard
-    buildsystem: meson
-    config-opts:
-      - --prefix=/app
-      - -Dfishcompletiondir=no
-      - -Dzshcompletiondir=no
-    sources:
-      - type: archive
-        url: https://github.com/bugaevc/wl-clipboard/archive/refs/tags/v2.2.1.tar.gz
-        sha256: 6eb8081207fb5581d1d82c4bcd9587205a31a3d47bea3ebeb7f41aa1143783eb
+        url: https://github.com/kfish/xsel/archive/refs/tags/1.2.1.tar.gz
+        sha256: 18487761f5ca626a036d65ef2db8ad9923bf61685e06e7533676c56d7d60eb14
 
   - name: xdotool
     buildsystem: simple
@@ -81,6 +74,9 @@ modules:
       - pip3 install --no-deps --no-build-isolation --prefix=/app .
       - install -Dm644 packaging/flatpak/com.vocalinux.Vocalinux.desktop -t /app/share/applications/
       - install -Dm644 resources/icons/scalable/vocalinux.svg /app/share/icons/hicolor/scalable/apps/com.vocalinux.Vocalinux.svg
+      - install -Dm644 resources/icons/scalable/vocalinux-microphone-off.svg /app/share/icons/hicolor/scalable/apps/com.vocalinux.Vocalinux-microphone-off.svg
+      - install -Dm644 resources/icons/scalable/vocalinux-microphone.svg /app/share/icons/hicolor/scalable/apps/com.vocalinux.Vocalinux-microphone.svg
+      - install -Dm644 resources/icons/scalable/vocalinux-microphone-process.svg /app/share/icons/hicolor/scalable/apps/com.vocalinux.Vocalinux-microphone-process.svg
       - install -Dm644 packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml -t /app/share/metainfo/
     sources:
       - type: dir

--- a/packaging/flatpak/com.vocalinux.Vocalinux.yml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.yml
@@ -13,6 +13,7 @@ finish-args:
   - --share=network
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --device=dri
   - --talk-name=org.freedesktop.IBus
@@ -40,7 +41,6 @@ modules:
         sha256: 5af29ba58bbdbb7bbcefaaecc77ec8fc413f0db6f4c4e286c40c3e1b83174fa0
 
   - shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
-
   - name: xsel
     buildsystem: simple
     build-commands:

--- a/packaging/flatpak/com.vocalinux.Vocalinux.yml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.yml
@@ -1,23 +1,21 @@
 app-id: com.vocalinux.Vocalinux
 runtime: org.gnome.Platform
-runtime-version: "46"
+runtime-version: "50"
 sdk: org.gnome.Sdk
 command: vocalinux
 
 build-options:
-  build-args:
-    - --share=network
+  env:
+    NO_REPAIR: "1"
+    PYWHISPERCPP_VERSION: "1.4.1"
 
 finish-args:
   - --share=network
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --socket=pulseaudio
   - --device=dri
-  - --device=input
-  - --filesystem=xdg-config/vocalinux:create
-  - --filesystem=xdg-data/vocalinux:create
   - --talk-name=org.freedesktop.IBus
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
@@ -30,6 +28,7 @@ modules:
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_INSTALL_PREFIX=/app
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     cleanup:
       - /include
       - /lib/cmake
@@ -73,11 +72,13 @@ modules:
         url: https://github.com/jordansissel/xdotool/archive/refs/tags/v3.20211022.1.tar.gz
         sha256: 82b15a944a5e82fee15e0f6116bd9f642bc3d0bb6989fc0ca5ad9dfe35de0847
 
+  - python3-build-dependencies.yaml
+  - python3-dependencies.yaml
+
   - name: vocalinux
     buildsystem: simple
     build-commands:
-      - pip3 install --ignore-installed --prefix=/app setuptools wheel meson-python
-      - pip3 install --ignore-installed --no-build-isolation --prefix=/app .
+      - pip3 install --no-deps --no-build-isolation --prefix=/app .
       - install -Dm644 packaging/flatpak/com.vocalinux.Vocalinux.desktop -t /app/share/applications/
       - install -Dm644 resources/icons/scalable/vocalinux.svg /app/share/icons/hicolor/scalable/apps/com.vocalinux.Vocalinux.svg
       - install -Dm644 packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml -t /app/share/metainfo/

--- a/packaging/flatpak/python3-build-dependencies.yaml
+++ b/packaging/flatpak/python3-build-dependencies.yaml
@@ -1,0 +1,11 @@
+name: python3-build-dependencies
+buildsystem: simple
+build-commands:
+  - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} meson-python pyproject-metadata
+sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/16/7f/d1b0c65b267a1463d752b324f11d3470e30889daefc4b9ec83029bfa30b5/meson_python-0.19.0-py3-none-any.whl
+    sha256: 67b5906c37404396d23c195e12c8825506074460d4a2e7083266b845d14f0298
+  - type: file
+    url: https://files.pythonhosted.org/packages/1d/0b/da4851b1e2d9c40c9bd74c0abd94510a7d797da9ccde0a90e8953751ed4a/pyproject_metadata-0.11.0-py3-none-any.whl
+    sha256: 85bbecca8694e2c00f63b492c96921d6c228454057c88e7c352b2077fcaa4096

--- a/packaging/flatpak/python3-dependencies.yaml
+++ b/packaging/flatpak/python3-dependencies.yaml
@@ -1,0 +1,165 @@
+# Generated with flatpak-pip-generator --runtime org.gnome.Sdk//50 --yaml --ignore-pkg vosk>=0.3.45 PyGObject; sys_platform == 'linux' --output /tmp/vocalinux-flatpak-gen3/python3-dependencies pywhispercpp pydub pynput evdev requests tqdm numpy pyaudio python-xlib psutil lxml meson-python pyproject-metadata
+name: python3-dependencies
+buildsystem: simple
+build-commands: []
+modules:
+  - name: python3-pywhispercpp
+    buildsystem: simple
+    build-commands:
+      - tar -xzf pywhispercpp-1.4.1.tar.gz
+      - python3 -c "from pathlib import Path; p = Path('pywhispercpp-1.4.1/setup.py'); s = p.read_text(); p.write_text(s.replace('setup(\\n    name=\"pywhispercpp\",', 'setup(\\n    name=\"pywhispercpp\",\\n    version=\"1.4.1\",'))"
+      - tar -czf pywhispercpp-1.4.1.tar.gz pywhispercpp-1.4.1
+      - PYWHISPERCPP_VERSION=1.4.1 NO_REPAIR=1 pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "pywhispercpp" --no-build-isolation
+    sources:
+      - &id002
+        type: file
+        url: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
+        sha256: 3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a
+      - &id003
+        type: file
+        url: https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl
+        sha256: 3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d
+      - &id004
+        type: file
+        url: https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl
+        sha256: 892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3
+      - &id008
+        type: file
+        url: https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz
+        sha256: 2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0
+      - type: file
+        url: https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl
+        sha256: e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917
+      - type: file
+        url: https://files.pythonhosted.org/packages/f6/7d/fe4b2b190d6cdcf0d5e4ca2b946d73bc449a586606a24d25ff50ffec5a5c/pywhispercpp-1.4.1.tar.gz
+        sha256: 520ce9275bb6fc81e0daa2e08144a80ee006b117a18058a77860c5b1c9c122f4
+      - &id005
+        type: file
+        url: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
+        sha256: 4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a
+      - &id007
+        type: file
+        url: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
+        sha256: ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf
+      - &id006
+        type: file
+        url: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
+        sha256: bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
+  - name: python3-pydub
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "pydub" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/a6/53/d78dc063216e62fc55f6b2eebb447f6a4b0a59f55c8406376f76bf959b08/pydub-0.25.1-py2.py3-none-any.whl
+        sha256: 65617e33033874b59d87db603aa1ed450633288aefead953b30bded59cb599a6
+  - name: python3-pynput
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "pynput" --no-build-isolation
+    sources:
+      - &id001
+        type: file
+        url: https://files.pythonhosted.org/packages/a5/f5/397b61091120a9ca5001041dd7bf76c385b3bfd67a0e5bcb74b852bd22a4/evdev-1.9.3.tar.gz
+        sha256: 2c140e01ac8437758fa23fe5c871397412461f42d421aa20241dc8fe8cfccbc9
+      - type: file
+        url: https://files.pythonhosted.org/packages/59/4f/ac3fa906ae8a375a536b12794128c5efacade9eaa917a35dfd27ce0c7400/pynput-1.8.1-py2.py3-none-any.whl
+        sha256: 42dfcf27404459ca16ca889c8fb8ffe42a9fe54f722fd1a3e130728e59e768d2
+      - &id009
+        type: file
+        url: https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl
+        sha256: c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398
+      - &id010
+        type: file
+        url: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+        sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
+  - name: python3-evdev
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "evdev" --no-build-isolation
+    sources:
+      - *id001
+  - name: python3-requests
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "requests" --no-build-isolation
+    sources:
+      - *id002
+      - *id003
+      - *id004
+      - *id005
+      - *id006
+  - name: python3-tqdm
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "tqdm" --no-build-isolation
+    sources:
+      - *id007
+  - name: python3-numpy
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "numpy" --no-build-isolation
+    sources:
+      - *id008
+  - name: python3-pyaudio
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "pyaudio" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/26/1d/8878c7752febb0f6716a7e1a52cb92ac98871c5aa522cba181878091607c/PyAudio-0.2.14.tar.gz
+        sha256: 78dfff3879b4994d1f4fc6485646a57755c6ee3c19647a491f790a0895bd2f87
+  - name: python3-python-xlib
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "python-xlib" --no-build-isolation
+    sources:
+      - *id009
+      - *id010
+  - name: python3-psutil
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "psutil" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz
+        sha256: 0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372
+  - name: python3-lxml
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "lxml" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz
+        sha256: bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13
+  - name: python3-meson-python
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "meson-python" --no-build-isolation
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/16/7f/d1b0c65b267a1463d752b324f11d3470e30889daefc4b9ec83029bfa30b5/meson_python-0.19.0-py3-none-any.whl
+        sha256: 67b5906c37404396d23c195e12c8825506074460d4a2e7083266b845d14f0298
+      - &id011
+        type: file
+        url: https://files.pythonhosted.org/packages/1d/0b/da4851b1e2d9c40c9bd74c0abd94510a7d797da9ccde0a90e8953751ed4a/pyproject_metadata-0.11.0-py3-none-any.whl
+        sha256: 85bbecca8694e2c00f63b492c96921d6c228454057c88e7c352b2077fcaa4096
+  - name: python3-pyproject-metadata
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "pyproject-metadata" --no-build-isolation
+    sources:
+      - *id011

--- a/packaging/flatpak/python3-dependencies.yaml
+++ b/packaging/flatpak/python3-dependencies.yaml
@@ -9,10 +9,10 @@ modules:
       - tar -xzf pywhispercpp-1.4.1.tar.gz
       - python3 -c "from pathlib import Path; p = Path('pywhispercpp-1.4.1/setup.py'); s = p.read_text(); p.write_text(s.replace('setup(\\n    name=\"pywhispercpp\",', 'setup(\\n    name=\"pywhispercpp\",\\n    version=\"1.4.1\",'))"
       - tar -czf pywhispercpp-1.4.1.tar.gz pywhispercpp-1.4.1
-      - PYWHISPERCPP_VERSION=1.4.1 NO_REPAIR=1 pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+      - PYWHISPERCPP_VERSION=1.4.1 NO_REPAIR=1 GGML_VULKAN=1 pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
         --prefix=${FLATPAK_DEST} "pywhispercpp" --no-build-isolation
-      - for lib in libggml.so libggml-base.so libggml-cpu.so libwhisper.so libwhisper.so.1
-        libwhisper.so.1.8.2; do ln -sf "python3.13/site-packages/${lib}" "${FLATPAK_DEST}/lib/${lib}";
+      - for lib in libggml.so libggml-base.so libggml-cpu.so libggml-vulkan.so libwhisper.so
+        libwhisper.so.1 libwhisper.so.1.8.2; do test ! -e "python3.13/site-packages/${lib}" || ln -sf "python3.13/site-packages/${lib}" "${FLATPAK_DEST}/lib/${lib}";
         done
     sources:
       - &id002

--- a/packaging/flatpak/python3-dependencies.yaml
+++ b/packaging/flatpak/python3-dependencies.yaml
@@ -11,6 +11,9 @@ modules:
       - tar -czf pywhispercpp-1.4.1.tar.gz pywhispercpp-1.4.1
       - PYWHISPERCPP_VERSION=1.4.1 NO_REPAIR=1 pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
         --prefix=${FLATPAK_DEST} "pywhispercpp" --no-build-isolation
+      - for lib in libggml.so libggml-base.so libggml-cpu.so libwhisper.so libwhisper.so.1
+        libwhisper.so.1.8.2; do ln -sf "python3.13/site-packages/${lib}" "${FLATPAK_DEST}/lib/${lib}";
+        done
     sources:
       - &id002
         type: file

--- a/packaging/flatpak/shared-modules/intltool/intltool-0.51.json
+++ b/packaging/flatpak/shared-modules/intltool/intltool-0.51.json
@@ -1,0 +1,20 @@
+{
+  "name": "intltool",
+  "cleanup": [ "*" ],
+  "sources": [
+    {
+      "type": "archive",
+      "url": "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz",
+      "mirror-urls": [
+        "https://sources.suse.com/SUSE:SLE-15-SP7:Update:BCI/000product/ca527df4d03bf96a67854a8ed2f0c64b/INCLUDED/SUSE:SLE-15-SP6:GA::intltool::45f77273c3f2ef792fa697b444183beb/intltool-0.51.0.tar.gz",
+        "https://mirror-hk.koddos.net/lfs/lfs-packages/12.0/intltool-0.51.0.tar.gz",
+        "https://gstreamer.freedesktop.org/src/mirror/intltool-0.51.0.tar.gz"
+      ],
+      "sha256": "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
+    },
+    {
+      "type": "patch",
+      "path": "intltool-perl5.26-regex-fixes.patch"
+    }
+  ]
+}

--- a/packaging/flatpak/shared-modules/intltool/intltool-perl5.26-regex-fixes.patch
+++ b/packaging/flatpak/shared-modules/intltool/intltool-perl5.26-regex-fixes.patch
@@ -1,0 +1,59 @@
+Description: Escape "{", to prevent complaints from perl 5.22 and 5.26
+Author: Roderich Schupp <roderich.schupp@gmail.com>
+Author: gregor herrmann <gregoa@debian.org>
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=788705
+Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=826471
+Bug-Upstream: https://bugs.launchpad.net/intltool/+bug/1490906
+
+Index: intltool-0.51.0/intltool-update.in
+===================================================================
+--- intltool-0.51.0.orig/intltool-update.in	2017-07-23 17:24:35.113169465 +0200
++++ intltool-0.51.0/intltool-update.in	2017-07-23 17:24:35.109169052 +0200
+@@ -1062,13 +1062,13 @@
+ 	}
+     }
+
+-    if ($str =~ /^(.*)\${?([A-Z_]+)}?(.*)$/)
++    if ($str =~ /^(.*)\$\{?([A-Z_]+)}?(.*)$/)
+     {
+ 	my $rest = $3;
+ 	my $untouched = $1;
+ 	my $sub = "";
+         # Ignore recursive definitions of variables
+-        $sub = $varhash{$2} if defined $varhash{$2} and $varhash{$2} !~ /\${?$2}?/;
++        $sub = $varhash{$2} if defined $varhash{$2} and $varhash{$2} !~ /\$\{?$2}?/;
+
+ 	return SubstituteVariable ("$untouched$sub$rest");
+     }
+@@ -1190,10 +1190,10 @@
+ 	$name    =~ s/\(+$//g;
+ 	$version =~ s/\(+$//g;
+
+-	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\${?AC_PACKAGE_NAME}?/);
+-	$varhash{"PACKAGE"} = $name if (not $name =~ /\${?PACKAGE}?/);
+-	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\${?AC_PACKAGE_VERSION}?/);
+-	$varhash{"VERSION"} = $version if (not $name =~ /\${?VERSION}?/);
++	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\$\{?AC_PACKAGE_NAME}?/);
++	$varhash{"PACKAGE"} = $name if (not $name =~ /\$\{?PACKAGE}?/);
++	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\$\{?AC_PACKAGE_VERSION}?/);
++	$varhash{"VERSION"} = $version if (not $name =~ /\$\{?VERSION}?/);
+     }
+
+     if ($conf_source =~ /^AC_INIT\(([^,\)]+),([^,\)]+)[,]?([^,\)]+)?/m)
+@@ -1219,11 +1219,11 @@
+ 	$version =~ s/\(+$//g;
+         $bugurl  =~ s/\(+$//g if (defined $bugurl);
+
+-	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\${?AC_PACKAGE_NAME}?/);
+-	$varhash{"PACKAGE"} = $name if (not $name =~ /\${?PACKAGE}?/);
+-	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\${?AC_PACKAGE_VERSION}?/);
+-	$varhash{"VERSION"} = $version if (not $name =~ /\${?VERSION}?/);
+-        $varhash{"PACKAGE_BUGREPORT"} = $bugurl if (defined $bugurl and not $bugurl =~ /\${?\w+}?/);
++	$varhash{"PACKAGE_NAME"} = $name if (not $name =~ /\$\{?AC_PACKAGE_NAME}?/);
++	$varhash{"PACKAGE"} = $name if (not $name =~ /\$\{?PACKAGE}?/);
++	$varhash{"PACKAGE_VERSION"} = $version if (not $name =~ /\$\{?AC_PACKAGE_VERSION}?/);
++	$varhash{"VERSION"} = $version if (not $name =~ /\$\{?VERSION}?/);
++        $varhash{"PACKAGE_BUGREPORT"} = $bugurl if (defined $bugurl and not $bugurl =~ /\$\{?\w+}?/);
+     }
+
+     # \s makes this not work, why?

--- a/packaging/flatpak/shared-modules/libayatana-appindicator/0001-Fix-HAVE_VALGRIND-AM_CONDITIONAL.patch
+++ b/packaging/flatpak/shared-modules/libayatana-appindicator/0001-Fix-HAVE_VALGRIND-AM_CONDITIONAL.patch
@@ -1,0 +1,50 @@
+From 729546c51806a1b3ea6cb6efb7a115b1baa811f1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Stefan=20Br=C3=BCns?= <stefan.bruens@rwth-aachen.de>
+Date: Mon, 18 Nov 2019 19:58:53 +0100
+Subject: [PATCH 1/1] Fix HAVE_VALGRIND AM_CONDITIONAL
+
+The AM_CONDITIONAL should also be run with --disable-tests, otherwise
+HAVE_VALGRIND is undefined.
+---
+ configure    | 4 ++--
+ configure.ac | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/configure b/configure
+index 831a3bb..8913b9b 100644
+--- a/configure
++++ b/configure
+@@ -14801,6 +14801,8 @@ else
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ $as_echo "yes" >&6; }
+ 	have_valgrind=yes
++fi
++
+ fi
+  if test "x$have_valgrind" = "xyes"; then
+   HAVE_VALGRIND_TRUE=
+@@ -14811,8 +14813,6 @@ else
+ fi
+
+
+-fi
+-
+
+
+
+diff --git a/configure.ac b/configure.ac
+index ace54d1..cbd38a6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -120,8 +120,8 @@ PKG_CHECK_MODULES(DBUSMENUTESTS,  json-glib-1.0 >= $JSON_GLIB_REQUIRED_VERSION
+                                   [have_tests=yes]
+ )
+ PKG_CHECK_MODULES(DBUSMENUTESTSVALGRIND, valgrind, have_valgrind=yes, have_valgrind=no)
+-AM_CONDITIONAL([HAVE_VALGRIND], [test "x$have_valgrind" = "xyes"])
+ ])
++AM_CONDITIONAL([HAVE_VALGRIND], [test "x$have_valgrind" = "xyes"])
+
+ AC_SUBST(DBUSMENUTESTS_CFLAGS)
+ AC_SUBST(DBUSMENUTESTS_LIBS)
+--
+2.46.2

--- a/packaging/flatpak/shared-modules/libayatana-appindicator/0001-Make-introspection-configurable.patch
+++ b/packaging/flatpak/shared-modules/libayatana-appindicator/0001-Make-introspection-configurable.patch
@@ -1,0 +1,43 @@
+From 8a09e6ad33c58c017c0c8fd756da036fc39428ea Mon Sep 17 00:00:00 2001
+From: Alexander Koskovich <akoskovich@pm.me>
+Date: Sun, 29 Sep 2024 13:47:54 -0400
+Subject: [PATCH 1/1] Make introspection configurable
+
+---
+ CMakeLists.txt     | 1 +
+ src/CMakeLists.txt | 4 ++++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0e13fcd..f3e9ec0 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -12,6 +12,7 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+ option(ENABLE_TESTS "Enable all tests and checks" OFF)
+ option(ENABLE_COVERAGE "Enable coverage reports (includes enabling all tests and checks)" OFF)
+ option(ENABLE_WERROR "Treat all build warnings as errors" OFF)
++option(ENABLE_INTROSPECTION "Enable introspection" ON)
+
+ if(ENABLE_COVERAGE)
+     set(ENABLE_TESTS ON)
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 5b3638d..aca9481 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -108,6 +108,8 @@ install(TARGETS "ayatana-ido3-0.4" LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIB
+
+ # AyatanaIdo3-0.4.gir
+
++if (ENABLE_INTROSPECTION)
++
+ find_package(GObjectIntrospection REQUIRED QUIET)
+
+ if (INTROSPECTION_FOUND)
+@@ -183,3 +185,5 @@ if (INTROSPECTION_FOUND)
+     endif ()
+
+ endif ()
++
++endif ()
+--
+2.46.2

--- a/packaging/flatpak/shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
+++ b/packaging/flatpak/shared-modules/libayatana-appindicator/libayatana-appindicator-gtk3.json
@@ -1,0 +1,121 @@
+{
+    "name": "libayatana-appindicator",
+    "buildsystem": "cmake-ninja",
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig"
+    ],
+    "config-opts": [
+        "-DENABLE_BINDINGS_MONO=NO",
+        "-DENABLE_BINDINGS_VALA=NO",
+        "-DENABLE_GTKDOC=NO"
+    ],
+    "modules": [
+        "../intltool/intltool-0.51.json",
+        {
+            "name": "libdbusmenu",
+            "buildsystem": "autotools",
+            "build-options": {
+                "cflags": "-Wno-error"
+            },
+            "cleanup": [
+                "*.la",
+                "/include",
+                "/lib/pkgconfig",
+                "/libexec",
+                "/share/doc",
+                "/share/gtk-doc"
+            ],
+            "config-opts": [
+                "--with-gtk=3",
+                "--disable-dumper",
+                "--disable-static",
+                "--disable-tests",
+                "--disable-gtk-doc",
+                "--enable-introspection=no",
+                "--disable-vala"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://launchpad.net/libdbusmenu/16.04/16.04.0/+download/libdbusmenu-16.04.0.tar.gz",
+                    "mirror-urls": [
+                        "https://sources.suse.com/SUSE:SLFO:Main:Build/libdbusmenu/a5b3e4717f09f90f9cd5568a5f933e8d/libdbusmenu-16.04.0.tar.gz",
+                        "https://mirror.math.princeton.edu/pub/frugalware/frugalware-2.1/source/xlib/libdbusmenu/libdbusmenu-16.04.0.tar.gz",
+                        "https://ftp.fr.openbsd.org/pub/OpenBSD/distfiles/libdbusmenu-16.04.0.tar.gz"
+                     ],
+                    "sha256": "b9cc4a2acd74509435892823607d966d424bd9ad5d0b00938f27240a1bfa878a"
+                },
+                {
+                    "type": "patch",
+                    "paths": [
+                        "0001-Fix-HAVE_VALGRIND-AM_CONDITIONAL.patch"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "ayatana-ido",
+            "buildsystem": "cmake-ninja",
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig"
+            ],
+            "config-opts": [
+                "-DENABLE_INTROSPECTION=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/AyatanaIndicators/ayatana-ido.git",
+                    "tag": "0.10.4",
+                    "commit": "f968079b09e2310fefc3fc307359025f1c74b3eb",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
+                },
+                {
+                    "type": "patch",
+                    "paths": [
+                        "0001-Make-introspection-configurable.patch"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "libayatana-indicator",
+            "buildsystem": "cmake-ninja",
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig",
+                "/libexec",
+                "/share"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/AyatanaIndicators/libayatana-indicator.git",
+                    "tag": "0.9.4",
+                    "commit": "611bb384b73fa6311777ba4c41381a06f5b99dad",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^([\\d.]+)$"
+                    }
+                }
+            ]
+        }
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/AyatanaIndicators/libayatana-appindicator.git",
+            "tag": "0.5.94",
+            "commit": "31e8bb083b307e1cc96af4874a94707727bd1e79",
+            "x-checker-data": {
+                "type": "git",
+                "tag-pattern": "^([\\d.]+)$"
+            }
+        }
+    ]
+}

--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -99,8 +99,9 @@ def check_dependencies():
             gi.require_version("AyatanaAppIndicator3", "0.1")
             from gi.repository import AyatanaAppIndicator3  # noqa: F401
         except (ImportError, ValueError):
-            missing_system_deps.append(
-                "AppIndicator3/AyatanaAppIndicator3 - Required for system tray icon"
+            logger.warning(
+                "AppIndicator3/AyatanaAppIndicator3 not available - "
+                "system tray icon will be disabled"
             )
 
     # pynput is used for keyboard detection but we check at module startup
@@ -108,8 +109,11 @@ def check_dependencies():
     # These are intentional checks to provide user-friendly error messages
     try:
         import pynput  # noqa: F401
-    except ImportError:
-        missing_python_deps.append("pynput (install with: pip install pynput)")
+    except ImportError as e:
+        if "not supported" in str(e) or "display" in str(e).lower():
+            logger.warning(f"pynput unavailable in headless environment: {e}")
+        else:
+            missing_python_deps.append("pynput (install with: pip install pynput)")
 
     try:
         import requests  # noqa: F401

--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -86,7 +86,10 @@ def check_dependencies():
             "GTK3 (install with: sudo apt install python3-gi gir1.2-gtk-3.0)"
         )
 
-    # Check for AppIndicator3 / Ayatana AppIndicator
+    # Check for AppIndicator3 / Ayatana AppIndicator.  The tray is a core part of the
+    # application UX, so startup should fail when neither typelib is available.  A
+    # missing StatusNotifierWatcher is handled separately because the app can still
+    # run while the desktop integration is being fixed.
     try:
         import gi
 
@@ -99,9 +102,9 @@ def check_dependencies():
             gi.require_version("AyatanaAppIndicator3", "0.1")
             from gi.repository import AyatanaAppIndicator3  # noqa: F401
         except (ImportError, ValueError):
-            logger.warning(
-                "AppIndicator3/AyatanaAppIndicator3 not available - "
-                "system tray icon will be disabled"
+            missing_system_deps.append(
+                "AppIndicator3/AyatanaAppIndicator3 "
+                "(install with: sudo apt install gir1.2-ayatanaappindicator3-0.1)"
             )
 
     # pynput is used for keyboard detection but we check at module startup

--- a/src/vocalinux/single_instance.py
+++ b/src/vocalinux/single_instance.py
@@ -14,8 +14,10 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-# Lock file location: ~/.local/share/vocalinux/
-LOCK_FILE_DIR = Path.home() / ".local" / "share" / "vocalinux"
+# Lock file location: $XDG_DATA_HOME/vocalinux/
+LOCK_FILE_DIR = (
+    Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share")) / "vocalinux"
+)
 LOCK_FILE_PATH = LOCK_FILE_DIR / "instance.lock"
 
 # Global lock file handle

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -1726,6 +1726,33 @@ class SpeechRecognitionManager:
                 except (IOError, OSError):
                     continue
 
+            # Validate that the saved device index still points to an input-capable
+            # device. USB devices may be replugged, causing index shifts — a previously
+            # valid index may now point to HDMI output or another output-only device.
+            if self.audio_device_index is not None:
+                try:
+                    device_info = audio.get_device_info_by_index(self.audio_device_index)
+                    name = device_info.get("name", "Unknown")
+                    max_input = device_info.get("maxInputChannels", 0)
+                    if max_input == 0:
+                        logger.warning(
+                            f"Audio device [{self.audio_device_index}] '{name}' "
+                            f"has no input channels (maxInputChannels={max_input}). "
+                            "Saved config may be stale. Falling back to system default."
+                        )
+                        self.audio_device_index = None
+                    else:
+                        logger.debug(
+                            f"Audio device [{self.audio_device_index}] '{name}' "
+                            f"validated: {max_input} input channel(s)"
+                        )
+                except (IOError, OSError) as e:
+                    logger.warning(
+                        f"Audio device [{self.audio_device_index}] no longer available "
+                        f"({e}). Falling back to system default."
+                    )
+                    self.audio_device_index = None
+
             # Detect supported channel count first (some devices require stereo)
             CHANNELS = _get_supported_channels(audio, self.audio_device_index)
             logger.info(f"Using {CHANNELS} channel(s) for recording")

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -438,7 +438,11 @@ def _show_notification(title: str, message: str, icon: str = "dialog-warning"):
 
 
 # Define constants
-MODELS_DIR = os.path.expanduser("~/.local/share/vocalinux/models")
+MODELS_DIR = os.path.join(
+    os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share")),
+    "vocalinux",
+    "models",
+)
 
 
 def _get_system_model_paths() -> list:

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -847,7 +847,7 @@ class SpeechRecognitionManager:
             self.state = RecognitionState.ERROR
             raise
 
-    def _build_whispercpp_model_kwargs(self, n_threads: int) -> dict:
+    def _build_whispercpp_model_kwargs(self, n_threads: int, backend: Optional[str] = None) -> dict:
         model_kwargs = {
             "n_threads": n_threads,
             "suppress_blank": True,
@@ -857,6 +857,8 @@ class SpeechRecognitionManager:
             "temperature": self.whispercpp_temperature,
             "temperature_inc": self.whispercpp_temperature_inc,
         }
+        if backend:
+            self._add_whispercpp_gpu_kwargs(model_kwargs, backend)
         if self.whispercpp_no_timestamps:
             model_kwargs["no_timestamps"] = True
         if self.whispercpp_no_context:
@@ -864,6 +866,30 @@ class SpeechRecognitionManager:
         if self.whispercpp_initial_prompt:
             model_kwargs["initial_prompt"] = self.whispercpp_initial_prompt
         return model_kwargs
+
+    def _add_whispercpp_gpu_kwargs(self, model_kwargs: dict, backend: str) -> None:
+        """Add supported pywhispercpp GPU arguments for the detected backend."""
+        from ..utils.whispercpp_model_info import ComputeBackend
+
+        if backend == ComputeBackend.CPU:
+            model_kwargs["use_gpu"] = False
+            return
+
+        # pywhispercpp mirrors whisper.cpp/llama.cpp bindings across releases, and
+        # parameter names vary.  Add the common GPU switches here; unsupported keys
+        # are removed by _filter_whispercpp_model_kwargs before construction.
+        model_kwargs.update(
+            {
+                "use_gpu": True,
+                "gpu_device": 0,
+                "n_gpu_layers": 999,
+            }
+        )
+
+        if backend == ComputeBackend.VULKAN:
+            os.environ.setdefault("GGML_VULKAN", "1")
+        elif backend == ComputeBackend.CUDA:
+            os.environ.setdefault("GGML_CUDA", "1")
 
     def _get_supported_whispercpp_params(self) -> Optional[set[str]]:
         """Return params supported by the active pywhispercpp native binding."""
@@ -901,6 +927,9 @@ class SpeechRecognitionManager:
                 "temperature_inc",
                 "no_context",
                 "initial_prompt",
+                "use_gpu",
+                "gpu_device",
+                "n_gpu_layers",
             }
 
         compatible_kwargs = {}
@@ -966,7 +995,7 @@ class SpeechRecognitionManager:
         load_start_time = time.time()
         loaded_backend = backend
 
-        model_kwargs = self._build_whispercpp_model_kwargs(n_threads)
+        model_kwargs = self._build_whispercpp_model_kwargs(n_threads, backend)
 
         # Attempt to load model; filter unsupported params and fall back to CPU if needed
         try:
@@ -1016,10 +1045,15 @@ class SpeechRecognitionManager:
             "Your GPU doesn't support whisper.cpp Vulkan.\n" "Switched to CPU mode - still fast!",
             "dialog-information",
         )
-        # Force CPU backend by disabling GPU backends
+        # Force CPU backend by disabling GPU backends and removing GPU-specific
+        # constructor arguments from the retry.
         os.environ["GGML_VULKAN"] = "0"
         os.environ["GGML_CUDA"] = "0"
-        self.model = self._load_model_with_compatible_params(model_path, model_kwargs)
+        cpu_kwargs = dict(model_kwargs)
+        cpu_kwargs.pop("gpu_device", None)
+        cpu_kwargs.pop("n_gpu_layers", None)
+        cpu_kwargs["use_gpu"] = False
+        self.model = self._load_model_with_compatible_params(model_path, cpu_kwargs)
         logger.info("Successfully loaded model with CPU backend")
         return cpu_backend
 

--- a/src/vocalinux/text_injection/ibus_engine.py
+++ b/src/vocalinux/text_injection/ibus_engine.py
@@ -58,7 +58,9 @@ except (ImportError, ValueError) as e:
 
 
 # File paths for communication
-VOCALINUX_IBUS_DIR = Path.home() / ".local" / "share" / "vocalinux-ibus"
+VOCALINUX_IBUS_DIR = (
+    Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share")) / "vocalinux-ibus"
+)
 SOCKET_PATH = VOCALINUX_IBUS_DIR / "inject.sock"
 PID_FILE = VOCALINUX_IBUS_DIR / "engine.pid"
 

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -619,6 +619,16 @@ class TextInjector:
                         raise
             logger.info("Text injection completed successfully")
 
+            # When using xdotool fallback on Wayland, xdotool may exit 0 but
+            # type into the XWayland layer instead of the native Wayland window.
+            # Always copy to clipboard so the user can paste manually as a fallback.
+            if self.environment == DesktopEnvironment.WAYLAND_XDOTOOL:
+                try:
+                    if self._copy_to_clipboard(text):
+                        self._show_clipboard_fallback_notification()
+                except Exception as clipboard_error:
+                    logger.debug(f"Wayland clipboard fallback failed: {clipboard_error}")
+
             if self._should_copy_to_clipboard():
                 threading.Thread(
                     target=self._copy_to_clipboard,

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -506,7 +506,11 @@ class TextInjector:
         try:
             import json
 
-            config_path = os.path.expanduser("~/.config/vocalinux/config.json")
+            config_path = os.path.join(
+                os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")),
+                "vocalinux",
+                "config.json",
+            )
             if os.path.exists(config_path):
                 with open(config_path, "r") as f:
                     config = json.load(f)

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -131,8 +131,10 @@ class TextInjector:
         x11_display = os.environ.get("DISPLAY")
         if session_type == "wayland":
             if os.environ.get("FLATPAK_ID") and not wayland_display and x11_display:
-                logger.info("Flatpak is running with X11 access only; using X11 text injection")
-                return DesktopEnvironment.X11
+                logger.info(
+                    "Flatpak is running with X11 access only; using XWayland text injection"
+                )
+                return DesktopEnvironment.WAYLAND_XDOTOOL
             return DesktopEnvironment.WAYLAND
         elif session_type == "x11":
             return DesktopEnvironment.X11

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -58,7 +58,7 @@ class TextInjector:
         self._ibus_init_thread: Optional[threading.Thread] = None
         self._state_lock = threading.Lock()
         self._clipboard_tool_health = {}
-        self._clipboard_timeout = 0.35
+        self._clipboard_timeout = 2.0
 
         # Force Wayland mode if requested
         if wayland_mode and self.environment == DesktopEnvironment.X11:
@@ -127,15 +127,20 @@ class TextInjector:
             The detected desktop environment
         """
         session_type = os.environ.get("XDG_SESSION_TYPE", "").lower()
+        wayland_display = os.environ.get("WAYLAND_DISPLAY")
+        x11_display = os.environ.get("DISPLAY")
         if session_type == "wayland":
+            if os.environ.get("FLATPAK_ID") and not wayland_display and x11_display:
+                logger.info("Flatpak is running with X11 access only; using X11 text injection")
+                return DesktopEnvironment.X11
             return DesktopEnvironment.WAYLAND
         elif session_type == "x11":
             return DesktopEnvironment.X11
         else:
             # Try to detect based on other methods
-            if "WAYLAND_DISPLAY" in os.environ:
+            if wayland_display:
                 return DesktopEnvironment.WAYLAND
-            elif "DISPLAY" in os.environ:
+            elif x11_display:
                 return DesktopEnvironment.X11
             else:
                 logger.warning("Could not detect desktop environment, defaulting to X11")
@@ -294,9 +299,11 @@ class TextInjector:
     def _run_clipboard_command(self, tool: str, text: str) -> bool:
         if tool == "wl-copy":
             subprocess.run(
-                ["wl-copy", text],
+                ["wl-copy"],
+                input=text,
                 check=True,
-                stderr=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
                 text=True,
                 timeout=self._clipboard_timeout,
             )
@@ -307,7 +314,8 @@ class TextInjector:
                 ["xclip", "-selection", "clipboard"],
                 input=text,
                 check=True,
-                stderr=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
                 text=True,
                 timeout=self._clipboard_timeout,
             )
@@ -318,7 +326,8 @@ class TextInjector:
                 ["xsel", "--clipboard", "--input"],
                 input=text,
                 check=True,
-                stderr=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
                 text=True,
                 timeout=self._clipboard_timeout,
             )
@@ -496,8 +505,8 @@ class TextInjector:
                 logger.warning(f"{tool} failed: {e}")
 
         logger.warning(
-            "Clipboard copy failed. Install wl-copy (Wayland) or xclip/xsel "
-            "to enable clipboard functionality."
+            "Clipboard copy failed. Make sure wl-copy (Wayland) or xclip/xsel "
+            "is installed and can access the session clipboard."
         )
         return False
 

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -13,7 +13,10 @@ from typing import Any, Optional
 logger = logging.getLogger(__name__)
 
 # Define constants
-CONFIG_DIR = os.path.expanduser("~/.config/vocalinux")
+CONFIG_DIR = os.path.join(
+    os.environ.get("XDG_CONFIG_HOME", os.path.expanduser("~/.config")),
+    "vocalinux",
+)
 CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
 
 # Default configuration

--- a/src/vocalinux/ui/first_run_dialog.py
+++ b/src/vocalinux/ui/first_run_dialog.py
@@ -39,6 +39,7 @@ class FirstRunDialog(Gtk.Dialog):
             Gtk.ResponseType.DELETE_EVENT: None,
         }
         self.result = None
+        self.connect("response", self._on_response)
 
         box = self.get_content_area()
         box.set_spacing(16)
@@ -105,11 +106,9 @@ class FirstRunDialog(Gtk.Dialog):
 
         self.show_all()
 
-    def do_response(self, response_id):
-        """Handle dialog response - override default handler to set result."""
+    def _on_response(self, _dialog, response_id):
+        """Record the selected first-run preference."""
         self.result = self._response_map.get(response_id, None)
-        # Call parent to actually close the dialog
-        Gtk.Dialog.do_response(self, response_id)
 
 
 def show_first_run_dialog(parent: Optional[Gtk.Window] = None) -> Optional[str]:

--- a/src/vocalinux/ui/keyboard_backends/__init__.py
+++ b/src/vocalinux/ui/keyboard_backends/__init__.py
@@ -58,15 +58,20 @@ class DesktopEnvironment:
             'x11', 'wayland', or 'unknown'
         """
         session_type = os.environ.get("XDG_SESSION_TYPE", "").lower()
+        wayland_display = os.environ.get("WAYLAND_DISPLAY")
+        x11_display = os.environ.get("DISPLAY")
         if session_type == "wayland":
+            if os.environ.get("FLATPAK_ID") and not wayland_display and x11_display:
+                logger.info("Flatpak is running with X11 access only; using X11 keyboard backend")
+                return DesktopEnvironment.X11
             return DesktopEnvironment.WAYLAND
         elif session_type == "x11":
             return DesktopEnvironment.X11
 
         # Fallback to environment variables
-        if "WAYLAND_DISPLAY" in os.environ:
+        if wayland_display:
             return DesktopEnvironment.WAYLAND
-        elif "DISPLAY" in os.environ:
+        elif x11_display:
             return DesktopEnvironment.X11
 
         logger.warning("Could not detect desktop environment, defaulting to unknown")

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -120,7 +120,11 @@ def get_available_engines():
 
 
 # Models directory
-MODELS_DIR = os.path.expanduser("~/.local/share/vocalinux/models")
+MODELS_DIR = os.path.join(
+    os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share")),
+    "vocalinux",
+    "models",
+)
 SYSTEM_MODELS_DIRS = [
     "/usr/local/share/vocalinux/models",
     "/usr/share/vocalinux/models",
@@ -402,7 +406,7 @@ def _prevent_scroll_on_hover(widget: Gtk.Widget):
 
 def _get_whisper_cache_dir() -> str:
     """Get the Whisper model cache directory."""
-    return os.path.expanduser("~/.local/share/vocalinux/models/whisper")
+    return os.path.join(MODELS_DIR, "whisper")
 
 
 def _is_whisper_model_downloaded(model_name: str) -> bool:

--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -12,8 +12,11 @@ from typing import Callable, Optional
 
 import gi
 
+logger = logging.getLogger(__name__)
+
 # Import GTK
 gi.require_version("Gtk", "3.0")
+AppIndicator3 = None
 try:
     gi.require_version("AppIndicator3", "0.1")
     from gi.repository import AppIndicator3
@@ -22,8 +25,13 @@ except (ImportError, ValueError):
         gi.require_version("AyatanaAppIndicator3", "0.1")
         from gi.repository import AyatanaAppIndicator3 as AppIndicator3
     except (ImportError, ValueError):
-        gi.require_version("AyatanaAppindicator3", "0.1")
-        from gi.repository import AyatanaAppindicator3 as AppIndicator3
+        try:
+            gi.require_version("AyatanaAppindicator3", "0.1")
+            from gi.repository import AyatanaAppindicator3 as AppIndicator3
+        except (ImportError, ValueError):
+            logger.warning(
+                "No AppIndicator implementation available. " "Running without system tray icon."
+            )
 
 from gi.repository import GdkPixbuf, Gio, GLib, GObject, Gtk
 
@@ -34,8 +42,6 @@ from ..utils.resource_manager import ResourceManager
 from .config_manager import ConfigManager
 from .keyboard_shortcuts import KeyboardShortcutManager
 from .settings_dialog import SettingsDialog
-
-logger = logging.getLogger(__name__)
 
 # Define constants
 APP_ID = "vocalinux"

--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -270,10 +270,10 @@ class TrayIndicator:
             if names_variant is not None:
                 name_list = names_variant.unpack()[0]
                 return "org.kde.StatusNotifierWatcher" in name_list
-        except Exception:
-            pass
+        except Exception as e:
+            logger.warning(f"Could not check StatusNotifierWatcher: {e}")
 
-        return True
+        return False
 
     def _show_missing_watcher_dialog(self):
         dialog = Gtk.MessageDialog(
@@ -422,19 +422,19 @@ class TrayIndicator:
             return False
 
         if state == RecognitionState.IDLE:
-            self.indicator.set_icon_full(self.icon_names["default"], "Microphone off")
+            self.indicator.set_icon(self.icon_paths["default"])
             self._set_menu_item_enabled("Start Voice Typing", True)
             self._set_menu_item_enabled("Stop Voice Typing", False)
         elif state == RecognitionState.LISTENING:
-            self.indicator.set_icon_full(self.icon_names["active"], "Microphone on")
+            self.indicator.set_icon(self.icon_paths["active"])
             self._set_menu_item_enabled("Start Voice Typing", False)
             self._set_menu_item_enabled("Stop Voice Typing", True)
         elif state == RecognitionState.PROCESSING:
-            self.indicator.set_icon_full(self.icon_names["processing"], "Processing speech")
+            self.indicator.set_icon(self.icon_paths["processing"])
             self._set_menu_item_enabled("Start Voice Typing", False)
             self._set_menu_item_enabled("Stop Voice Typing", True)
         elif state == RecognitionState.ERROR:
-            self.indicator.set_icon_full(self.icon_names["default"], "Error")
+            self.indicator.set_icon(self.icon_paths["default"])
             self._set_menu_item_enabled("Start Voice Typing", True)
             self._set_menu_item_enabled("Stop Voice Typing", False)
 

--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -183,6 +183,10 @@ class TrayIndicator:
         """Initialize the system tray indicator."""
         logger.info("Initializing system tray indicator")
 
+        if AppIndicator3 is None:
+            logger.warning("AppIndicator is not available; continuing without a tray icon")
+            return False
+
         # Log the icon directory path
         logger.info(f"Using icon directory: {ICON_DIR}")
         logger.info(f"Icon directory exists: {os.path.exists(ICON_DIR)}")
@@ -272,6 +276,7 @@ class TrayIndicator:
                 return "org.kde.StatusNotifierWatcher" in name_list
         except Exception as e:
             logger.warning(f"Could not check StatusNotifierWatcher: {e}")
+            return True
 
         return False
 
@@ -422,23 +427,32 @@ class TrayIndicator:
             return False
 
         if state == RecognitionState.IDLE:
-            self.indicator.set_icon(self.icon_paths["default"])
+            self._set_indicator_icon("default", "Microphone off")
             self._set_menu_item_enabled("Start Voice Typing", True)
             self._set_menu_item_enabled("Stop Voice Typing", False)
         elif state == RecognitionState.LISTENING:
-            self.indicator.set_icon(self.icon_paths["active"])
+            self._set_indicator_icon("active", "Microphone on")
             self._set_menu_item_enabled("Start Voice Typing", False)
             self._set_menu_item_enabled("Stop Voice Typing", True)
         elif state == RecognitionState.PROCESSING:
-            self.indicator.set_icon(self.icon_paths["processing"])
+            self._set_indicator_icon("processing", "Processing speech")
             self._set_menu_item_enabled("Start Voice Typing", False)
             self._set_menu_item_enabled("Stop Voice Typing", True)
         elif state == RecognitionState.ERROR:
-            self.indicator.set_icon(self.icon_paths["default"])
+            self._set_indicator_icon("default", "Error")
             self._set_menu_item_enabled("Start Voice Typing", True)
             self._set_menu_item_enabled("Stop Voice Typing", False)
 
         return False  # Remove idle callback
+
+    def _set_indicator_icon(self, icon_key: str, description: str) -> None:
+        """Set the tray icon using the most reliable format for the runtime."""
+        if os.environ.get("FLATPAK_ID") and os.path.exists(self.icon_paths[icon_key]):
+            self.indicator.set_icon(self.icon_paths[icon_key])
+        elif hasattr(self.indicator, "set_icon_full"):
+            self.indicator.set_icon_full(self.icon_names[icon_key], description)
+        else:
+            self.indicator.set_icon(self.icon_names[icon_key])
 
     def _set_menu_item_enabled(self, label: str, enabled: bool):
         """

--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -56,6 +56,11 @@ ACTIVE_ICON = "vocalinux-microphone"
 PROCESSING_ICON = "vocalinux-microphone-process"
 FLATPAK_ICON_PREFIX = os.environ.get("FLATPAK_ID")
 FLATPAK_ICON_DIR = "/app/share/icons/hicolor/scalable/apps"
+FLATPAK_ICON_SUFFIXES = {
+    "default": "microphone-off",
+    "active": "microphone",
+    "processing": "microphone-process",
+}
 
 # /dev/input settle-detection tuning (used after resume)
 _INPUT_SETTLE_SECONDS = 2
@@ -104,17 +109,7 @@ class TrayIndicator:
             "active": _resource_manager.get_icon_path(ACTIVE_ICON),
             "processing": _resource_manager.get_icon_path(PROCESSING_ICON),
         }
-        self.icon_names = {
-            "default": DEFAULT_ICON,
-            "active": ACTIVE_ICON,
-            "processing": PROCESSING_ICON,
-        }
-        if FLATPAK_ICON_PREFIX:
-            self.icon_names = {
-                "default": f"{FLATPAK_ICON_PREFIX}-microphone-off",
-                "active": f"{FLATPAK_ICON_PREFIX}-microphone",
-                "processing": f"{FLATPAK_ICON_PREFIX}-microphone-process",
-            }
+        self.icon_names = self._build_icon_names()
 
         # Register for speech recognition state changes
         self.speech_engine.register_state_callback(self._on_recognition_state_changed)
@@ -133,6 +128,32 @@ class TrayIndicator:
 
         # Set up keyboard shortcuts with mode support
         self._setup_keyboard_shortcuts()
+
+    @staticmethod
+    def _build_icon_names() -> dict[str, str]:
+        """Return icon names visible to the current runtime."""
+        package_names = {
+            "default": DEFAULT_ICON,
+            "active": ACTIVE_ICON,
+            "processing": PROCESSING_ICON,
+        }
+        if not FLATPAK_ICON_PREFIX:
+            return package_names
+
+        icon_names = {}
+        for key, suffix in FLATPAK_ICON_SUFFIXES.items():
+            exported_name = f"{FLATPAK_ICON_PREFIX}-{suffix}"
+            exported_path = os.path.join(FLATPAK_ICON_DIR, f"{exported_name}.svg")
+            if os.path.exists(exported_path):
+                icon_names[key] = exported_name
+            else:
+                logger.warning(
+                    "Flatpak exported icon missing: %s; falling back to bundled icon name %s",
+                    exported_path,
+                    package_names[key],
+                )
+                icon_names[key] = package_names[key]
+        return icon_names
 
     def _setup_keyboard_shortcuts(self):
         """Set up keyboard shortcuts based on configured mode."""
@@ -225,6 +246,7 @@ class TrayIndicator:
                 icon_theme_path,
             )
             self.indicator.set_icon_theme_path(icon_theme_path)
+            self._set_indicator_icon("default", "Microphone off")
             self.indicator.set_status(AppIndicator3.IndicatorStatus.ACTIVE)
         except Exception as e:
             logger.error(f"Failed to create AppIndicator: {e}")

--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -44,7 +44,7 @@ from .keyboard_shortcuts import KeyboardShortcutManager
 from .settings_dialog import SettingsDialog
 
 # Define constants
-APP_ID = "vocalinux"
+APP_ID = os.environ.get("FLATPAK_ID", "vocalinux")
 
 # Initialize resource manager
 _resource_manager = ResourceManager()
@@ -54,6 +54,8 @@ ICON_DIR = _resource_manager.icons_dir
 DEFAULT_ICON = "vocalinux-microphone-off"
 ACTIVE_ICON = "vocalinux-microphone"
 PROCESSING_ICON = "vocalinux-microphone-process"
+FLATPAK_ICON_PREFIX = os.environ.get("FLATPAK_ID")
+FLATPAK_ICON_DIR = "/app/share/icons/hicolor/scalable/apps"
 
 # /dev/input settle-detection tuning (used after resume)
 _INPUT_SETTLE_SECONDS = 2
@@ -107,6 +109,12 @@ class TrayIndicator:
             "active": ACTIVE_ICON,
             "processing": PROCESSING_ICON,
         }
+        if FLATPAK_ICON_PREFIX:
+            self.icon_names = {
+                "default": f"{FLATPAK_ICON_PREFIX}-microphone-off",
+                "active": f"{FLATPAK_ICON_PREFIX}-microphone",
+                "processing": f"{FLATPAK_ICON_PREFIX}-microphone-process",
+            }
 
         # Register for speech recognition state changes
         self.speech_engine.register_state_callback(self._on_recognition_state_changed)
@@ -187,27 +195,36 @@ class TrayIndicator:
             logger.warning("AppIndicator is not available; continuing without a tray icon")
             return False
 
-        # Log the icon directory path
-        logger.info(f"Using icon directory: {ICON_DIR}")
-        logger.info(f"Icon directory exists: {os.path.exists(ICON_DIR)}")
+        icon_theme_path = FLATPAK_ICON_DIR if FLATPAK_ICON_PREFIX else ICON_DIR
 
-        # List available icon files and check if they exist
-        if os.path.exists(ICON_DIR):
-            icon_files = os.listdir(ICON_DIR)
+        # Log the icon directory path
+        logger.info(f"Using icon directory: {icon_theme_path}")
+        logger.info(f"Icon directory exists: {os.path.exists(icon_theme_path)}")
+
+        # List available themed icons and check if packaged resource icons exist.
+        if os.path.exists(icon_theme_path):
+            icon_files = os.listdir(icon_theme_path)
             logger.info(f"Available icon files: {icon_files}")
 
+        if os.path.exists(ICON_DIR):
             for name, path in self.icon_paths.items():
                 exists = os.path.exists(path)
                 logger.info(f"Icon '{name}' ({path}): {'exists' if exists else 'missing'}")
 
         try:
+            default_icon_name = getattr(self, "icon_names", {}).get("default")
+            if not default_icon_name:
+                default_icon_name = (
+                    f"{FLATPAK_ICON_PREFIX}-microphone-off" if FLATPAK_ICON_PREFIX else DEFAULT_ICON
+                )
+
             self.indicator = AppIndicator3.Indicator.new_with_path(
                 APP_ID,
-                DEFAULT_ICON,
+                default_icon_name,
                 AppIndicator3.IndicatorCategory.APPLICATION_STATUS,
-                ICON_DIR,
+                icon_theme_path,
             )
-            self.indicator.set_icon_theme_path(ICON_DIR)
+            self.indicator.set_icon_theme_path(icon_theme_path)
             self.indicator.set_status(AppIndicator3.IndicatorStatus.ACTIVE)
         except Exception as e:
             logger.error(f"Failed to create AppIndicator: {e}")
@@ -447,8 +464,10 @@ class TrayIndicator:
 
     def _set_indicator_icon(self, icon_key: str, description: str) -> None:
         """Set the tray icon using the most reliable format for the runtime."""
-        if os.environ.get("FLATPAK_ID") and os.path.exists(self.icon_paths[icon_key]):
-            self.indicator.set_icon(self.icon_paths[icon_key])
+        if FLATPAK_ICON_PREFIX and hasattr(self.indicator, "set_icon_full"):
+            self.indicator.set_icon_full(self.icon_names[icon_key], description)
+        elif FLATPAK_ICON_PREFIX:
+            self.indicator.set_icon(self.icon_names[icon_key])
         elif hasattr(self.indicator, "set_icon_full"):
             self.indicator.set_icon_full(self.icon_names[icon_key], description)
         else:

--- a/src/vocalinux/utils/whispercpp_model_info.py
+++ b/src/vocalinux/utils/whispercpp_model_info.py
@@ -69,14 +69,8 @@ def detect_vulkan_support() -> tuple[bool, Optional[str]]:
     Returns:
         Tuple of (is_available, device_name)
     """
-    """
-    Detect if Vulkan is available and get device info.
-
-    Returns:
-        Tuple of (is_available, device_name)
-    """
     try:
-        # Check for vulkaninfo command
+        # Prefer vulkaninfo when it is available because it can name the device.
         result = subprocess.run(
             ["vulkaninfo", "--summary"],
             capture_output=True,
@@ -84,7 +78,6 @@ def detect_vulkan_support() -> tuple[bool, Optional[str]]:
             timeout=5,
         )
         if result.returncode == 0:
-            # Try to extract GPU name from output
             for line in result.stdout.split("\n"):
                 if "deviceName" in line or "GPU" in line:
                     device_name = line.split(":")[-1].strip()
@@ -94,7 +87,21 @@ def detect_vulkan_support() -> tuple[bool, Optional[str]]:
             logger.info("Vulkan support detected")
             return True, "Vulkan GPU"
     except (subprocess.TimeoutExpired, FileNotFoundError, Exception) as e:
-        logger.debug(f"Vulkan detection failed: {e}")
+        logger.debug(f"vulkaninfo detection failed: {e}")
+
+    # Flatpak generally exposes render nodes through --device=dri, but may not
+    # include vulkaninfo. Treat render nodes as a GPU-capable hint so the
+    # Vulkan-enabled whisper.cpp build gets a chance to initialize, with safe
+    # fallback to CPU handled during model load.
+    render_dir = "/dev/dri"
+    try:
+        if os.path.isdir(render_dir) and any(
+            name.startswith("renderD") for name in os.listdir(render_dir)
+        ):
+            logger.info("Vulkan-capable DRI render node detected")
+            return True, "DRI render node"
+    except OSError as e:
+        logger.debug(f"DRI render node detection failed: {e}")
 
     return False, None
 

--- a/src/vocalinux/utils/whispercpp_model_info.py
+++ b/src/vocalinux/utils/whispercpp_model_info.py
@@ -249,7 +249,12 @@ def get_model_path(model_name: str) -> str:
     Returns:
         Path to the model file
     """
-    models_dir = os.path.expanduser("~/.local/share/vocalinux/models/whispercpp")
+    models_dir = os.path.join(
+        os.environ.get("XDG_DATA_HOME", os.path.expanduser("~/.local/share")),
+        "vocalinux",
+        "models",
+        "whispercpp",
+    )
     os.makedirs(models_dir, exist_ok=True)
 
     if model_name == "large":

--- a/tests/test_keyboard_init_ext.py
+++ b/tests/test_keyboard_init_ext.py
@@ -33,6 +33,17 @@ class TestDesktopEnvironmentDetect:
             result = DesktopEnvironment.detect()
             assert result == DesktopEnvironment.WAYLAND
 
+    def test_detect_flatpak_x11_only_wayland_session(self):
+        """Flatpak can run on XWayland while the host session is Wayland."""
+        env = {
+            "FLATPAK_ID": "com.vocalinux.Vocalinux",
+            "XDG_SESSION_TYPE": "wayland",
+            "DISPLAY": ":0",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            result = DesktopEnvironment.detect()
+            assert result == DesktopEnvironment.X11
+
     def test_detect_xdg_session_type_x11(self):
         """Test detection of X11 via XDG_SESSION_TYPE."""
         with patch.dict(os.environ, {"XDG_SESSION_TYPE": "x11"}, clear=False):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -530,6 +530,37 @@ class TestCheckDependencies(unittest.TestCase):
                 # Should return False because both indicators are missing
                 self.assertFalse(result)
 
+    def test_check_dependencies_ignores_headless_pynput_import_error(self):
+        """Headless pynput import errors should not fail dependency checks."""
+        import builtins
+
+        mock_gi = MagicMock()
+        mock_gtk = MagicMock()
+        mock_appindicator = MagicMock()
+        mock_requests = MagicMock()
+        real_import = builtins.__import__
+
+        def import_side_effect(name, *args, **kwargs):
+            if name == "pynput":
+                raise ImportError("display not supported")
+            return real_import(name, *args, **kwargs)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "gi": mock_gi,
+                "gi.repository": MagicMock(Gtk=mock_gtk, AppIndicator3=mock_appindicator),
+                "requests": mock_requests,
+            },
+            clear=False,
+        ):
+            with patch("builtins.__import__", side_effect=import_side_effect):
+                with patch("vocalinux.main.logger") as mock_logger:
+                    result = check_dependencies()
+
+        self.assertTrue(result)
+        mock_logger.warning.assert_called()
+
 
 class TestMainConfigPrecedence(unittest.TestCase):
     """Test cases for configuration precedence in main."""

--- a/tests/test_recognition_manager_advanced.py
+++ b/tests/test_recognition_manager_advanced.py
@@ -561,6 +561,40 @@ class TestWhispercppModelKwargs(unittest.TestCase):
         kwargs = mgr._build_whispercpp_model_kwargs(n_threads=4)
         self.assertEqual(kwargs.get("initial_prompt"), "test prompt")
 
+    def test_model_kwargs_enable_vulkan_gpu_backend(self):
+        from vocalinux.utils.whispercpp_model_info import ComputeBackend
+
+        mgr = _make_manager(engine="whisper_cpp")
+        with patch.dict(os.environ, {}, clear=True):
+            kwargs = mgr._build_whispercpp_model_kwargs(n_threads=4, backend=ComputeBackend.VULKAN)
+            self.assertEqual(os.environ["GGML_VULKAN"], "1")
+
+        self.assertTrue(kwargs["use_gpu"])
+        self.assertEqual(kwargs["gpu_device"], 0)
+        self.assertEqual(kwargs["n_gpu_layers"], 999)
+
+    def test_model_kwargs_enable_cuda_gpu_backend(self):
+        from vocalinux.utils.whispercpp_model_info import ComputeBackend
+
+        mgr = _make_manager(engine="whisper_cpp")
+        with patch.dict(os.environ, {}, clear=True):
+            kwargs = mgr._build_whispercpp_model_kwargs(n_threads=4, backend=ComputeBackend.CUDA)
+            self.assertEqual(os.environ["GGML_CUDA"], "1")
+
+        self.assertTrue(kwargs["use_gpu"])
+        self.assertEqual(kwargs["gpu_device"], 0)
+        self.assertEqual(kwargs["n_gpu_layers"], 999)
+
+    def test_model_kwargs_disable_gpu_for_cpu_backend(self):
+        from vocalinux.utils.whispercpp_model_info import ComputeBackend
+
+        mgr = _make_manager(engine="whisper_cpp")
+        kwargs = mgr._build_whispercpp_model_kwargs(n_threads=4, backend=ComputeBackend.CPU)
+
+        self.assertFalse(kwargs["use_gpu"])
+        self.assertNotIn("gpu_device", kwargs)
+        self.assertNotIn("n_gpu_layers", kwargs)
+
     def test_model_kwargs_custom_numerics(self):
         mgr = _make_manager(
             engine="whisper_cpp",

--- a/tests/test_recognition_manager_advanced.py
+++ b/tests/test_recognition_manager_advanced.py
@@ -496,6 +496,33 @@ class TestInitWhispercpp(unittest.TestCase):
             {"n_threads": 4},
         )
 
+    def test_cpu_fallback_removes_gpu_kwargs_and_disables_gpu(self):
+        mgr = _make_manager(engine="whisper_cpp")
+        with patch.object(mgr, "_load_model_with_compatible_params", return_value=MagicMock()) as mock_load:
+            loaded_backend = mgr._handle_gpu_fallback(
+                RuntimeError("unsupported device"),
+                "/tmp/model.bin",
+                {"n_threads": 4, "use_gpu": True, "gpu_device": 0, "n_gpu_layers": 999},
+                "cpu",
+            )
+
+        self.assertEqual(loaded_backend, "cpu")
+        mock_load.assert_called_once_with(
+            "/tmp/model.bin",
+            {"n_threads": 4, "use_gpu": False},
+        )
+
+    def test_cpu_fallback_reraises_unknown_runtime_error(self):
+        mgr = _make_manager(engine="whisper_cpp")
+
+        with self.assertRaisesRegex(RuntimeError, "unexpected load failure"):
+            mgr._handle_gpu_fallback(
+                RuntimeError("unexpected load failure"),
+                "/tmp/model.bin",
+                {"n_threads": 4},
+                "cpu",
+            )
+
 
 class TestDownloadVoskModel(unittest.TestCase):
     pass

--- a/tests/test_recognition_manager_advanced.py
+++ b/tests/test_recognition_manager_advanced.py
@@ -498,7 +498,9 @@ class TestInitWhispercpp(unittest.TestCase):
 
     def test_cpu_fallback_removes_gpu_kwargs_and_disables_gpu(self):
         mgr = _make_manager(engine="whisper_cpp")
-        with patch.object(mgr, "_load_model_with_compatible_params", return_value=MagicMock()) as mock_load:
+        with patch.object(
+            mgr, "_load_model_with_compatible_params", return_value=MagicMock()
+        ) as mock_load:
             loaded_backend = mgr._handle_gpu_fallback(
                 RuntimeError("unsupported device"),
                 "/tmp/model.bin",

--- a/tests/test_text_injector_ext.py
+++ b/tests/test_text_injector_ext.py
@@ -93,7 +93,7 @@ class TestDetectEnvironment(unittest.TestCase):
                         result = obj._detect_environment()
                         self.assertIn(result, [DesktopEnvironment.X11, DesktopEnvironment.X11_IBUS])
 
-    def test_flatpak_wayland_session_without_wayland_socket_uses_x11(self):
+    def test_flatpak_wayland_session_without_wayland_socket_uses_xwayland(self):
         from vocalinux.text_injection.text_injector import DesktopEnvironment
 
         obj = _make_injector(DesktopEnvironment.X11)
@@ -108,7 +108,7 @@ class TestDetectEnvironment(unittest.TestCase):
         ):
             result = obj._detect_environment()
 
-        self.assertEqual(result, DesktopEnvironment.X11)
+        self.assertEqual(result, DesktopEnvironment.WAYLAND_XDOTOOL)
 
     # IBus detection tests removed due to test-ordering mock pollution issues
 

--- a/tests/test_text_injector_ext.py
+++ b/tests/test_text_injector_ext.py
@@ -52,7 +52,7 @@ def _make_injector(env) -> Any:
     obj._ibus_init_thread = None
     obj._state_lock = threading.Lock()
     obj._clipboard_tool_health = {}
-    obj._clipboard_timeout = 0.35
+    obj._clipboard_timeout = 2.0
     return obj
 
 
@@ -92,6 +92,23 @@ class TestDetectEnvironment(unittest.TestCase):
                     ):
                         result = obj._detect_environment()
                         self.assertIn(result, [DesktopEnvironment.X11, DesktopEnvironment.X11_IBUS])
+
+    def test_flatpak_wayland_session_without_wayland_socket_uses_x11(self):
+        from vocalinux.text_injection.text_injector import DesktopEnvironment
+
+        obj = _make_injector(DesktopEnvironment.X11)
+        with patch.dict(
+            os.environ,
+            {
+                "FLATPAK_ID": "com.vocalinux.Vocalinux",
+                "XDG_SESSION_TYPE": "wayland",
+                "DISPLAY": ":0",
+            },
+            clear=True,
+        ):
+            result = obj._detect_environment()
+
+        self.assertEqual(result, DesktopEnvironment.X11)
 
     # IBus detection tests removed due to test-ordering mock pollution issues
 
@@ -278,6 +295,25 @@ class TestShortcutWithWaylandTool(unittest.TestCase):
 
 
 class TestCopyToClipboard(unittest.TestCase):
+    def test_wl_copy_uses_stdin_and_closed_pipes(self):
+        from vocalinux.text_injection.text_injector import DesktopEnvironment
+
+        obj = _make_injector(DesktopEnvironment.WAYLAND)
+        with (
+            patch(
+                "shutil.which",
+                side_effect=lambda name: "/usr/bin/wl-copy" if name == "wl-copy" else None,
+            ),
+            patch("subprocess.run") as mock_run,
+        ):
+            result = obj._copy_to_clipboard("hello")
+
+        self.assertTrue(result)
+        self.assertEqual(mock_run.call_args.args[0], ["wl-copy"])
+        self.assertEqual(mock_run.call_args.kwargs["input"], "hello")
+        self.assertEqual(mock_run.call_args.kwargs["stdout"], subprocess.DEVNULL)
+        self.assertEqual(mock_run.call_args.kwargs["stderr"], subprocess.DEVNULL)
+
     def test_copy_success(self):
         from vocalinux.text_injection.text_injector import DesktopEnvironment
 

--- a/tests/test_tray_indicator.py
+++ b/tests/test_tray_indicator.py
@@ -361,6 +361,26 @@ class TestTrayIndicator(unittest.TestCase):
         )
         self.assertEqual(result, False)
 
+    def test_flatpak_icons_use_exported_icon_names(self):
+        """Flatpak tray icons must use host-visible exported icon names."""
+        modules_to_remove = [k for k in list(sys.modules.keys()) if "tray_indicator" in k]
+        for mod in modules_to_remove:
+            del sys.modules[mod]
+
+        with patch.dict(os.environ, {"FLATPAK_ID": "com.vocalinux.Vocalinux"}):
+            from vocalinux.ui.tray_indicator import TrayIndicator
+
+            tray = TrayIndicator.__new__(TrayIndicator)
+            tray.indicator = MagicMock()
+            tray.icon_names = {
+                "active": "com.vocalinux.Vocalinux-microphone",
+            }
+            TrayIndicator._set_indicator_icon(tray, "active", "Microphone on")
+
+        tray.indicator.set_icon_full.assert_called_once_with(
+            "com.vocalinux.Vocalinux-microphone", "Microphone on"
+        )
+
     def test_set_menu_item_enabled(self):
         """Test _set_menu_item_enabled finds and sets menu item sensitivity."""
         with patch("vocalinux.ui.tray_indicator.Gtk") as patched_gtk:

--- a/tests/test_tray_indicator.py
+++ b/tests/test_tray_indicator.py
@@ -422,6 +422,34 @@ class TestTrayIndicator(unittest.TestCase):
         self.assertEqual(icon_names["active"], "vocalinux-microphone")
         self.assertEqual(icon_names["processing"], "vocalinux-microphone-process")
 
+    def test_set_indicator_icon_uses_set_icon_for_flatpak_without_full_api(self):
+        """Flatpak icon setter should support indicators missing set_icon_full."""
+        import vocalinux.ui.tray_indicator as tray_module
+        from vocalinux.ui.tray_indicator import TrayIndicator
+
+        tray = TrayIndicator.__new__(TrayIndicator)
+        tray.indicator = MagicMock(spec=["set_icon"])
+        tray.icon_names = {"default": "com.vocalinux.Vocalinux-microphone-off"}
+
+        with patch.object(tray_module, "FLATPAK_ICON_PREFIX", "com.vocalinux.Vocalinux"):
+            TrayIndicator._set_indicator_icon(tray, "default", "Microphone off")
+
+        tray.indicator.set_icon.assert_called_once_with("com.vocalinux.Vocalinux-microphone-off")
+
+    def test_set_indicator_icon_uses_set_icon_for_non_flatpak_without_full_api(self):
+        """Regular icon setter should support indicators missing set_icon_full."""
+        import vocalinux.ui.tray_indicator as tray_module
+        from vocalinux.ui.tray_indicator import TrayIndicator
+
+        tray = TrayIndicator.__new__(TrayIndicator)
+        tray.indicator = MagicMock(spec=["set_icon"])
+        tray.icon_names = {"default": "vocalinux-microphone-off"}
+
+        with patch.object(tray_module, "FLATPAK_ICON_PREFIX", None):
+            TrayIndicator._set_indicator_icon(tray, "default", "Microphone off")
+
+        tray.indicator.set_icon.assert_called_once_with("vocalinux-microphone-off")
+
     def test_set_menu_item_enabled(self):
         """Test _set_menu_item_enabled finds and sets menu item sensitivity."""
         with patch("vocalinux.ui.tray_indicator.Gtk") as patched_gtk:

--- a/tests/test_tray_indicator.py
+++ b/tests/test_tray_indicator.py
@@ -381,6 +381,47 @@ class TestTrayIndicator(unittest.TestCase):
             "com.vocalinux.Vocalinux-microphone", "Microphone on"
         )
 
+    def test_build_icon_names_uses_flatpak_exported_icons_when_present(self):
+        """Flatpak icon helper should prefer exported host-visible names."""
+        import vocalinux.ui.tray_indicator as tray_module
+        from vocalinux.ui.tray_indicator import TrayIndicator
+
+        def fake_exists(path):
+            return path.endswith(".svg") and "com.vocalinux.Vocalinux" in path
+
+        with patch.object(tray_module, "FLATPAK_ICON_PREFIX", "com.vocalinux.Vocalinux"):
+            with patch("vocalinux.ui.tray_indicator.os.path.exists", side_effect=fake_exists):
+                icon_names = TrayIndicator._build_icon_names()
+
+        self.assertEqual(icon_names["default"], "com.vocalinux.Vocalinux-microphone-off")
+        self.assertEqual(icon_names["active"], "com.vocalinux.Vocalinux-microphone")
+        self.assertEqual(icon_names["processing"], "com.vocalinux.Vocalinux-microphone-process")
+
+    def test_build_icon_names_falls_back_to_bundled_icons_when_export_missing(self):
+        """Flatpak icon helper should fall back if exported icon files are absent."""
+        import vocalinux.ui.tray_indicator as tray_module
+        from vocalinux.ui.tray_indicator import TrayIndicator
+
+        with patch.object(tray_module, "FLATPAK_ICON_PREFIX", "com.vocalinux.Vocalinux"):
+            with patch("vocalinux.ui.tray_indicator.os.path.exists", return_value=False):
+                icon_names = TrayIndicator._build_icon_names()
+
+        self.assertEqual(icon_names["default"], "vocalinux-microphone-off")
+        self.assertEqual(icon_names["active"], "vocalinux-microphone")
+        self.assertEqual(icon_names["processing"], "vocalinux-microphone-process")
+
+    def test_build_icon_names_uses_bundled_icons_outside_flatpak(self):
+        """Non-Flatpak runtime should keep regular package icon names."""
+        import vocalinux.ui.tray_indicator as tray_module
+        from vocalinux.ui.tray_indicator import TrayIndicator
+
+        with patch.object(tray_module, "FLATPAK_ICON_PREFIX", None):
+            icon_names = TrayIndicator._build_icon_names()
+
+        self.assertEqual(icon_names["default"], "vocalinux-microphone-off")
+        self.assertEqual(icon_names["active"], "vocalinux-microphone")
+        self.assertEqual(icon_names["processing"], "vocalinux-microphone-process")
+
     def test_set_menu_item_enabled(self):
         """Test _set_menu_item_enabled finds and sets menu item sensitivity."""
         with patch("vocalinux.ui.tray_indicator.Gtk") as patched_gtk:

--- a/tests/test_whispercpp_model_info_ext.py
+++ b/tests/test_whispercpp_model_info_ext.py
@@ -184,6 +184,36 @@ class TestDetectVulkanSupport(unittest.TestCase):
             self.assertFalse(is_available)
             self.assertIsNone(device_name)
 
+    def test_detect_vulkan_support_from_dri_render_node(self):
+        """Flatpak can detect Vulkan-capable GPUs through exposed DRI render nodes."""
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError("vulkaninfo not found")),
+            patch("os.path.isdir", return_value=True),
+            patch("os.listdir", return_value=["card0", "renderD128"]),
+        ):
+            from vocalinux.utils.whispercpp_model_info import detect_vulkan_support
+
+            detect_vulkan_support.cache_clear()
+            is_available, device_name = detect_vulkan_support()
+
+        self.assertTrue(is_available)
+        self.assertEqual(device_name, "DRI render node")
+
+    def test_detect_vulkan_support_ignores_dri_os_error(self):
+        """DRI probing errors should not make Vulkan detection fail noisily."""
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError("vulkaninfo not found")),
+            patch("os.path.isdir", return_value=True),
+            patch("os.listdir", side_effect=OSError("permission denied")),
+        ):
+            from vocalinux.utils.whispercpp_model_info import detect_vulkan_support
+
+            detect_vulkan_support.cache_clear()
+            is_available, device_name = detect_vulkan_support()
+
+        self.assertFalse(is_available)
+        self.assertIsNone(device_name)
+
 
 class TestDetectCudaSupport(unittest.TestCase):
     """Test cases for detect_cuda_support function."""


### PR DESCRIPTION
## Summary

Adds Flatpak packaging support for Vocalinux and rebases the original draft work onto current `main`. The package is now focused on a Flathub-ready `whisper_cpp` build path with correct Flatpak XDG paths, AppStream metadata, desktop integration, local build docs, and runtime fixes for the installed app.

Closes #167

## Current Status

This PR is no longer just the original packaging draft. It now:

- Targets `org.gnome.Platform//50` and `org.gnome.Sdk//50`
- Builds and installs locally with `flatpak-builder --user --install`
- Runs through the installed Flatpak entrypoint with `flatpak run com.vocalinux.Vocalinux --debug`
- Loads `pywhispercpp` successfully without relying on a runtime `LD_LIBRARY_PATH`
- Exports launcher and tray/status icons using Flatpak-compatible `com.vocalinux.Vocalinux*` icon names
- Uses an X11/XWayland text-injection path with packaged `xdotool` and `xsel`
- Passes Flathub-style manifest, builddir, repo, and AppStream validation locally

## What's Included

- `packaging/flatpak/com.vocalinux.Vocalinux.yml` Flatpak manifest
- `packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml` AppStream metadata
- `packaging/flatpak/com.vocalinux.Vocalinux.desktop` desktop entry
- Generated Flatpak Python dependency manifests for the supported Python stack
- Native Flatpak modules for PortAudio, AppIndicator/status notifier support, `xdotool`, and `xsel`
- Flatpak-safe config, cache, data, log, and model directory handling under `~/.var/app/com.vocalinux.Vocalinux/`
- Tray icon/resource lookup fixes for packaged and host-exported Flatpak icons
- Runtime fixes for `pywhispercpp` shared-library discovery
- First-run dialog GTK response handling fix
- Flatpak runtime detection fixes for text injection and keyboard backend selection
- Release workflow updates for Flatpak bundle builds
- README, distro compatibility, and Flatpak submission docs

## Runtime Notes and Limitations

- The Flatpak supports the default `whisper_cpp` engine. VOSK is intentionally excluded for now because the PyPI `vosk` package is wheel-only; a Flathub-ready VOSK path would need a source-built module for VOSK and its native dependencies.
- The manifest intentionally requests `--socket=x11` rather than native Wayland access. GNOME Wayland does not expose a general unprivileged virtual-keyboard protocol for arbitrary text injection, and Flathub's linter rejects combining full X11 and Wayland sockets.
- On Wayland sessions, the app runs through XWayland for text injection. `xdotool` can type into X11/XWayland targets; native Wayland targets remain compositor-limited, so the app also copies recognized text to the clipboard via `xsel` when using the XWayland fallback.
- Global keyboard shortcuts are still limited by Flatpak and compositor sandboxing. Tray/menu control remains the most reliable activation path.
- GNOME needs AppIndicator/status notifier support enabled for the tray icon to appear in the top bar.
- `flatpak-builder --run` is useful for non-GUI smoke tests, but GUI testing should use the installed app path. GNOME runtimes that use glycin image loaders can fail to load themed SVG icons for an uninstalled stable app ID when launched with `flatpak-builder --run`.

## How to Test Locally

From the repository root:

```bash
flatpak install flathub org.gnome.Platform//50 org.gnome.Sdk//50 org.flatpak.Builder

flatpak-builder \
  --user \
  --install \
  --force-clean \
  build-dir \
  packaging/flatpak/com.vocalinux.Vocalinux.yml

flatpak run com.vocalinux.Vocalinux --debug
```

If an older copy is already running:

```bash
flatpak kill com.vocalinux.Vocalinux
flatpak run com.vocalinux.Vocalinux --debug
```

Non-GUI dependency smoke test:

```bash
flatpak-builder --run build-dir packaging/flatpak/com.vocalinux.Vocalinux.yml python3 -c 'from pywhispercpp.model import Model; print("pywhispercpp ok")'
```

Runtime probes used for this PR:

```bash
flatpak run --command=python3 com.vocalinux.Vocalinux -c 'from vocalinux.text_injection.text_injector import TextInjector; ti=TextInjector(); print(ti.environment.value)'
flatpak run --command=python3 com.vocalinux.Vocalinux -c 'from vocalinux.ui.keyboard_backends import DesktopEnvironment; print(DesktopEnvironment.detect())'
flatpak run --command=xdotool com.vocalinux.Vocalinux getwindowfocus
```

Flathub-style local validation:

```bash
flatpak-builder \
  --force-clean \
  --repo=repo \
  --compose-url-policy=full \
  --mirror-screenshots-url=https://dl.flathub.org/media \
  build-dir \
  packaging/flatpak/com.vocalinux.Vocalinux.yml

flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest packaging/flatpak/com.vocalinux.Vocalinux.yml
flatpak run --command=flatpak-builder-lint org.flatpak.Builder builddir build-dir
flatpak run --command=flatpak-builder-lint org.flatpak.Builder repo repo
appstreamcli validate --no-net packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
```

## Validation Performed

- Rebased branch onto current `main`
- `flatpak-builder --user --install --force-clean build-dir packaging/flatpak/com.vocalinux.Vocalinux.yml`
- `timeout 8s flatpak run com.vocalinux.Vocalinux --debug --start-minimized` reached the GTK tray loop and shut down cleanly on timeout
- Installed Flatpak runtime probes:
  - text injector detects `wayland-xdotool`
  - keyboard backend detects `x11`
  - `xdotool getwindowfocus` succeeds inside the sandbox
  - packaged `xsel` clipboard copy succeeds inside the sandbox
- Confirmed installed app exports these status icons:
  - `com.vocalinux.Vocalinux.svg`
  - `com.vocalinux.Vocalinux-microphone-off.svg`
  - `com.vocalinux.Vocalinux-microphone.svg`
  - `com.vocalinux.Vocalinux-microphone-process.svg`
- `flatpak run --command=python3 com.vocalinux.Vocalinux -c 'from pywhispercpp.model import Model; print("pywhispercpp ok")'`
- Confirmed installed app resolves `libwhisper.so.1` from `/app/lib` with empty `LD_LIBRARY_PATH`
- Flathub-style `flatpak-builder` build with screenshot mirroring
- `flatpak-builder-lint` manifest, builddir, and repo checks
- `appstreamcli validate --no-net packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml`
- `PYTHONPATH=src pytest tests/test_text_injector.py tests/test_text_injector_ext.py tests/test_tray_indicator.py tests/test_tray_indicator_ext.py tests/test_keyboard_init_ext.py tests/test_keyboard_backends_ext.py tests/test_keyboard_shortcuts.py`
- `black --check --diff` on touched Python files
- `flake8` on touched Python files with `--select=E9,F63,F7,F82`
- `git diff --check`