### PR TITLE
feat: add configurable Whisper language candidates

### DIFF
--- a/src/vocalinux/main.py
+++ b/src/vocalinux/main.py
@@ -370,6 +370,9 @@ def main():
             whispercpp_no_timestamps=advanced_settings.get("whispercpp_no_timestamps", True),
             whispercpp_no_context=advanced_settings.get("whispercpp_no_context", True),
             whispercpp_initial_prompt=advanced_settings.get("whispercpp_initial_prompt", ""),
+            whispercpp_language_candidates=advanced_settings.get(
+                "whispercpp_language_candidates", ""
+            ),
             whispercpp_temperature=advanced_settings.get("whispercpp_temperature", 0.0),
             whispercpp_temperature_inc=advanced_settings.get("whispercpp_temperature_inc", -1.0),
             whispercpp_entropy_thold=advanced_settings.get("whispercpp_entropy_thold", 2.4),

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -560,6 +560,9 @@ class SpeechRecognitionManager:
         self.whispercpp_no_timestamps = kwargs.get("whispercpp_no_timestamps", True)
         self.whispercpp_no_context = kwargs.get("whispercpp_no_context", True)
         self.whispercpp_initial_prompt = kwargs.get("whispercpp_initial_prompt", "")
+        self.whispercpp_language_candidates = self._normalize_language_candidates(
+            kwargs.get("whispercpp_language_candidates", "")
+        )
         self.whispercpp_temperature = kwargs.get("whispercpp_temperature", 0.0)
         self.whispercpp_temperature_inc = kwargs.get("whispercpp_temperature_inc", -1.0)
         self.whispercpp_entropy_thold = kwargs.get("whispercpp_entropy_thold", 2.4)
@@ -604,6 +607,23 @@ class SpeechRecognitionManager:
             self._init_whispercpp()
         else:
             raise ValueError(f"Unsupported speech recognition engine: {engine}")
+
+    @staticmethod
+    def _normalize_language_candidates(value) -> list[str]:
+        """Normalize a comma-separated string or list of Whisper language codes."""
+        if value is None:
+            return []
+
+        raw_candidates = value.replace(";", ",").split(",") if isinstance(value, str) else value
+        candidates = []
+        for candidate in raw_candidates:
+            code = str(candidate).strip().lower().replace("_", "-")
+            if not code:
+                continue
+            code = code.split("-", 1)[0]
+            if code not in candidates:
+                candidates.append(code)
+        return candidates
 
     def _resolve_voice_commands_enabled(self) -> bool:
         """Resolve effective voice commands state from preference and engine."""
@@ -1066,6 +1086,25 @@ class SpeechRecognitionManager:
                 if self.model is None:
                     logger.warning("Model is None during transcription, returning empty result")
                     return ""
+
+                if lang is None and self.whispercpp_language_candidates:
+                    detected, lang_probs = self.model.auto_detect_language(
+                        audio_float,
+                        n_threads=min(4, max(1, os.cpu_count() or 1)),
+                    )
+                    candidate_probs = {
+                        candidate: float(lang_probs.get(candidate, 0.0))
+                        for candidate in self.whispercpp_language_candidates
+                    }
+                    lang = max(candidate_probs, key=candidate_probs.get)
+                    logger.info(
+                        "whisper.cpp restricted language detection: detected=%s %.3f, candidates=%s, using=%s %.3f",
+                        detected[0],
+                        float(detected[1]),
+                        ",".join(self.whispercpp_language_candidates),
+                        lang,
+                        candidate_probs[lang],
+                    )
 
                 # Transcribe with whisper.cpp
                 # pywhispercpp expects audio as numpy array
@@ -2156,6 +2195,7 @@ class SpeechRecognitionManager:
             "whispercpp_no_timestamps",
             "whispercpp_no_context",
             "whispercpp_initial_prompt",
+            "whispercpp_language_candidates",
             "whispercpp_temperature",
             "whispercpp_temperature_inc",
             "whispercpp_entropy_thold",
@@ -2163,7 +2203,10 @@ class SpeechRecognitionManager:
             "whispercpp_no_speech_thold",
         ):
             if param_name in kwargs:
-                setattr(self, param_name, kwargs[param_name])
+                value = kwargs[param_name]
+                if param_name == "whispercpp_language_candidates":
+                    value = self._normalize_language_candidates(value)
+                setattr(self, param_name, value)
                 restart_needed = True
 
         self._voice_commands_enabled = self._resolve_voice_commands_enabled()

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -61,6 +61,7 @@ DEFAULT_CONFIG = {
         "whispercpp_no_timestamps": True,
         "whispercpp_no_context": True,
         "whispercpp_initial_prompt": "",
+        "whispercpp_language_candidates": "",
         "whispercpp_temperature": 0.0,
         "whispercpp_temperature_inc": -1.0,
         "whispercpp_entropy_thold": 2.4,

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1582,6 +1582,21 @@ class SettingsDialog(Gtk.Dialog):
         )
         group.add_row(no_speech_row)
 
+        candidates_help = (
+            "Optional comma-separated Whisper language codes for auto-detect, "
+            "such as en,es. Leave blank to consider all languages."
+        )
+        self.advanced_language_candidates_entry = Gtk.Entry()
+        self.advanced_language_candidates_entry.set_placeholder_text("en,es")
+        self.advanced_language_candidates_entry.set_tooltip_text(candidates_help)
+        language_candidates_row = PreferenceRow(
+            title="Language Candidates",
+            subtitle="Restrict auto-detect to selected language codes",
+            widget=self.advanced_language_candidates_entry,
+        )
+        language_candidates_row.set_tooltip_text(candidates_help)
+        group.add_row(language_candidates_row)
+
         # Initial Prompt -- moved to the end and made multiline
         initial_prompt_help = (
             "Optional. Add names, jargon, punctuation style, or other context to bias "
@@ -1637,6 +1652,7 @@ class SettingsDialog(Gtk.Dialog):
         self.advanced_entropy_thold_spin.connect("value-changed", self._on_advanced_param_changed)
         self.advanced_logprob_thold_spin.connect("value-changed", self._on_advanced_param_changed)
         self.advanced_no_speech_thold_spin.connect("value-changed", self._on_advanced_param_changed)
+        self.advanced_language_candidates_entry.connect("changed", self._on_advanced_param_changed)
 
         self.advanced_initial_prompt_buffer = self.advanced_initial_prompt_textview.get_buffer()
         self.advanced_initial_prompt_buffer.connect("changed", self._on_advanced_prompt_changed)
@@ -1727,6 +1743,9 @@ class SettingsDialog(Gtk.Dialog):
             self.advanced_no_timestamps_switch.set_active(defaults["whispercpp_no_timestamps"])
             self.advanced_no_context_switch.set_active(defaults["whispercpp_no_context"])
             self.advanced_initial_prompt_buffer.set_text(defaults["whispercpp_initial_prompt"], -1)
+            self.advanced_language_candidates_entry.set_text(
+                defaults["whispercpp_language_candidates"]
+            )
             self.advanced_temperature_spin.set_value(defaults["whispercpp_temperature"])
             self.advanced_temperature_inc_spin.set_value(defaults["whispercpp_temperature_inc"])
             self.advanced_entropy_thold_spin.set_value(defaults["whispercpp_entropy_thold"])
@@ -1839,6 +1858,9 @@ class SettingsDialog(Gtk.Dialog):
         )
         self.advanced_initial_prompt_buffer.set_text(
             advanced_settings.get("whispercpp_initial_prompt", ""), -1
+        )
+        self.advanced_language_candidates_entry.set_text(
+            advanced_settings.get("whispercpp_language_candidates", "")
         )
         self.advanced_temperature_spin.set_value(
             advanced_settings.get("whispercpp_temperature", 0.0)
@@ -2327,6 +2349,7 @@ class SettingsDialog(Gtk.Dialog):
                 self.advanced_initial_prompt_buffer.get_end_iter(),
                 False,
             ),
+            "whispercpp_language_candidates": self.advanced_language_candidates_entry.get_text(),
             "whispercpp_temperature": self.advanced_temperature_spin.get_value(),
             "whispercpp_temperature_inc": self.advanced_temperature_inc_spin.get_value(),
             "whispercpp_entropy_thold": self.advanced_entropy_thold_spin.get_value(),

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -538,6 +538,7 @@ class TestTypedAccessors(unittest.TestCase):
         self.assertTrue(advanced["whispercpp_no_timestamps"])
         self.assertTrue(advanced["whispercpp_no_context"])
         self.assertEqual(advanced["whispercpp_initial_prompt"], "")
+        self.assertEqual(advanced["whispercpp_language_candidates"], "")
         self.assertEqual(advanced["whispercpp_temperature"], 0.0)
         self.assertEqual(advanced["whispercpp_temperature_inc"], -1.0)
         self.assertEqual(advanced["whispercpp_entropy_thold"], 2.4)
@@ -548,6 +549,7 @@ class TestTypedAccessors(unittest.TestCase):
         self.config_manager.set("advanced", "whispercpp_temperature", 0.5)
         self.config_manager.set("advanced", "whispercpp_no_timestamps", False)
         self.config_manager.set("advanced", "whispercpp_initial_prompt", "Meeting notes")
+        self.config_manager.set("advanced", "whispercpp_language_candidates", "en,es")
         self.config_manager.save_config()
 
         new_manager = ConfigManager()
@@ -555,3 +557,4 @@ class TestTypedAccessors(unittest.TestCase):
         self.assertEqual(advanced["whispercpp_temperature"], 0.5)
         self.assertFalse(advanced["whispercpp_no_timestamps"])
         self.assertEqual(advanced["whispercpp_initial_prompt"], "Meeting notes")
+        self.assertEqual(advanced["whispercpp_language_candidates"], "en,es")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -225,6 +225,7 @@ class TestMainModule(unittest.TestCase):
                 whispercpp_no_timestamps=True,
                 whispercpp_no_context=True,
                 whispercpp_initial_prompt="",
+                whispercpp_language_candidates="",
                 whispercpp_temperature=0.0,
                 whispercpp_temperature_inc=-1.0,
                 whispercpp_entropy_thold=2.4,

--- a/tests/test_recognition_manager_advanced.py
+++ b/tests/test_recognition_manager_advanced.py
@@ -257,6 +257,13 @@ class TestReconfigure(unittest.TestCase):
             mgr.reconfigure(engine="vosk")
         self.assertEqual(mgr.engine, "vosk")
 
+    def test_reconfigure_language_candidates(self):
+        mgr = _make_manager()
+        mgr.state = RecognitionState.IDLE
+        with patch.object(mgr, "_init_whispercpp"):
+            mgr.reconfigure(whispercpp_language_candidates="en,es")
+        self.assertEqual(mgr.whispercpp_language_candidates, ["en", "es"])
+
 
 class TestProcessFinalBuffer(unittest.TestCase):
     def test_process_final_buffer_whispercpp(self):
@@ -288,6 +295,18 @@ class TestProcessFinalBuffer(unittest.TestCase):
 
 
 class TestTranscribeWhispercpp(unittest.TestCase):
+    def test_normalize_language_candidates(self):
+        self.assertEqual(
+            SpeechRecognitionManager._normalize_language_candidates(" en-US, es ; fr "),
+            ["en", "es", "fr"],
+        )
+        self.assertEqual(
+            SpeechRecognitionManager._normalize_language_candidates(["EN", "es", "en"]),
+            ["en", "es"],
+        )
+        self.assertEqual(SpeechRecognitionManager._normalize_language_candidates(""), [])
+        self.assertEqual(SpeechRecognitionManager._normalize_language_candidates(None), [])
+
     def test_transcribe_success(self):
         mgr = _make_manager()
         mgr.language = "en-us"
@@ -358,6 +377,80 @@ class TestTranscribeWhispercpp(unittest.TestCase):
 
         with patch.dict("sys.modules", {"numpy": mock_np}):
             result = mgr._transcribe_with_whispercpp([b"\x00\x00" * 512])
+
+        self.assertEqual(result, "bonjour")
+        mgr.model.transcribe.assert_called_once()
+        self.assertIsNone(mgr.model.transcribe.call_args.kwargs["language"])
+
+    def test_transcribe_specific_language(self):
+        mgr = _make_manager()
+        mgr.language = "es"
+        mock_segment = MagicMock()
+        mock_segment.text = "hola"
+        mgr.model = MagicMock()
+        mgr.model.transcribe.return_value = [mock_segment]
+
+        mock_np = MagicMock()
+        mock_np.frombuffer.return_value = MagicMock(__len__=lambda s: 16000)
+        mock_np.frombuffer.return_value.astype.return_value = mock_np.frombuffer.return_value
+        mock_np.int16 = "int16"
+        mock_np.float32 = "float32"
+
+        with patch.dict("sys.modules", {"numpy": mock_np}):
+            result = mgr._transcribe_with_whispercpp([b"\x00\x00" * 512])
+
+        self.assertEqual(result, "hola")
+        mgr.model.transcribe.assert_called_once()
+        self.assertEqual(mgr.model.transcribe.call_args.kwargs["language"], "es")
+
+    def test_transcribe_candidate_languages_restricts_to_english(self):
+        mgr = _make_manager(whispercpp_language_candidates="en,es")
+        mgr.language = "auto"
+        mock_segment = MagicMock()
+        mock_segment.text = "hello"
+        mgr.model = MagicMock()
+        mgr.model.auto_detect_language.return_value = (("en", 0.8), {"en": 0.7, "es": 0.3})
+        mgr.model.transcribe.return_value = [mock_segment]
+
+        mock_np = MagicMock()
+        mock_np.frombuffer.return_value = MagicMock(__len__=lambda s: 16000)
+        mock_np.frombuffer.return_value.astype.return_value = mock_np.frombuffer.return_value
+        mock_np.int16 = "int16"
+        mock_np.float32 = "float32"
+
+        with patch.dict("sys.modules", {"numpy": mock_np}):
+            result = mgr._transcribe_with_whispercpp([b"\x00\x00" * 512])
+
+        self.assertEqual(result, "hello")
+        mgr.model.auto_detect_language.assert_called_once()
+        mgr.model.transcribe.assert_called_once()
+        self.assertEqual(mgr.model.transcribe.call_args.kwargs["language"], "en")
+
+    def test_transcribe_candidate_languages_restricts_to_spanish(self):
+        mgr = _make_manager(whispercpp_language_candidates=["en", "es", "fr"])
+        mgr.language = "auto"
+        mock_segment = MagicMock()
+        mock_segment.text = "hola"
+        mgr.model = MagicMock()
+        mgr.model.auto_detect_language.return_value = (
+            ("de", 0.6),
+            {"en": 0.2, "es": 0.5, "fr": 0.1},
+        )
+        mgr.model.transcribe.return_value = [mock_segment]
+
+        mock_np = MagicMock()
+        mock_np.frombuffer.return_value = MagicMock(__len__=lambda s: 16000)
+        mock_np.frombuffer.return_value.astype.return_value = mock_np.frombuffer.return_value
+        mock_np.int16 = "int16"
+        mock_np.float32 = "float32"
+
+        with patch.dict("sys.modules", {"numpy": mock_np}):
+            result = mgr._transcribe_with_whispercpp([b"\x00\x00" * 512])
+
+        self.assertEqual(result, "hola")
+        mgr.model.auto_detect_language.assert_called_once()
+        mgr.model.transcribe.assert_called_once()
+        self.assertEqual(mgr.model.transcribe.call_args.kwargs["language"], "es")
 
 
 class TestTranscribeWhisper(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add configurable whisper.cpp language candidates for auto-detection
- accept comma-separated codes like `en,es` (or config lists) and normalize region codes like `en-US` to `en`
- when candidates are set and language is `auto`, detect language probabilities once and force decoding to the highest candidate
- expose the setting in Advanced Settings as **Language Candidates**
- add focused tests for normalization, unrestricted auto-detect, fixed language, and restricted candidate selection

## Why
Whisper auto-detect can consider every supported language. For multilingual dictation where the user knows the possible languages, constraining detection improves predictability without hardcoding a specific language pair.

## Example
Set Advanced Settings > Language Candidates to:

```text
en,es
```

That keeps auto-detect limited to English or Spanish. Users can also choose other sets like `en,fr,de`.

## Validation
- `PYTHONPATH=src /home/juanfra/.local/share/vocalinux/venv/bin/python -m pytest tests/test_recognition_manager_advanced.py tests/test_settings_dialog.py tests/test_whispercpp_model_info_ext.py tests/test_config_manager.py tests/test_main.py -q`
- `PYTHONPATH=src /home/juanfra/.local/share/vocalinux/venv/bin/python -m py_compile src/vocalinux/speech_recognition/recognition_manager.py src/vocalinux/ui/settings_dialog.py src/vocalinux/ui/config_manager.py src/vocalinux/main.py tests/test_recognition_manager_advanced.py tests/test_config_manager.py tests/test_main.py`
- `black --check` on changed files