### PR TITLE
fix: paste into Firefox through clipboard fallback

### DIFF
--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -534,6 +534,89 @@ class TextInjector:
         except Exception as e:
             logger.debug(f"Could not show clipboard notification: {e}")
 
+    def _get_current_x11_app_id(self) -> str:
+        """Return a best-effort identifier for the focused X11/XWayland application."""
+        if not shutil.which("xdotool"):
+            return ""
+
+        try:
+            env = os.environ.copy()
+            window = subprocess.run(
+                ["xdotool", "getactivewindow"],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                check=False,
+                timeout=1,
+            )
+            window_id = window.stdout.strip()
+            if window.returncode != 0 or not window_id:
+                return ""
+
+            app_parts = []
+            for args in (
+                ["xdotool", "getwindowclassname", window_id],
+                ["xdotool", "getwindowname", window_id],
+            ):
+                result = subprocess.run(
+                    args,
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.DEVNULL,
+                    text=True,
+                    check=False,
+                    timeout=1,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    app_parts.append(result.stdout.strip())
+
+            pid_result = subprocess.run(
+                ["xdotool", "getwindowpid", window_id],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                check=False,
+                timeout=1,
+            )
+            if pid_result.returncode == 0 and pid_result.stdout.strip():
+                pid = pid_result.stdout.strip()
+                for proc_file in (f"/proc/{pid}/comm", f"/proc/{pid}/cmdline"):
+                    try:
+                        with open(proc_file, "r", encoding="utf-8", errors="ignore") as f:
+                            app_parts.append(f.read().replace("\x00", " "))
+                    except OSError:
+                        continue
+
+            return " ".join(app_parts).lower()
+        except Exception as e:
+            logger.debug(f"Could not identify active X11 application: {e}")
+            return ""
+
+    def _inject_via_x11_clipboard_paste(self, text: str) -> bool:
+        """Inject text by copying to clipboard and sending Ctrl+V through xdotool."""
+        if not shutil.which("xdotool"):
+            return False
+
+        if not self._copy_to_clipboard(text):
+            logger.warning("Could not copy text to clipboard for X11 paste injection")
+            return False
+
+        try:
+            subprocess.run(
+                ["xdotool", "key", "--clearmodifiers", "ctrl+v"],
+                check=True,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=3,
+            )
+            logger.info(f"Text injected via X11 clipboard paste: '{text[:20]}...'")
+            return True
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+            logger.warning(f"X11 paste simulation failed: {e}")
+            return False
+
     def inject_text(self, text: str) -> bool:
         """
         Inject text into the currently focused application.
@@ -553,6 +636,9 @@ class TextInjector:
 
         # Get information about the current window/application
         self._log_current_window_info()
+        target_app = ""
+        if self.environment in (DesktopEnvironment.X11_IBUS, DesktopEnvironment.WAYLAND_IBUS):
+            target_app = self._get_current_x11_app_id().lower()
 
         # Note: No shell escaping needed - subprocess is called with list arguments,
         # which passes text directly without shell interpretation
@@ -568,6 +654,10 @@ class TextInjector:
                 self.environment == DesktopEnvironment.WAYLAND_IBUS
                 or self.environment == DesktopEnvironment.X11_IBUS
             ):
+                if "firefox" in target_app and self._inject_via_x11_clipboard_paste(text):
+                    logger.info("Used Firefox clipboard-paste fallback instead of IBus")
+                    return True
+
                 if self._ibus_injector is not None:
                     result = self._ibus_injector.inject_text(text)
                     if result:

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -435,6 +435,51 @@ class TestTextInjector(unittest.TestCase):
         result = injector.inject_text("Test")
         self.assertTrue(result)
 
+    def test_firefox_ibus_uses_clipboard_paste_fallback(self):
+        """Test Firefox uses clipboard-paste instead of IBus injection."""
+        injector = TextInjector()
+        injector.environment = DesktopEnvironment.X11_IBUS
+        injector._ibus_injector = MagicMock()
+
+        with patch.object(injector, "_get_current_x11_app_id", return_value="Navigator Firefox"):
+            with patch.object(injector, "_inject_via_x11_clipboard_paste", return_value=True):
+                result = injector.inject_text("Test")
+
+        self.assertTrue(result)
+        injector._ibus_injector.inject_text.assert_not_called()
+
+    def test_non_firefox_ibus_keeps_ibus_injection(self):
+        """Test non-Firefox IBus targets keep the normal IBus path."""
+        injector = TextInjector()
+        injector.environment = DesktopEnvironment.X11_IBUS
+        injector._ibus_injector = MagicMock()
+        injector._ibus_injector.inject_text.return_value = True
+
+        with patch.object(injector, "_get_current_x11_app_id", return_value="Code"):
+            with patch.object(injector, "_inject_via_x11_clipboard_paste") as mock_paste:
+                result = injector.inject_text("Test")
+
+        self.assertTrue(result)
+        mock_paste.assert_not_called()
+        injector._ibus_injector.inject_text.assert_called_once_with("Test")
+
+    def test_x11_clipboard_paste_uses_xdotool_ctrl_v(self):
+        """Test X11 clipboard-paste copies text and sends Ctrl+V."""
+        injector = TextInjector()
+
+        with patch.object(injector, "_copy_to_clipboard", return_value=True) as mock_copy:
+            result = injector._inject_via_x11_clipboard_paste("Test")
+
+        self.assertTrue(result)
+        mock_copy.assert_called_once_with("Test")
+        self.mock_subprocess.assert_any_call(
+            ["xdotool", "key", "--clearmodifiers", "ctrl+v"],
+            check=True,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=3,
+        )
+
     def test_inject_text_returns_false_on_failure(self):
         """Test that inject_text returns False on failure."""
         injector = TextInjector()


### PR DESCRIPTION
## Summary
- detect focused Firefox windows when using the IBus text injection path
- use clipboard copy plus `xdotool key ctrl+v` for Firefox instead of direct IBus commit
- keep the existing IBus path for other applications
- add tests for Firefox fallback, non-Firefox behavior, and X11 paste injection

## Why
Firefox text fields can ignore IBus commit text in some X11 desktop setups even while terminal and other applications work. Clipboard paste is the reliable path there and already matches the existing clipboard fallback model.

## Impact
Firefox users get the dictated text inserted instead of silently losing it. The recognized text is copied to clipboard as part of the paste fallback.

## Validation
- `PYTHONPATH=src /home/juanfra/.local/share/vocalinux/venv/bin/python -m pytest tests/test_text_injector.py -q`
- `PYTHONPATH=src /home/juanfra/.local/share/vocalinux/venv/bin/python -m py_compile src/vocalinux/text_injection/text_injector.py tests/test_text_injector.py`
- `black --check` on changed files