### PR TITLE
docs: document AppImage install path after #573

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,20 @@ XWayland on Wayland sessions. See [`packaging/flatpak/README.md`](packaging/flat
 for build details, permissions, and Flathub submission notes. Flathub publishing
 is in progress.
 
+### AppImage (portable)
+
+Download a self-contained AppImage from
+[GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases) (new tags
+and nightlies after the packaging merge; see asset names on each release):
+
+```bash
+chmod +x Vocalinux-<version>-x86_64.AppImage   # or ...-aarch64.AppImage
+./Vocalinux-<version>-x86_64.AppImage
+```
+
+Host still needs text-injection tools (`xdotool` / `wtype` / `ydotool`), same as
+PyPI. Full notes: [docs/INSTALL.md](docs/INSTALL.md#appimage).
+
 ### Alternative: Install from Source
 
 ```bash
@@ -426,6 +440,7 @@ This script generates all three sounds using the same smooth glide algorithm. Yo
 - [ ] In-app update mechanism
 - [ ] Application-specific commands
 - [x] ~~Flatpak packaging~~ ✅ (Flathub submission in progress)
+- [x] ~~AppImage packaging~~ ✅ (x86_64 + aarch64 on tags and nightlies)
 - [ ] Debian/Ubuntu package (.deb)
 - [x] ~~Wayland support via IBus~~ ✅
 - [ ] Voice command customization

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -111,6 +111,38 @@ model during setup.
 On Ubuntu 24.04+ or Pop!_OS, install `libgirepository-2.0-dev` if
 `libgirepository1.0-dev` is not available.
 
+### AppImage
+
+Portable build with no installer and no root required. Download from
+[GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases): AppImage
+assets ship on **new tags** and **nightlies** after the AppImage packaging
+landed ([#573](https://github.com/jatinkrmalik/vocalinux/pull/573)). Older
+release tags may only have the Python wheel and sdist.
+
+Assets are named:
+
+| Architecture | File |
+|--------------|------|
+| Intel/AMD 64-bit | `Vocalinux-<version>-x86_64.AppImage` |
+| ARM64 | `Vocalinux-<version>-aarch64.AppImage` |
+
+```bash
+# Example for x86_64 (use the version string from the release asset name)
+chmod +x Vocalinux-<version>-x86_64.AppImage
+./Vocalinux-<version>-x86_64.AppImage
+```
+
+The AppImage bundles the Python runtime, Vocalinux, GTK, and related libraries.
+It does **not** bundle text-injection tools. Install those on the host the same
+way as for the PyPI path:
+
+- **X11:** `xdotool`
+- **Wayland:** `wtype` (and often `wl-clipboard` / `xclip` / `xsel`)
+- Some setups use `ydotool`
+
+See [Text Injection Not Working](#text-injection-not-working) if dictated text
+does not appear in apps.
+
 ## System Requirements
 
 | Requirement | Details |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -49,6 +49,12 @@ Use this checklist for every release:
 - [ ] Push branch and create PR
 - [ ] After PR merge, create tag: `git tag -a vX.Y.Z-PHASE -m "Release X.Y.Z-PHASE"`
 - [ ] Push tag: `git push origin vX.Y.Z-PHASE`
+
+### Release assets (automatic)
+- [ ] Confirm GitHub Release includes wheel + sdist
+- [ ] Confirm AppImages attached by `.github/workflows/release.yml`:
+  - `Vocalinux-X.Y.Z[-PHASE]-x86_64.AppImage` (main job)
+  - `Vocalinux-X.Y.Z[-PHASE]-aarch64.AppImage` (arm64 job; may appear shortly after publish)
 ```
 
 ## Detailed Release Steps
@@ -299,16 +305,21 @@ git push origin v0.5.0-beta
 After pushing the tag, the GitHub Actions workflow will automatically:
 
 1. Build the Python package (wheel and sdist)
-2. Create a GitHub Release with auto-generated notes
-3. Publish to PyPI
-4. Deploy the website to vocalinux.com
-5. Mark as pre-release if version contains alpha/beta/rc
+2. Build the x86_64 AppImage and attach it (plus wheel/sdist) to the GitHub Release
+3. Build and attach the aarch64 AppImage from a separate arm64 job
+4. Publish to PyPI
+5. Publish the AUR package when AUR secrets are configured
+6. Mark as pre-release if the version contains alpha/beta/rc
+
+Nightlies (`.github/workflows/nightly.yml`) also attach AppImages with the same
+`Vocalinux-<version>-<arch>.AppImage` naming.
 
 Monitor at: https://github.com/jatinkrmalik/vocalinux/actions
 
 ### Step 9: Post-Release Tasks
 
 - [ ] Verify GitHub Release was created correctly
+- [ ] Verify release assets: wheel, sdist, `Vocalinux-*-x86_64.AppImage`, and `Vocalinux-*-aarch64.AppImage`
 - [ ] Verify PyPI package was published (if applicable)
 - [ ] Verify website was deployed (check vocalinux.com)
 - [ ] Announce on social media/communities

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -26,6 +26,15 @@ This guide explains how to update Vocalinux to the latest version.
 
 See the [full changelog](https://github.com/jatinkrmalik/vocalinux/releases/tag/v0.14.2).
 
+### Packaging note (after v0.14.2)
+
+AppImage builds are produced by the release and nightly workflows
+([#573](https://github.com/jatinkrmalik/vocalinux/pull/573)). They appear on
+**new tags** and **nightlies** as `Vocalinux-<version>-x86_64.AppImage` and
+`Vocalinux-<version>-aarch64.AppImage`. Download from
+[GitHub Releases](https://github.com/jatinkrmalik/vocalinux/releases); see
+[INSTALL.md](INSTALL.md#appimage) for run steps and host text-injection tools.
+
 ---
 
 ## What's New in v0.14.1

--- a/web/src/app/install/page.tsx
+++ b/web/src/app/install/page.tsx
@@ -76,6 +76,59 @@ export default function InstallGuidesPage() {
             {installCommand}
           </code>
         </div>
+
+        <div className="mt-6 rounded-2xl border border-zinc-200 bg-white p-6 text-left shadow-sm dark:border-zinc-700 dark:bg-zinc-800">
+          <h2 className="mb-2 text-xl font-semibold">AppImage (portable)</h2>
+          <p className="mb-3 text-sm text-muted-foreground">
+            Prefer a single file with no installer? Download{" "}
+            <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-xs dark:bg-zinc-900">
+              Vocalinux-&lt;version&gt;-x86_64.AppImage
+            </code>{" "}
+            or{" "}
+            <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-xs dark:bg-zinc-900">
+              Vocalinux-&lt;version&gt;-aarch64.AppImage
+            </code>{" "}
+            from{" "}
+            <a
+              href="https://github.com/jatinkrmalik/vocalinux/releases"
+              className="font-semibold text-primary hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              GitHub Releases
+            </a>{" "}
+            (new tags and nightlies). Then:
+          </p>
+          <code className="mb-3 block overflow-x-auto whitespace-pre-wrap break-all rounded-lg border border-zinc-800 bg-zinc-950 p-4 text-sm text-green-400">
+            chmod +x Vocalinux-&lt;version&gt;-x86_64.AppImage
+            {"\n"}
+            ./Vocalinux-&lt;version&gt;-x86_64.AppImage
+          </code>
+          <p className="text-sm text-muted-foreground">
+            The host still needs text-injection tools (
+            <code className="rounded bg-zinc-100 px-1 py-0.5 text-xs dark:bg-zinc-900">
+              xdotool
+            </code>
+            ,{" "}
+            <code className="rounded bg-zinc-100 px-1 py-0.5 text-xs dark:bg-zinc-900">
+              wtype
+            </code>
+            , or{" "}
+            <code className="rounded bg-zinc-100 px-1 py-0.5 text-xs dark:bg-zinc-900">
+              ydotool
+            </code>
+            ), same as a PyPI install. Full guide:{" "}
+            <a
+              href="https://github.com/jatinkrmalik/vocalinux/blob/main/docs/INSTALL.md#appimage"
+              className="font-semibold text-primary hover:underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              INSTALL.md
+            </a>
+            .
+          </p>
+        </div>
       </section>
 
       <section className="mt-14 grid gap-6 md:grid-cols-3">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1022,6 +1022,69 @@ export default function HomePage() {
                   </div>
                 </div>
 
+                {/* Other install options */}
+                <div className="mt-8 rounded-xl border border-zinc-200 bg-zinc-50 p-4 dark:border-zinc-700 dark:bg-zinc-900">
+                  <h4 className="mb-2 font-semibold">Other install options</h4>
+                  <ul className="space-y-2 text-sm text-muted-foreground">
+                    <li>
+                      <strong className="text-foreground">AppImage:</strong>{" "}
+                      portable{" "}
+                      <code className="rounded bg-zinc-200 px-1 py-0.5 text-xs dark:bg-zinc-800">
+                        Vocalinux-&lt;version&gt;-x86_64.AppImage
+                      </code>{" "}
+                      /{" "}
+                      <code className="rounded bg-zinc-200 px-1 py-0.5 text-xs dark:bg-zinc-800">
+                        …-aarch64.AppImage
+                      </code>{" "}
+                      on{" "}
+                      <a
+                        href="https://github.com/jatinkrmalik/vocalinux/releases"
+                        className="font-semibold text-primary hover:underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        GitHub Releases
+                      </a>{" "}
+                      (new tags and nightlies).{" "}
+                      <code className="rounded bg-zinc-200 px-1 py-0.5 text-xs dark:bg-zinc-800">
+                        chmod +x
+                      </code>{" "}
+                      and run. Host still needs{" "}
+                      <code className="rounded bg-zinc-200 px-1 py-0.5 text-xs dark:bg-zinc-800">
+                        xdotool
+                      </code>
+                      /{" "}
+                      <code className="rounded bg-zinc-200 px-1 py-0.5 text-xs dark:bg-zinc-800">
+                        wtype
+                      </code>
+                      /{" "}
+                      <code className="rounded bg-zinc-200 px-1 py-0.5 text-xs dark:bg-zinc-800">
+                        ydotool
+                      </code>
+                      .
+                    </li>
+                    <li>
+                      <strong className="text-foreground">Arch (AUR):</strong>{" "}
+                      <code className="rounded bg-zinc-200 px-1 py-0.5 text-xs dark:bg-zinc-800">
+                        yay -S vocalinux
+                      </code>
+                    </li>
+                    <li>
+                      <strong className="text-foreground">Flatpak / PyPI:</strong>{" "}
+                      see the{" "}
+                      <a
+                        href="https://github.com/jatinkrmalik/vocalinux/blob/main/docs/INSTALL.md"
+                        className="font-semibold text-primary hover:underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        installation guide
+                      </a>
+                      .
+                    </li>
+                  </ul>
+                </div>
+
                 {/* What the installer does */}
                 <div className="mt-8 rounded-lg bg-zinc-50 p-4 dark:bg-zinc-900">
                   <h4 className="mb-3 font-semibold">


### PR DESCRIPTION
## Summary

Documents the AppImage packaging from #573 as a first-class install option alongside `install.sh`, PyPI, AUR, and Flatpak.

- **INSTALL.md**: download from GitHub Releases, `chmod +x`, run; `Vocalinux-<version>-x86_64.AppImage` / `…-aarch64.AppImage`; host still needs `xdotool` / `wtype` / `ydotool`
- **README**: short install option + roadmap checkbox
- **RELEASE_PROCESS**: checklist that release/nightly workflows attach AppImages
- **UPDATE.md**: packaging note for releases after the merge (does not claim AppImages on older tags such as v0.14.2)
- **Website** (`/` install section + `/install`): same portable path, consistent with INSTALL.md

Accuracy: AppImages ship on **new tags** and **nightlies** once the post-#573 workflows run. Current v0.14.2 and some nightlies may only have wheel/sdist until those jobs produce assets.

## Test plan

- [x] Relative markdown links resolve in-repo
- [x] `cd web && npm run build` succeeds
- [ ] Spot-check GitHub Releases wording against live assets after next tag/nightly