### PR TITLE
ci: automatically label PRs when changes are requested

### DIFF
--- a/.github/workflows/changes-requested-label.yml
+++ b/.github/workflows/changes-requested-label.yml
@@ -1,0 +1,108 @@
+name: Label Changes Requested
+
+on:
+  pull_request_target:
+    types: [synchronize]
+  pull_request_review:
+    types: [submitted, dismissed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Changes Requested label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = "Changes Requested";
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            async function ensureLabel() {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label,
+                  color: "d93f0b",
+                  description: "A reviewer has requested changes on this pull request",
+                });
+              }
+            }
+
+            async function hasChangesRequested() {
+              const { data: reviews } = await github.rest.pulls.listReviews({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+
+              const latestByUser = new Map();
+              for (const review of reviews) {
+                if (review.state === "PENDING") {
+                  continue;
+                }
+                latestByUser.set(review.user.login, review);
+              }
+
+              return [...latestByUser.values()].some(
+                (review) => review.state === "CHANGES_REQUESTED"
+              );
+            }
+
+            async function addLabel() {
+              await ensureLabel();
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: prNumber,
+                labels: [label],
+              });
+            }
+
+            async function removeLabel() {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: prNumber,
+                  name: label,
+                });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            if (context.eventName === "pull_request_review") {
+              const review = context.payload.review;
+
+              if (review.state === "changes_requested") {
+                await addLabel();
+                return;
+              }
+
+              if (review.state === "approved" || context.payload.action === "dismissed") {
+                if (!(await hasChangesRequested())) {
+                  await removeLabel();
+                }
+              }
+
+              return;
+            }
+
+            if (
+              context.eventName === "pull_request_target" &&
+              context.payload.action === "synchronize"
+            ) {
+              await removeLabel();
+            }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a GitHub Actions workflow that manages a **Changes Requested** label on pull requests based on review state.

### Behavior

- **Adds** the `Changes Requested` label when a reviewer submits a review requesting changes
- **Removes** the label when:
  - New commits are pushed to the PR (assuming feedback is being addressed)
  - All outstanding change requests are cleared (e.g. reviewer approves, or a changes-requested review is dismissed)
- **Creates** the label automatically on first use if it does not already exist (orange `#d93f0b`)

Uses `pull_request_target` for synchronize events so labeling works on fork PRs too, matching the existing labeler workflow pattern.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the code style of this project
- [x] No application code changes — CI workflow only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d4d84f8-c20e-4671-831e-f034ceda5f47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d4d84f8-c20e-4671-831e-f034ceda5f47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

