### PR TITLE
feat(text-injection): let config.json pin the injection backend

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -168,6 +168,52 @@ To check which backend is being used, look for these log messages when starting 
 [INFO] whisper.cpp configured with n_threads=16
 ```
 
+### Text injection backend
+
+Vocalinux types your dictated text using one of several backends. It picks one
+automatically, and on most desktops the automatic choice is correct.
+
+Autodetection can be wrong, though, and it fails in a way that is easy to
+misread: on a compositor that does not relay IBus commits to native Wayland
+applications, IBus reports the text as delivered while nothing appears. If
+dictation works in some windows (typically XWayland ones, like a browser) but
+silently does nothing in others, that is the symptom.
+
+Pin the backend explicitly in `~/.config/vocalinux/config.json`:
+
+```json
+{
+  "text_injection": {
+    "backend": "wtype"
+  }
+}
+```
+
+| Value | Backend |
+|---|---|
+| `auto` | Autodetect (default) |
+| `ibus` | IBus input method |
+| `wtype` | wtype virtual keyboard (Wayland) |
+| `ydotool` | ydotool uinput (Wayland; needs `ydotoold`) |
+
+The setting takes effect on the next start. When it is set to anything other
+than `ibus`, Vocalinux does not take the IBus path at all.
+
+On X11 the injection tool is always `xdotool`, so the practical choice there is
+`ibus` versus anything else: pinning a non-`ibus` value turns IBus off and
+dictates through `xdotool`, which is useful when IBus is unreliable in a
+particular application.
+
+To try a backend for a single run without changing the saved setting, set
+`VOCALINUX_FORCE_BACKEND`, which overrides the config value:
+
+```bash
+VOCALINUX_FORCE_BACKEND=wtype vocalinux --debug
+```
+
+Either way, the startup log records which backend was pinned and where the
+choice came from, so `vocalinux --debug` will confirm it took effect.
+
 ### Auto-pause and model keep-alive
 
 Optional power-saving controls live under settings:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -194,6 +194,23 @@ To check which backend is being used, look for these log messages when starting 
 [INFO] whisper.cpp configured with n_threads=4 (GPU backend: vulkan)
 ```
 
+### Auto-pause and model keep-alive
+
+Optional power-saving controls live under settings:
+
+- **Auto-pause apps** — unload the speech model while configured apps/games are running, then reload when they exit
+- **Model keep-alive** — unload the model after a configurable idle timeout so idle dictation does not keep GPU/CPU resources warm
+
+## Troubleshooting
+
+If you encounter issues, check the [Installation Guide](INSTALL.md) troubleshooting section or run the application with debug logging:
+
+```bash
+vocalinux --debug
+```
+
+Check the logs for error messages and possible solutions.
+
 ### Text injection backend
 
 Vocalinux types your dictated text using one of several backends. It picks one
@@ -240,20 +257,3 @@ VOCALINUX_FORCE_BACKEND=wtype vocalinux --debug
 
 Either way, the startup log records which backend was pinned and where the
 choice came from, so `vocalinux --debug` will confirm it took effect.
-
-### Auto-pause and model keep-alive
-
-Optional power-saving controls live under settings:
-
-- **Auto-pause apps** — unload the speech model while configured apps/games are running, then reload when they exit
-- **Model keep-alive** — unload the model after a configurable idle timeout so idle dictation does not keep GPU/CPU resources warm
-
-## Troubleshooting
-
-If you encounter issues, check the [Installation Guide](INSTALL.md) troubleshooting section or run the application with debug logging:
-
-```bash
-vocalinux --debug
-```
-
-Check the logs for error messages and possible solutions.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -194,6 +194,52 @@ To check which backend is being used, look for these log messages when starting 
 [INFO] whisper.cpp configured with n_threads=4 (GPU backend: vulkan)
 ```
 
+### Text injection backend
+
+Vocalinux types your dictated text using one of several backends. It picks one
+automatically, and on most desktops the automatic choice is correct.
+
+Autodetection can be wrong, though, and it fails in a way that is easy to
+misread: on a compositor that does not relay IBus commits to native Wayland
+applications, IBus reports the text as delivered while nothing appears. If
+dictation works in some windows (typically XWayland ones, like a browser) but
+silently does nothing in others, that is the symptom.
+
+Pin the backend explicitly in `~/.config/vocalinux/config.json`:
+
+```json
+{
+  "text_injection": {
+    "backend": "wtype"
+  }
+}
+```
+
+| Value | Backend |
+|---|---|
+| `auto` | Autodetect (default) |
+| `ibus` | IBus input method |
+| `wtype` | wtype virtual keyboard (Wayland) |
+| `ydotool` | ydotool uinput (Wayland; needs `ydotoold`) |
+
+The setting takes effect on the next start. When it is set to anything other
+than `ibus`, Vocalinux does not take the IBus path at all.
+
+On X11 the injection tool is always `xdotool`, so the practical choice there is
+`ibus` versus anything else: pinning a non-`ibus` value turns IBus off and
+dictates through `xdotool`, which is useful when IBus is unreliable in a
+particular application.
+
+To try a backend for a single run without changing the saved setting, set
+`VOCALINUX_FORCE_BACKEND`, which overrides the config value:
+
+```bash
+VOCALINUX_FORCE_BACKEND=wtype vocalinux --debug
+```
+
+Either way, the startup log records which backend was pinned and where the
+choice came from, so `vocalinux --debug` will confirm it took effect.
+
 ### Auto-pause and model keep-alive
 
 Optional power-saving controls live under settings:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -221,14 +221,15 @@ Pin the backend explicitly in `~/.config/vocalinux/config.json`:
 | `ibus` | IBus input method |
 | `wtype` | wtype virtual keyboard (Wayland) |
 | `ydotool` | ydotool uinput (Wayland; needs `ydotoold`) |
+| `xdotool` | xdotool (X11). On Wayland it only turns IBus off -- the Wayland tool is still picked automatically |
 
 The setting takes effect on the next start. When it is set to anything other
 than `ibus`, Vocalinux does not take the IBus path at all.
 
-On X11 the injection tool is always `xdotool`, so the practical choice there is
-`ibus` versus anything else: pinning a non-`ibus` value turns IBus off and
-dictates through `xdotool`, which is useful when IBus is unreliable in a
-particular application.
+On X11 the injection tool is `xdotool` regardless of which non-`ibus` value you
+pin, so `xdotool` is the name to use there when IBus is unreliable in a
+particular application. Pinning `ibus` keeps the IBus path; pinning anything
+else turns it off.
 
 To try a backend for a single run without changing the saved setting, set
 `VOCALINUX_FORCE_BACKEND`, which overrides the config value:

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -475,6 +475,9 @@ class TextInjector:
 
         Accepts ``ibus``, ``wtype``, ``ydotool`` or ``auto``. Anything else is
         ignored with a warning, so a typo cannot silently pin a backend.
+
+        This covers the environment variable only. ``_backend_preference()``
+        combines it with the persistent ``text_injection.backend`` setting.
         """
         value = os.environ.get("VOCALINUX_FORCE_BACKEND", "").strip().lower()
         if not value or value == "auto":
@@ -487,12 +490,61 @@ class TextInjector:
         )
         return "auto"
 
+    @staticmethod
+    def _configured_backend() -> str:
+        """Backend pinned via ``text_injection.backend`` in config.json, or ``"auto"``.
+
+        The environment variable is fine for a one-off experiment, but a user
+        whose compositor is autodetected wrongly needs the choice to survive a
+        restart without wrapping the launcher in a shell script (issue #476).
+
+        Read from disk rather than through ConfigManager to keep this package
+        independent of the UI layer, matching ``_should_copy_to_clipboard()``.
+        """
+        try:
+            import json
+
+            config_path = os.path.join(config_dir(), "config.json")
+            if not os.path.exists(config_path):
+                return "auto"
+            with open(config_path, "r") as f:
+                config = json.load(f)
+            value = str(config.get("text_injection", {}).get("backend", "") or "").strip().lower()
+            if not value or value == "auto":
+                return "auto"
+            if value in ("ibus", "wtype", "ydotool"):
+                return value
+            logger.warning(
+                "Ignoring unknown text_injection.backend=%r (expected ibus/wtype/ydotool/auto)",
+                value,
+            )
+        except Exception as e:  # unreadable/corrupt config must not block startup
+            logger.debug(f"Could not read text_injection.backend setting: {e}")
+        return "auto"
+
+    @staticmethod
+    def _backend_preference() -> str:
+        """The backend to pin, from the environment or config.json.
+
+        ``VOCALINUX_FORCE_BACKEND`` wins so a backend can still be A/B-tested
+        for one run without editing (or permanently changing) the user's config.
+        """
+        forced = TextInjector._forced_backend()
+        if forced != "auto":
+            return forced
+        return TextInjector._configured_backend()
+
     def _check_dependencies(self):
         """Check for the required tools for text injection."""
         ibus_requested = False
-        forced = self._forced_backend()
+        forced = self._backend_preference()
         if forced != "auto":
-            logger.info("VOCALINUX_FORCE_BACKEND=%s: overriding backend autodetection", forced)
+            source = (
+                "VOCALINUX_FORCE_BACKEND"
+                if self._forced_backend() != "auto"
+                else "text_injection.backend"
+            )
+            logger.info("%s=%s: overriding backend autodetection", source, forced)
 
         # Prefer IBus on both X11 and Wayland - it sends Unicode directly,
         # bypassing keyboard layout issues entirely

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -460,6 +460,37 @@ class TextInjector:
         return False
 
     @staticmethod
+    def _forced_backend_setting() -> Optional[str]:
+        """``VOCALINUX_FORCE_BACKEND`` as three distinct states.
+
+        ``None`` when the variable is not set, ``"auto"`` when it is explicitly
+        set to auto, otherwise the backend name. The distinction matters:
+        ``auto`` is how a user asks for autodetection *this run* despite a saved
+        ``text_injection.backend`` pin, which is the one-run A/B test this
+        variable exists for. Collapsing it into "nothing was set" would let the
+        saved pin win and make the variable useless for that.
+
+        Accepts ``ibus``, ``wtype``, ``ydotool`` or ``auto``.
+        """
+        raw = os.environ.get("VOCALINUX_FORCE_BACKEND")
+        if raw is None:
+            return None
+        value = raw.strip().lower()
+        if not value:
+            return None
+        if value == "auto":
+            return "auto"
+        if value in ("ibus", "wtype", "ydotool"):
+            return value
+        logger.warning(
+            "Ignoring unknown VOCALINUX_FORCE_BACKEND=%r (expected ibus/wtype/ydotool/auto)",
+            value,
+        )
+        # Deliberately unset rather than "auto": a typo in a shell variable should
+        # not discard a valid saved pin, only fail to override it.
+        return None
+
+    @staticmethod
     def _forced_backend() -> str:
         """Backend pinned via ``VOCALINUX_FORCE_BACKEND``, or ``"auto"``.
 
@@ -473,18 +504,11 @@ class TextInjector:
         ignored with a warning, so a typo cannot silently pin a backend.
 
         This covers the environment variable only. ``_backend_preference()``
-        combines it with the persistent ``text_injection.backend`` setting.
+        combines it with the persistent ``text_injection.backend`` setting, and
+        needs unset and an explicit ``auto`` told apart -- see
+        ``_forced_backend_setting()``.
         """
-        value = os.environ.get("VOCALINUX_FORCE_BACKEND", "").strip().lower()
-        if not value or value == "auto":
-            return "auto"
-        if value in ("ibus", "wtype", "ydotool"):
-            return value
-        logger.warning(
-            "Ignoring unknown VOCALINUX_FORCE_BACKEND=%r (expected ibus/wtype/ydotool/auto)",
-            value,
-        )
-        return "auto"
+        return TextInjector._forced_backend_setting() or "auto"
 
     def _resolve_wayland_key_tool(self) -> Optional[str]:
         """Pick (or reuse) the Wayland virtual-keyboard tool for key events.
@@ -557,10 +581,12 @@ class TextInjector:
 
         ``VOCALINUX_FORCE_BACKEND`` wins so a backend can still be A/B-tested
         for one run without editing (or permanently changing) the user's config.
+        That includes an explicit ``auto``, which asks for autodetection this run
+        and so must short-circuit here rather than fall through to the saved pin.
         """
-        forced = TextInjector._forced_backend()
-        if forced != "auto":
-            return forced
+        env = TextInjector._forced_backend_setting()
+        if env is not None:
+            return env
         return TextInjector._configured_backend()
 
     def _check_dependencies(self):

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -681,7 +681,12 @@ class TextInjector:
         forced, pin_source = self._resolve_backend_pin()
         self._backend_pin = (forced, pin_source)
         if pin_source and forced != "auto":
-            logger.info("%s=%s: overriding backend autodetection", pin_source, forced)
+            # States the request, not the result. Nothing has been checked for
+            # availability yet, and an unavailable pin falls through to
+            # autodetection further down -- so a word like "overriding" here
+            # would describe an outcome this line cannot know, and would read as
+            # contradicting the "was not applied" warning when it does not hold.
+            logger.info("%s=%s: backend pin requested", pin_source, forced)
 
         # Prefer IBus on both X11 and Wayland - it sends Unicode directly,
         # bypassing keyboard layout issues entirely

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -240,6 +240,16 @@ class TextInjector:
         "weston",
     )
 
+    # Backends a user may pin explicitly, via VOCALINUX_FORCE_BACKEND or the
+    # text_injection.backend setting. Named once so the two readers and the two
+    # "expected ..." messages cannot drift apart as values are added.
+    _SELECTABLE_BACKENDS = ("ibus", "wtype", "ydotool", "xdotool")
+
+    @staticmethod
+    def _accepted_backends_help() -> str:
+        """The accepted pin values, for user-facing "expected ..." messages."""
+        return "/".join(TextInjector._SELECTABLE_BACKENDS) + "/auto"
+
     def _kde_virtual_keyboard_enabled(self) -> bool:
         """Return True when KWin VirtualKeyboard / input method is enabled.
 
@@ -480,11 +490,12 @@ class TextInjector:
             return None
         if value == "auto":
             return "auto"
-        if value in ("ibus", "wtype", "ydotool"):
+        if value in TextInjector._SELECTABLE_BACKENDS:
             return value
         logger.warning(
-            "Ignoring unknown VOCALINUX_FORCE_BACKEND=%r (expected ibus/wtype/ydotool/auto)",
+            "Ignoring unknown VOCALINUX_FORCE_BACKEND=%r (expected %s)",
             value,
+            TextInjector._accepted_backends_help(),
         )
         # Deliberately unset rather than "auto": a typo in a shell variable should
         # not discard a valid saved pin, only fail to override it.
@@ -565,11 +576,12 @@ class TextInjector:
             value = str(config.get("text_injection", {}).get("backend", "") or "").strip().lower()
             if not value or value == "auto":
                 return "auto"
-            if value in ("ibus", "wtype", "ydotool"):
+            if value in TextInjector._SELECTABLE_BACKENDS:
                 return value
             logger.warning(
-                "Ignoring unknown text_injection.backend=%r (expected ibus/wtype/ydotool/auto)",
+                "Ignoring unknown text_injection.backend=%r (expected %s)",
                 value,
+                TextInjector._accepted_backends_help(),
             )
         except Exception as e:  # unreadable/corrupt config must not block startup
             logger.debug(f"Could not read text_injection.backend setting: {e}")
@@ -657,6 +669,20 @@ class TextInjector:
                     os.environ.get("XDG_CURRENT_DESKTOP", "unknown"),
                 )
             else:
+                # force_ibus short-circuits all three guards above, so a pinned
+                # run arrives here without any of them having been evaluated.
+                # This warns for the compositor guard only: that is the case
+                # with a documented silent failure (#478, #485), where IBus
+                # reports the commit as delivered and the text never arrives.
+                # The other two guards are out of scope for this warning.
+                if force_ibus and not self._wayland_compositor_bridges_ibus():
+                    logger.warning(
+                        "Compositor '%s' does not bridge IBus to native Wayland apps, but an "
+                        "explicit ibus pin overrides that check. Dictation may silently do "
+                        "nothing in native Wayland windows; remove the pin to fall back to "
+                        "wtype/ydotool.",
+                        os.environ.get("XDG_CURRENT_DESKTOP", "unknown"),
+                    )
                 try:
                     if wayland_scoped_ibus and not ibus_active:
                         logger.info(

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -471,6 +471,9 @@ class TextInjector:
 
         Accepts ``ibus``, ``wtype``, ``ydotool`` or ``auto``. Anything else is
         ignored with a warning, so a typo cannot silently pin a backend.
+
+        This covers the environment variable only. ``_backend_preference()``
+        combines it with the persistent ``text_injection.backend`` setting.
         """
         value = os.environ.get("VOCALINUX_FORCE_BACKEND", "").strip().lower()
         if not value or value == "auto":
@@ -516,12 +519,61 @@ class TextInjector:
         logger.info(f"Using {tool} for Wayland key events")
         return tool
 
+    @staticmethod
+    def _configured_backend() -> str:
+        """Backend pinned via ``text_injection.backend`` in config.json, or ``"auto"``.
+
+        The environment variable is fine for a one-off experiment, but a user
+        whose compositor is autodetected wrongly needs the choice to survive a
+        restart without wrapping the launcher in a shell script (issue #476).
+
+        Read from disk rather than through ConfigManager to keep this package
+        independent of the UI layer, matching ``_should_copy_to_clipboard()``.
+        """
+        try:
+            import json
+
+            config_path = os.path.join(config_dir(), "config.json")
+            if not os.path.exists(config_path):
+                return "auto"
+            with open(config_path, "r") as f:
+                config = json.load(f)
+            value = str(config.get("text_injection", {}).get("backend", "") or "").strip().lower()
+            if not value or value == "auto":
+                return "auto"
+            if value in ("ibus", "wtype", "ydotool"):
+                return value
+            logger.warning(
+                "Ignoring unknown text_injection.backend=%r (expected ibus/wtype/ydotool/auto)",
+                value,
+            )
+        except Exception as e:  # unreadable/corrupt config must not block startup
+            logger.debug(f"Could not read text_injection.backend setting: {e}")
+        return "auto"
+
+    @staticmethod
+    def _backend_preference() -> str:
+        """The backend to pin, from the environment or config.json.
+
+        ``VOCALINUX_FORCE_BACKEND`` wins so a backend can still be A/B-tested
+        for one run without editing (or permanently changing) the user's config.
+        """
+        forced = TextInjector._forced_backend()
+        if forced != "auto":
+            return forced
+        return TextInjector._configured_backend()
+
     def _check_dependencies(self):
         """Check for the required tools for text injection."""
         ibus_requested = False
-        forced = self._forced_backend()
+        forced = self._backend_preference()
         if forced != "auto":
-            logger.info("VOCALINUX_FORCE_BACKEND=%s: overriding backend autodetection", forced)
+            source = (
+                "VOCALINUX_FORCE_BACKEND"
+                if self._forced_backend() != "auto"
+                else "text_injection.backend"
+            )
+            logger.info("%s=%s: overriding backend autodetection", source, forced)
 
         # Prefer IBus on both X11 and Wayland - it sends Unicode directly,
         # bypassing keyboard layout issues entirely

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -570,27 +570,67 @@ class TextInjector:
 
         Read from disk rather than through ConfigManager to keep this package
         independent of the UI layer, matching ``_should_copy_to_clipboard()``.
-        """
-        try:
-            import json
 
-            config_path = os.path.join(config_dir(), "config.json")
-            if not os.path.exists(config_path):
-                return "auto"
+        A file that cannot be used is reported at warning level, not debug. This
+        setting is hand-edited, so a stray comma is a likely way to reach it, and
+        the symptom of staying quiet is the silent IBus miss the pin was set to
+        avoid -- indistinguishable from the pin simply not working.
+
+        The two shape checks below are what keep the lookup total, so the
+        handler only has to cover reading and parsing. Locating the file is
+        deliberately outside the handler: ``config_dir()`` resolving a path is
+        not a failure this should paper over, and computing it inside the
+        ``try`` only meant the handler could not name the file it failed on.
+        """
+        import json
+
+        config_path = os.path.join(config_dir(), "config.json")
+        if not os.path.exists(config_path):
+            return "auto"
+
+        try:
             with open(config_path, "r") as f:
                 config = json.load(f)
-            value = str(config.get("text_injection", {}).get("backend", "") or "").strip().lower()
-            if not value or value == "auto":
-                return "auto"
-            if value in TextInjector._SELECTABLE_BACKENDS:
-                return value
+        except (OSError, ValueError) as e:
+            # Corrupt or unreadable must not block startup, but must not pass
+            # unmentioned either: the user edited this file expecting an effect.
             logger.warning(
-                "Ignoring unknown text_injection.backend=%r (expected %s)",
-                value,
-                TextInjector._accepted_backends_help(),
+                "Ignoring text_injection.backend: could not read %s (%s). "
+                "Continuing with backend autodetection.",
+                config_path,
+                e,
             )
-        except Exception as e:  # unreadable/corrupt config must not block startup
-            logger.debug(f"Could not read text_injection.backend setting: {e}")
+            return "auto"
+
+        if not isinstance(config, dict):
+            logger.warning(
+                "Ignoring text_injection.backend: %s is not a JSON object. "
+                "Continuing with backend autodetection.",
+                config_path,
+            )
+            return "auto"
+
+        section = config.get("text_injection")
+        if section is None:
+            return "auto"
+        if not isinstance(section, dict):
+            logger.warning(
+                "Ignoring text_injection.backend: the text_injection section of %s "
+                "is not a JSON object. Continuing with backend autodetection.",
+                config_path,
+            )
+            return "auto"
+
+        value = str(section.get("backend", "") or "").strip().lower()
+        if not value or value == "auto":
+            return "auto"
+        if value in TextInjector._SELECTABLE_BACKENDS:
+            return value
+        logger.warning(
+            "Ignoring unknown text_injection.backend=%r (expected %s)",
+            value,
+            TextInjector._accepted_backends_help(),
+        )
         return "auto"
 
     @staticmethod

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -14,7 +14,7 @@ import subprocess
 import threading
 import time
 from enum import Enum
-from typing import Optional  # noqa: F401
+from typing import Optional, Tuple  # noqa: F401
 
 from ..utils.host_process import host_env
 from ..utils.paths import config_dir
@@ -106,6 +106,7 @@ class TextInjector:
             wayland_mode: Force Wayland compatibility mode
         """
         self._ibus_injector: Optional[IBusTextInjector] = None
+        self._backend_pin: Tuple[str, Optional[str]] = ("auto", None)
         self.environment = self._detect_environment()
         self._session_environment = self.environment
         self._ibus_ready = False
@@ -167,6 +168,11 @@ class TextInjector:
                 self._test_xdotool_fallback()
             except Exception as e:
                 logger.error(f"XWayland fallback test failed: {e}")
+
+        # Last, so it sees the final selection: _check_dependencies() returns early
+        # on two paths, and the wtype probe above can still demote a pin that was
+        # honoured up to that point.
+        self._warn_if_pin_not_honoured(*self._backend_pin)
 
     def stop(self) -> None:
         """
@@ -588,8 +594,14 @@ class TextInjector:
         return "auto"
 
     @staticmethod
-    def _backend_preference() -> str:
-        """The backend to pin, from the environment or config.json.
+    def _resolve_backend_pin() -> Tuple[str, Optional[str]]:
+        """The pinned backend and where it came from, resolved once.
+
+        Returns ``(backend, source)``. ``source`` names the setting that won, or
+        is ``None`` when nothing pinned anything. Both come from a single pass so
+        callers that report the source cannot disagree with the value actually
+        used -- and so the environment is parsed once per construction, which
+        also means a malformed value is reported once rather than per caller.
 
         ``VOCALINUX_FORCE_BACKEND`` wins so a backend can still be A/B-tested
         for one run without editing (or permanently changing) the user's config.
@@ -598,20 +610,78 @@ class TextInjector:
         """
         env = TextInjector._forced_backend_setting()
         if env is not None:
-            return env
-        return TextInjector._configured_backend()
+            return env, "VOCALINUX_FORCE_BACKEND"
+        configured = TextInjector._configured_backend()
+        if configured != "auto":
+            return configured, "text_injection.backend"
+        return "auto", None
+
+    @staticmethod
+    def _backend_preference() -> str:
+        """The backend to pin, from the environment or config.json."""
+        return TextInjector._resolve_backend_pin()[0]
+
+    def _resolved_backend(self) -> Optional[str]:
+        """The backend actually in effect, read back from final state.
+
+        Deliberately reads ``environment`` before ``wayland_tool``: the wtype
+        probe in ``__init__`` demotes a failed wtype to ``WAYLAND_XDOTOOL``
+        without clearing ``wayland_tool``, and ``inject_text()`` follows
+        ``environment``. Reading the tool first would report wtype while
+        injection actually goes through XWayland.
+        """
+        if self._ibus_injector is not None or self.environment in (
+            DesktopEnvironment.X11_IBUS,
+            DesktopEnvironment.WAYLAND_IBUS,
+        ):
+            return "ibus"
+        if self.environment in (
+            DesktopEnvironment.X11,
+            DesktopEnvironment.WAYLAND_XDOTOOL,
+        ):
+            return "xdotool"
+        return getattr(self, "wayland_tool", None)
+
+    def _warn_if_pin_not_honoured(self, pinned: str, source: Optional[str]) -> None:
+        """Say so when the backend in use is not the one that was pinned.
+
+        One comparison rather than a check per cause: a missing binary, a value
+        that does not apply to this session type, IBus being unavailable and the
+        wtype probe demoting to XWayland all end the same way -- something other
+        than the pinned backend is doing the typing -- and a new cause is covered
+        without adding a branch here.
+
+        This is a startup diagnostic, not a live invariant. It runs once, at the
+        end of construction. ``_try_recover_from_fallback()`` can later switch
+        the tool when ydotoold appears mid-session, so a pin that becomes
+        honoured (or stops being honoured) after startup is not reported again.
+        """
+        if not source or pinned == "auto":
+            return
+        resolved = self._resolved_backend()
+        # Unreachable today (every path either sets a backend or raises before
+        # construction finishes), but guarded so a future path cannot render
+        # "using None instead" at a user.
+        if resolved is None or resolved == pinned:
+            return
+
+        if pinned in self._SELECTABLE_BACKENDS and pinned != "ibus":
+            reason = f" ({pinned} is not installed)" if not shutil.which(pinned) else ""
+        elif pinned == "ibus" and not is_ibus_available():
+            reason = " (IBus support is not available)"
+        else:
+            reason = ""
+        logger.warning(
+            "%s=%s was not applied%s; using %s instead.", source, pinned, reason, resolved
+        )
 
     def _check_dependencies(self):
         """Check for the required tools for text injection."""
         ibus_requested = False
-        forced = self._backend_preference()
-        if forced != "auto":
-            source = (
-                "VOCALINUX_FORCE_BACKEND"
-                if self._forced_backend() != "auto"
-                else "text_injection.backend"
-            )
-            logger.info("%s=%s: overriding backend autodetection", source, forced)
+        forced, pin_source = self._resolve_backend_pin()
+        self._backend_pin = (forced, pin_source)
+        if pin_source and forced != "auto":
+            logger.info("%s=%s: overriding backend autodetection", pin_source, forced)
 
         # Prefer IBus on both X11 and Wayland - it sends Unicode directly,
         # bypassing keyboard layout issues entirely
@@ -714,11 +784,11 @@ class TextInjector:
             # ydotool for native Wayland typing; wtype needs a Wayland socket.
             if forced == "wtype" and wtype_available:
                 self.wayland_tool = "wtype"
-                logger.info("VOCALINUX_FORCE_BACKEND=wtype: using wtype for Wayland injection")
+                logger.info("%s=wtype: using wtype for Wayland injection", pin_source)
             elif forced == "ydotool" and ydotool_available:
                 self._ensure_ydotoold()
                 self.wayland_tool = "ydotool"
-                logger.info("VOCALINUX_FORCE_BACKEND=ydotool: using ydotool for Wayland injection")
+                logger.info("%s=ydotool: using ydotool for Wayland injection", pin_source)
             elif ydotool_available and self._ensure_ydotoold():
                 self.wayland_tool = "ydotool"
                 logger.info("Using ydotool for Wayland text injection")

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -80,6 +80,10 @@ DEFAULT_CONFIG = {
         # the next dictation session (push-to-talk / toggle) continues cleanly
         # without glueing onto the previous sentence ("Hello.This").
         "append_trailing_space": True,
+        # Text-injection backend: "auto" autodetects, or pin "ibus"/"wtype"/
+        # "ydotool" when the autodetection is wrong for your compositor (#476).
+        # VOCALINUX_FORCE_BACKEND overrides this for a single run.
+        "backend": "auto",
     },
     "advanced": {
         "power_user_mode": False,

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -140,6 +140,10 @@ DEFAULT_CONFIG = {
         # Clipboard-paste chord: auto-detect terminals, or force Ctrl+V /
         # Ctrl+Shift+V when a nested terminal panel is not detected.
         "paste_shortcut": "auto",
+        # Text-injection backend: "auto" autodetects, or pin "ibus"/"wtype"/
+        # "ydotool" when the autodetection is wrong for your compositor (#476).
+        # VOCALINUX_FORCE_BACKEND overrides this for a single run.
+        "backend": "auto",
     },
     "advanced": {
         "power_user_mode": False,

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -2,12 +2,14 @@
 Tests for text injection functionality.
 """
 
+import contextlib
+import json
 import os
 import subprocess
 import sys
 import threading
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 # Update import path to use the new package structure
 from vocalinux.text_injection.text_injector import (
@@ -2226,6 +2228,85 @@ class TestCompositorIBusBridging(unittest.TestCase):
             ):
                 injector = TextInjector()
         self.assertEqual(injector.wayland_tool, "ydotool")
+
+
+@contextlib.contextmanager
+def _fake_config(config):
+    """Pretend config.json holds ``config``; ``None`` means no file at all.
+
+    Kept off the filesystem on purpose: another suite patches
+    ``tempfile.mkdtemp`` globally, so a real temp dir makes these tests
+    order-dependent.
+    """
+    with patch("vocalinux.text_injection.text_injector.config_dir", return_value="/fake/config"):
+        if config is None:
+            with patch("os.path.exists", return_value=False):
+                yield
+            return
+        payload = config if isinstance(config, str) else json.dumps(config)
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=payload)):
+                yield
+
+
+class TestConfiguredBackend(unittest.TestCase):
+    """text_injection.backend in config.json pins the injection backend (#476)."""
+
+    def test_recognised_backends(self):
+        for value in ("ibus", "wtype", "ydotool"):
+            with _fake_config({"text_injection": {"backend": value}}):
+                self.assertEqual(TextInjector._configured_backend(), value)
+
+    def test_value_is_normalised(self):
+        with _fake_config({"text_injection": {"backend": "  WType  "}}):
+            self.assertEqual(TextInjector._configured_backend(), "wtype")
+
+    def test_auto_or_missing_means_auto(self):
+        for config in (
+            {"text_injection": {"backend": "auto"}},
+            {"text_injection": {"backend": ""}},
+            {"text_injection": {}},
+            {},
+            None,  # no config.json at all
+        ):
+            with _fake_config(config):
+                self.assertEqual(TextInjector._configured_backend(), "auto")
+
+    def test_unknown_value_falls_back_to_auto(self):
+        """A typo must not silently pin the wrong backend."""
+        with _fake_config({"text_injection": {"backend": "wtpye"}}):
+            self.assertEqual(TextInjector._configured_backend(), "auto")
+
+    def test_corrupt_config_does_not_raise(self):
+        """An unreadable config must not stop text injection from starting."""
+        with _fake_config("{not valid json"):
+            self.assertEqual(TextInjector._configured_backend(), "auto")
+
+
+class TestBackendPreference(unittest.TestCase):
+    """The environment variable wins over the persisted setting."""
+
+    def test_environment_overrides_config(self):
+        """A one-off experiment must not require editing the user's config."""
+        with _fake_config({"text_injection": {"backend": "ibus"}}):
+            with patch.dict("os.environ", {"VOCALINUX_FORCE_BACKEND": "wtype"}):
+                self.assertEqual(TextInjector._backend_preference(), "wtype")
+
+    def test_config_used_when_environment_unset(self):
+        with _fake_config({"text_injection": {"backend": "ydotool"}}):
+            with patch.dict("os.environ", {}, clear=True):
+                self.assertEqual(TextInjector._backend_preference(), "ydotool")
+
+    def test_auto_when_neither_is_set(self):
+        with _fake_config(None):
+            with patch.dict("os.environ", {}, clear=True):
+                self.assertEqual(TextInjector._backend_preference(), "auto")
+
+    def test_invalid_environment_value_still_falls_back_to_config(self):
+        """A typo in the variable must not discard a valid saved preference."""
+        with _fake_config({"text_injection": {"backend": "wtype"}}):
+            with patch.dict("os.environ", {"VOCALINUX_FORCE_BACKEND": "wtpye"}):
+                self.assertEqual(TextInjector._backend_preference(), "wtype")
 
 
 class TestForcedBackend(unittest.TestCase):

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -2397,6 +2397,33 @@ class TestBackendPreference(unittest.TestCase):
                 self.assertEqual(TextInjector._backend_preference(), "wtype")
 
 
+class TestSelectableBackends(unittest.TestCase):
+    """xdotool is a pinnable value, and both readers accept the same set."""
+
+    def test_xdotool_is_accepted_from_the_environment(self):
+        with patch.dict("os.environ", {"VOCALINUX_FORCE_BACKEND": "xdotool"}):
+            self.assertEqual(TextInjector._forced_backend_setting(), "xdotool")
+
+    def test_xdotool_is_accepted_from_config(self):
+        with _fake_config({"text_injection": {"backend": "xdotool"}}):
+            self.assertEqual(TextInjector._configured_backend(), "xdotool")
+
+    def test_both_readers_accept_the_same_values(self):
+        """A value valid in one source must be valid in the other."""
+        for value in TextInjector._SELECTABLE_BACKENDS:
+            with patch.dict("os.environ", {"VOCALINUX_FORCE_BACKEND": value}):
+                self.assertEqual(TextInjector._forced_backend_setting(), value)
+            with _fake_config({"text_injection": {"backend": value}}):
+                self.assertEqual(TextInjector._configured_backend(), value)
+
+    def test_help_text_lists_every_selectable_value(self):
+        """Guards the 'expected ...' messages against drifting from the tuple."""
+        help_text = TextInjector._accepted_backends_help()
+        for value in TextInjector._SELECTABLE_BACKENDS:
+            self.assertIn(value, help_text)
+        self.assertIn("auto", help_text)
+
+
 class TestForcedBackendSetting(unittest.TestCase):
     """The raw three-state reading of VOCALINUX_FORCE_BACKEND.
 

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -2,13 +2,15 @@
 Tests for text injection functionality.
 """
 
+import contextlib
+import json
 import os
 import subprocess
 import sys
 import threading
 import unittest
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 # Update import path to use the new package structure
 from vocalinux.text_injection.text_injector import (
@@ -2292,6 +2294,85 @@ class TestCompositorIBusBridging(unittest.TestCase):
             ):
                 injector = TextInjector()
         self.assertEqual(injector.wayland_tool, "ydotool")
+
+
+@contextlib.contextmanager
+def _fake_config(config):
+    """Pretend config.json holds ``config``; ``None`` means no file at all.
+
+    Kept off the filesystem on purpose: another suite patches
+    ``tempfile.mkdtemp`` globally, so a real temp dir makes these tests
+    order-dependent.
+    """
+    with patch("vocalinux.text_injection.text_injector.config_dir", return_value="/fake/config"):
+        if config is None:
+            with patch("os.path.exists", return_value=False):
+                yield
+            return
+        payload = config if isinstance(config, str) else json.dumps(config)
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=payload)):
+                yield
+
+
+class TestConfiguredBackend(unittest.TestCase):
+    """text_injection.backend in config.json pins the injection backend (#476)."""
+
+    def test_recognised_backends(self):
+        for value in ("ibus", "wtype", "ydotool"):
+            with _fake_config({"text_injection": {"backend": value}}):
+                self.assertEqual(TextInjector._configured_backend(), value)
+
+    def test_value_is_normalised(self):
+        with _fake_config({"text_injection": {"backend": "  WType  "}}):
+            self.assertEqual(TextInjector._configured_backend(), "wtype")
+
+    def test_auto_or_missing_means_auto(self):
+        for config in (
+            {"text_injection": {"backend": "auto"}},
+            {"text_injection": {"backend": ""}},
+            {"text_injection": {}},
+            {},
+            None,  # no config.json at all
+        ):
+            with _fake_config(config):
+                self.assertEqual(TextInjector._configured_backend(), "auto")
+
+    def test_unknown_value_falls_back_to_auto(self):
+        """A typo must not silently pin the wrong backend."""
+        with _fake_config({"text_injection": {"backend": "wtpye"}}):
+            self.assertEqual(TextInjector._configured_backend(), "auto")
+
+    def test_corrupt_config_does_not_raise(self):
+        """An unreadable config must not stop text injection from starting."""
+        with _fake_config("{not valid json"):
+            self.assertEqual(TextInjector._configured_backend(), "auto")
+
+
+class TestBackendPreference(unittest.TestCase):
+    """The environment variable wins over the persisted setting."""
+
+    def test_environment_overrides_config(self):
+        """A one-off experiment must not require editing the user's config."""
+        with _fake_config({"text_injection": {"backend": "ibus"}}):
+            with patch.dict("os.environ", {"VOCALINUX_FORCE_BACKEND": "wtype"}):
+                self.assertEqual(TextInjector._backend_preference(), "wtype")
+
+    def test_config_used_when_environment_unset(self):
+        with _fake_config({"text_injection": {"backend": "ydotool"}}):
+            with patch.dict("os.environ", {}, clear=True):
+                self.assertEqual(TextInjector._backend_preference(), "ydotool")
+
+    def test_auto_when_neither_is_set(self):
+        with _fake_config(None):
+            with patch.dict("os.environ", {}, clear=True):
+                self.assertEqual(TextInjector._backend_preference(), "auto")
+
+    def test_invalid_environment_value_still_falls_back_to_config(self):
+        """A typo in the variable must not discard a valid saved preference."""
+        with _fake_config({"text_injection": {"backend": "wtype"}}):
+            with patch.dict("os.environ", {"VOCALINUX_FORCE_BACKEND": "wtpye"}):
+                self.assertEqual(TextInjector._backend_preference(), "wtype")
 
 
 class TestForcedBackend(unittest.TestCase):

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -2344,9 +2344,66 @@ class TestConfiguredBackend(unittest.TestCase):
             self.assertEqual(TextInjector._configured_backend(), "auto")
 
     def test_corrupt_config_does_not_raise(self):
-        """An unreadable config must not stop text injection from starting."""
+        """An unreadable config must not stop text injection from starting.
+
+        Only that it survives; that it also says so is
+        test_corrupt_config_warns_that_the_pin_is_ignored.
+        """
         with _fake_config("{not valid json"):
             self.assertEqual(TextInjector._configured_backend(), "auto")
+
+    def _warnings(self, logs):
+        return [line for line in logs.output if line.startswith("WARNING")]
+
+    def test_corrupt_config_warns_that_the_pin_is_ignored(self):
+        """A stray comma is the likely way to break a file people hand-edit.
+
+        Staying quiet leaves the user with autodetection and the silent IBus
+        miss they set the pin to avoid, with nothing to tell the two apart.
+        """
+        with _fake_config("{not valid json"):
+            with self.assertLogs("vocalinux.text_injection.text_injector", level="DEBUG") as logs:
+                self.assertEqual(TextInjector._configured_backend(), "auto")
+        warned = self._warnings(logs)
+        self.assertTrue(warned, f"corrupt config was not reported: {logs.output}")
+        self.assertIn("text_injection.backend", warned[0])
+
+    def test_config_that_is_not_an_object_warns(self):
+        """Valid JSON that is not an object reaches the lookup as a non-mapping.
+
+        Guarded rather than caught: the shape check is what lets the handler
+        stay narrow instead of swallowing every AttributeError raised below it.
+        """
+        with _fake_config("[1, 2, 3]"):
+            with self.assertLogs("vocalinux.text_injection.text_injector", level="DEBUG") as logs:
+                self.assertEqual(TextInjector._configured_backend(), "auto")
+        warned = self._warnings(logs)
+        self.assertTrue(warned, f"non-object config was not reported: {logs.output}")
+        self.assertIn("not a JSON object", warned[0])
+
+    def test_text_injection_section_that_is_not_an_object_warns(self):
+        """The top level being a mapping is not enough; the section can still not be.
+
+        Contrast with test_config_that_is_not_an_object_warns: a single
+        top-level check passes this input and then fails on the lookup.
+        """
+        with _fake_config({"text_injection": [1, 2]}):
+            with self.assertLogs("vocalinux.text_injection.text_injector", level="DEBUG") as logs:
+                self.assertEqual(TextInjector._configured_backend(), "auto")
+        warned = self._warnings(logs)
+        self.assertTrue(warned, f"non-object section was not reported: {logs.output}")
+        self.assertIn("text_injection section", warned[0])
+
+    def test_absent_config_is_not_reported(self):
+        """No config.json is the default install, not a problem to warn about."""
+        for config in (None, {}, {"text_injection": {}}):
+            with self.subTest(config=config):
+                # A mocked logger rather than assertLogs: the assertion is that
+                # nothing was logged, and assertLogs fails when nothing is.
+                with _fake_config(config):
+                    with patch("vocalinux.text_injection.text_injector.logger") as mock_logger:
+                        self.assertEqual(TextInjector._configured_backend(), "auto")
+                mock_logger.warning.assert_not_called()
 
 
 class TestBackendPreference(unittest.TestCase):

--- a/tests/test_text_injector.py
+++ b/tests/test_text_injector.py
@@ -2368,11 +2368,65 @@ class TestBackendPreference(unittest.TestCase):
             with patch.dict("os.environ", {}, clear=True):
                 self.assertEqual(TextInjector._backend_preference(), "auto")
 
-    def test_invalid_environment_value_still_falls_back_to_config(self):
-        """A typo in the variable must not discard a valid saved preference."""
+    def test_explicit_auto_overrides_a_saved_pin(self):
+        """``VOCALINUX_FORCE_BACKEND=auto`` asks for autodetection *this run*.
+
+        It must not be read as "nothing was set" and fall through to the saved
+        pin, or the variable cannot undo a pin for a single run -- which is the
+        one-off A/B test it exists for.
+        """
+        with _fake_config({"text_injection": {"backend": "wtype"}}):
+            with patch.dict("os.environ", {"VOCALINUX_FORCE_BACKEND": "auto"}):
+                self.assertEqual(TextInjector._backend_preference(), "auto")
+
+    def test_unset_environment_uses_the_saved_pin(self):
+        """Regression guard for the case explicit ``auto`` must NOT behave like."""
+        with _fake_config({"text_injection": {"backend": "wtype"}}):
+            with patch.dict("os.environ", {}, clear=True):
+                self.assertEqual(TextInjector._backend_preference(), "wtype")
+
+    def test_typo_in_environment_is_treated_as_unset_not_as_auto(self):
+        """A typo falls through to the saved pin rather than discarding it.
+
+        Deliberate: an unrecognised value means the user failed to override
+        their preference, not that they asked for autodetection. Contrast
+        ``test_explicit_auto_overrides_a_saved_pin``, where they did ask.
+        """
         with _fake_config({"text_injection": {"backend": "wtype"}}):
             with patch.dict("os.environ", {"VOCALINUX_FORCE_BACKEND": "wtpye"}):
                 self.assertEqual(TextInjector._backend_preference(), "wtype")
+
+
+class TestForcedBackendSetting(unittest.TestCase):
+    """The raw three-state reading of VOCALINUX_FORCE_BACKEND.
+
+    ``_forced_backend()`` collapses unset and explicit ``auto`` together, which
+    is fine for its own callers but loses the distinction ``_backend_preference()``
+    needs to tell "no opinion" from "autodetect this run".
+    """
+
+    def test_unset_is_none_and_is_distinct_from_explicit_auto(self):
+        with patch.dict("os.environ", {}, clear=True):
+            self.assertIsNone(TextInjector._forced_backend_setting())
+
+    def test_explicit_auto_is_the_string_not_none(self):
+        for value in ("auto", "  AUTO  "):
+            with patch.dict("os.environ", {"VOCALINUX_FORCE_BACKEND": value}):
+                self.assertEqual(TextInjector._forced_backend_setting(), "auto")
+
+    def test_empty_value_counts_as_unset(self):
+        with patch.dict("os.environ", {"VOCALINUX_FORCE_BACKEND": "   "}):
+            self.assertIsNone(TextInjector._forced_backend_setting())
+
+    def test_recognised_backends_are_returned(self):
+        for value in ("ibus", "wtype", "ydotool"):
+            with patch.dict("os.environ", {"VOCALINUX_FORCE_BACKEND": value.upper()}):
+                self.assertEqual(TextInjector._forced_backend_setting(), value)
+
+    def test_unknown_value_is_unset_rather_than_auto(self):
+        """See ``test_typo_in_environment_is_treated_as_unset_not_as_auto``."""
+        with patch.dict("os.environ", {"VOCALINUX_FORCE_BACKEND": "ibsu"}):
+            self.assertIsNone(TextInjector._forced_backend_setting())
 
 
 class TestForcedBackend(unittest.TestCase):

--- a/tests/test_text_injector_ext.py
+++ b/tests/test_text_injector_ext.py
@@ -6,7 +6,7 @@ import sys
 import threading
 import unittest
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -356,6 +356,36 @@ class TestCheckDependencies(unittest.TestCase):
                 {"XDG_SESSION_TYPE": "wayland", "VOCALINUX_FORCE_BACKEND": "wtype"},
                 clear=True,
             ),
+            patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=True),
+            patch("vocalinux.text_injection.text_injector.IBusTextInjector") as mock_ibus_class,
+            patch(
+                "shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}" if cmd in ("wtype", "ydotool") else None,
+            ),
+        ):
+            obj._check_dependencies()
+
+        self.assertEqual(obj.wayland_tool, "wtype")
+        mock_ibus_class.assert_not_called()
+
+    def test_config_backend_wtype_skips_ibus(self):
+        """text_injection.backend=wtype pins wtype with no environment variable set.
+
+        The environment variable is a one-off; this is the persisted setting from
+        issue #476, so it has to survive a restart on its own.
+        """
+        import json as _json
+
+        from vocalinux.text_injection.text_injector import DesktopEnvironment
+
+        obj = _make_injector(DesktopEnvironment.WAYLAND)
+        config = _json.dumps({"text_injection": {"backend": "wtype"}})
+
+        with (
+            patch.dict(os.environ, {"XDG_SESSION_TYPE": "wayland"}, clear=True),
+            patch("vocalinux.text_injection.text_injector.config_dir", return_value="/fake/config"),
+            patch("os.path.exists", return_value=True),
+            patch("builtins.open", mock_open(read_data=config)),
             patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=True),
             patch("vocalinux.text_injection.text_injector.IBusTextInjector") as mock_ibus_class,
             patch(

--- a/tests/test_text_injector_ext.py
+++ b/tests/test_text_injector_ext.py
@@ -1,5 +1,6 @@
 """Extra tests for text_injector.py to improve branch coverage."""
 
+import json
 import os
 import subprocess
 import sys
@@ -471,6 +472,165 @@ class TestCheckDependencies(unittest.TestCase):
 
         output, _ = self._run_ibus_pin(bridges=True, env=DesktopEnvironment.X11)
         self.assertFalse([line for line in output if line.startswith("WARNING")])
+
+    def _run_with_pin(self, pin, tools, ibus_available=True, bridges=True, env=None):
+        """Construct through _check_dependencies with a pin; return (injector, logs)."""
+        from vocalinux.text_injection.text_injector import DesktopEnvironment, TextInjector
+
+        obj = _make_injector(env or DesktopEnvironment.WAYLAND)
+        obj._backend_pin = ("auto", None)
+        environ = {
+            "XDG_SESSION_TYPE": "x11" if env == DesktopEnvironment.X11 else "wayland",
+            "XDG_CURRENT_DESKTOP": "Hyprland",
+        }
+        if pin:
+            environ["VOCALINUX_FORCE_BACKEND"] = pin
+        with (
+            patch.dict(os.environ, environ, clear=True),
+            patch(
+                "vocalinux.text_injection.text_injector.is_ibus_available",
+                return_value=ibus_available,
+            ),
+            patch(
+                "vocalinux.text_injection.text_injector.is_ibus_active_input_method",
+                return_value=True,
+            ),
+            patch(
+                "vocalinux.text_injection.text_injector.is_ibus_daemon_running", return_value=True
+            ),
+            patch.object(TextInjector, "_wayland_compositor_bridges_ibus", lambda s: bridges),
+            patch("vocalinux.text_injection.text_injector.IBusTextInjector"),
+            patch.object(TextInjector, "_start_ibus_initialization", lambda s: None),
+            patch.object(TextInjector, "_ensure_ydotoold", lambda s: "ydotool" in tools),
+            patch("shutil.which", side_effect=lambda c: f"/usr/bin/{c}" if c in tools else None),
+            self.assertLogs("vocalinux.text_injection.text_injector", level="DEBUG") as logs,
+        ):
+            obj._check_dependencies()
+            obj._warn_if_pin_not_honoured(*obj._backend_pin)
+        return obj, logs.output
+
+    def _not_applied(self, output):
+        return [line for line in output if "was not applied" in line]
+
+    def test_pin_with_missing_binary_warns_and_names_the_reason(self):
+        """A pin for a tool that is not installed must not resume autodetection silently."""
+        _, output = self._run_with_pin("wtype", tools=("ydotool",))
+        warned = self._not_applied(output)
+        self.assertTrue(warned, f"expected a not-applied warning, got: {output}")
+        self.assertIn("is not installed", warned[0])
+        self.assertIn("using ydotool instead", warned[0])
+
+    def test_pin_that_does_not_apply_to_this_session_warns_without_a_reason(self):
+        """xdotool on Wayland resolves to whatever autodetection picks; say so plainly."""
+        _, output = self._run_with_pin("xdotool", tools=("wtype", "ydotool", "xdotool"))
+        warned = self._not_applied(output)
+        self.assertTrue(warned, f"expected a not-applied warning, got: {output}")
+        self.assertNotIn("is not installed", warned[0])
+
+    def test_ibus_pin_warns_when_ibus_support_is_unavailable(self):
+        _, output = self._run_with_pin("ibus", tools=("wtype", "ydotool"), ibus_available=False)
+        warned = self._not_applied(output)
+        self.assertTrue(warned, f"expected a not-applied warning, got: {output}")
+        self.assertIn("IBus support is not available", warned[0])
+
+    def test_honoured_pin_does_not_warn(self):
+        _, output = self._run_with_pin("wtype", tools=("wtype", "ydotool"))
+        self.assertFalse(self._not_applied(output))
+
+    def test_no_pin_never_warns(self):
+        _, output = self._run_with_pin(None, tools=("wtype", "ydotool"))
+        self.assertFalse(self._not_applied(output))
+
+    def test_honoured_ibus_pin_on_unbridged_compositor_warns_only_once(self):
+        """The denylist-bypass warning and this one must not both fire.
+
+        The pin IS honoured there, so the backend in use matches what was
+        pinned; only the bypass warning is appropriate.
+        """
+        _, output = self._run_with_pin("ibus", tools=("wtype", "ydotool"), bridges=False)
+        self.assertTrue([line for line in output if "overrides that check" in line])
+        self.assertFalse(self._not_applied(output))
+
+    def test_honoured_ibus_pin_on_bridged_compositor_warns_neither_way(self):
+        _, output = self._run_with_pin("ibus", tools=("wtype", "ydotool"), bridges=True)
+        self.assertFalse([line for line in output if "overrides that check" in line])
+        self.assertFalse(self._not_applied(output))
+
+    def test_pinned_log_line_names_the_config_source_not_the_variable(self):
+        """A config-sourced pin must not be reported as VOCALINUX_FORCE_BACKEND."""
+        from vocalinux.text_injection.text_injector import DesktopEnvironment, TextInjector
+
+        obj = _make_injector(DesktopEnvironment.WAYLAND)
+        obj._backend_pin = ("auto", None)
+        config = json.dumps({"text_injection": {"backend": "wtype"}})
+        with (
+            patch.dict(os.environ, {"XDG_SESSION_TYPE": "wayland"}, clear=True),
+            patch("vocalinux.text_injection.text_injector.config_dir", return_value="/fake/config"),
+            patch("os.path.exists", return_value=True),
+            patch("builtins.open", mock_open(read_data=config)),
+            patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False),
+            patch.object(TextInjector, "_ensure_ydotoold", lambda s: False),
+            patch("shutil.which", side_effect=lambda c: f"/usr/bin/{c}" if c == "wtype" else None),
+            self.assertLogs("vocalinux.text_injection.text_injector", level="DEBUG") as logs,
+        ):
+            obj._check_dependencies()
+        pinned_lines = [line for line in logs.output if "wtype" in line and "=" in line]
+        self.assertTrue(pinned_lines)
+        self.assertFalse(
+            [line for line in pinned_lines if "VOCALINUX_FORCE_BACKEND" in line],
+            f"config-sourced pin reported as the env var: {pinned_lines}",
+        )
+
+    def test_x11_pin_resolving_to_xdotool_warns(self):
+        """On X11 the tool is always xdotool, so a wtype pin cannot be honoured.
+
+        This is the X11 reporter's case on #476: they wanted IBus off, which a
+        non-ibus pin does, but the pin they set is not what ends up typing.
+        """
+        from vocalinux.text_injection.text_injector import DesktopEnvironment
+
+        _, output = self._run_with_pin(
+            "wtype", tools=("xdotool", "wtype"), env=DesktopEnvironment.X11
+        )
+        warned = self._not_applied(output)
+        self.assertTrue(warned, f"expected a not-applied warning, got: {output}")
+        self.assertIn("using xdotool instead", warned[0])
+
+    def test_ibus_pin_that_fails_to_initialise_warns_without_a_reason(self):
+        """IBus is available but construction blew up, so no cheap reason applies."""
+        from vocalinux.text_injection.text_injector import DesktopEnvironment, TextInjector
+
+        obj = _make_injector(DesktopEnvironment.WAYLAND)
+        obj._backend_pin = ("auto", None)
+        with (
+            patch.dict(
+                os.environ,
+                {"XDG_SESSION_TYPE": "wayland", "VOCALINUX_FORCE_BACKEND": "ibus"},
+                clear=True,
+            ),
+            patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=True),
+            patch(
+                "vocalinux.text_injection.text_injector.is_ibus_active_input_method",
+                return_value=True,
+            ),
+            patch(
+                "vocalinux.text_injection.text_injector.is_ibus_daemon_running", return_value=True
+            ),
+            patch.object(TextInjector, "_wayland_compositor_bridges_ibus", lambda s: True),
+            patch(
+                "vocalinux.text_injection.text_injector.IBusTextInjector",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch.object(TextInjector, "_ensure_ydotoold", lambda s: True),
+            patch("shutil.which", side_effect=lambda c: f"/usr/bin/{c}"),
+            self.assertLogs("vocalinux.text_injection.text_injector", level="DEBUG") as logs,
+        ):
+            obj._check_dependencies()
+            obj._warn_if_pin_not_honoured(*obj._backend_pin)
+        warned = self._not_applied(logs.output)
+        self.assertTrue(warned, f"expected a not-applied warning, got: {logs.output}")
+        self.assertNotIn("not available", warned[0])
+        self.assertNotIn("not installed", warned[0])
 
     def test_force_backend_ydotool_skips_ibus_and_wtype(self):
         """VOCALINUX_FORCE_BACKEND=ydotool pins ydotool even when wtype is available."""

--- a/tests/test_text_injector_ext.py
+++ b/tests/test_text_injector_ext.py
@@ -519,18 +519,26 @@ class TestCheckDependencies(unittest.TestCase):
             ),
             patch("vocalinux.text_injection.text_injector.IBusTextInjector"),
             patch.object(TextInjector, "_start_ibus_initialization", lambda s: None),
+            # shutil.which is patched to claim every tool exists, so without this
+            # the real probe shells out to a ydotoold that may not be installed
+            # and logs a warning that has nothing to do with the pin.
+            patch.object(TextInjector, "_ensure_ydotoold", lambda s: True),
             patch("shutil.which", side_effect=lambda c: f"/usr/bin/{c}"),
             self.assertLogs("vocalinux.text_injection.text_injector", level="DEBUG") as logs,
         ):
             obj._check_dependencies()
         return logs.output, len(calls)
 
+    @staticmethod
+    def _silent_failure_warnings(output):
+        """Only the denylist-bypass warning, not every warning the run emits."""
+        return [line for line in output if "may silently do nothing" in line]
+
     def test_ibus_pin_on_unbridged_compositor_warns_about_silent_failure(self):
         """Pinning ibus can re-enable the silent drop the denylist exists to stop."""
         output, _ = self._run_ibus_pin(bridges=False)
-        warnings = [line for line in output if line.startswith("WARNING")]
         self.assertTrue(
-            any("may silently do nothing" in line for line in warnings),
+            self._silent_failure_warnings(output),
             f"expected a silent-failure warning, got: {output}",
         )
 
@@ -542,8 +550,8 @@ class TestCheckDependencies(unittest.TestCase):
         """
         output, _ = self._run_ibus_pin(bridges=True)
         self.assertFalse(
-            [line for line in output if line.startswith("WARNING")],
-            f"expected no warning on a bridged compositor, got: {output}",
+            self._silent_failure_warnings(output),
+            f"expected no silent-failure warning on a bridged compositor, got: {output}",
         )
 
     def test_ibus_pin_never_double_checks_the_compositor(self):
@@ -562,7 +570,7 @@ class TestCheckDependencies(unittest.TestCase):
         from vocalinux.text_injection.text_injector import DesktopEnvironment
 
         output, _ = self._run_ibus_pin(bridges=True, env=DesktopEnvironment.X11)
-        self.assertFalse([line for line in output if line.startswith("WARNING")])
+        self.assertFalse(self._silent_failure_warnings(output))
 
     def _run_with_pin(
         self, pin, tools, ibus_available=True, bridges=True, env=None, ydotoold_ready=None

--- a/tests/test_text_injector_ext.py
+++ b/tests/test_text_injector_ext.py
@@ -396,6 +396,97 @@ class TestCheckDependencies(unittest.TestCase):
         self.assertEqual(obj.wayland_tool, "wtype")
         mock_ibus_class.assert_not_called()
 
+    def test_x11_config_pin_never_constructs_ibus(self):
+        """On X11 the user guide promises any non-ibus pin turns the IBus path off.
+
+        The X11 reporter on #476 wanted exactly that. The pin does not choose the
+        tool there -- xdotool always does the typing -- so the only thing the pin
+        changes on X11 is whether IBus runs, and that is what this asserts.
+        """
+        import json as _json
+
+        from vocalinux.text_injection.text_injector import DesktopEnvironment
+
+        def run(pinned):
+            """Drive _check_dependencies on X11 under conditions IBus would pass."""
+            obj = _make_injector(DesktopEnvironment.X11)
+            section = {"backend": pinned} if pinned else {}
+            config = _json.dumps({"text_injection": section})
+
+            with (
+                patch.dict(os.environ, {"XDG_SESSION_TYPE": "x11"}, clear=True),
+                patch(
+                    "vocalinux.text_injection.text_injector.config_dir",
+                    return_value="/fake/config",
+                ),
+                patch("os.path.exists", return_value=True),
+                patch("builtins.open", mock_open(read_data=config)),
+                patch(
+                    "vocalinux.text_injection.text_injector.is_ibus_available", return_value=True
+                ),
+                patch(
+                    "vocalinux.text_injection.text_injector.is_ibus_active_input_method",
+                    return_value=True,
+                ),
+                patch(
+                    "vocalinux.text_injection.text_injector.is_ibus_daemon_running",
+                    return_value=True,
+                ),
+                patch("vocalinux.text_injection.text_injector.IBusTextInjector") as mock_ibus_class,
+                patch("shutil.which", side_effect=lambda c: f"/usr/bin/{c}"),
+            ):
+                obj._check_dependencies()
+            return mock_ibus_class
+
+        # Control: with no pin these same conditions do construct IBus, so a
+        # not-called assertion below is the pin's doing and not the environment's.
+        self.assertTrue(run(None).called, "control failed: IBus was not constructed without a pin")
+
+        for pinned in ("xdotool", "wtype"):
+            with self.subTest(backend=pinned):
+                run(pinned).assert_not_called()
+
+    def test_explicit_auto_environment_ignores_the_saved_config_pin(self):
+        """VOCALINUX_FORCE_BACKEND=auto is how you get one run of plain autodetection.
+
+        The resolver already knows an explicit auto from an unset variable; this
+        drives the whole of _check_dependencies to show the saved pin really is
+        not consulted, rather than only that the resolver returned "auto".
+        """
+        import json as _json
+
+        from vocalinux.text_injection.text_injector import DesktopEnvironment, TextInjector
+
+        obj = _make_injector(DesktopEnvironment.WAYLAND)
+        obj._backend_pin = ("auto", None)
+        config = _json.dumps({"text_injection": {"backend": "wtype"}})
+
+        with (
+            patch.dict(
+                os.environ,
+                {"XDG_SESSION_TYPE": "wayland", "VOCALINUX_FORCE_BACKEND": "auto"},
+                clear=True,
+            ),
+            patch("vocalinux.text_injection.text_injector.config_dir", return_value="/fake/config"),
+            patch("os.path.exists", return_value=True),
+            patch("builtins.open", mock_open(read_data=config)),
+            patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=False),
+            patch.object(TextInjector, "_ensure_ydotoold", lambda s: True),
+            patch("shutil.which", side_effect=lambda c: f"/usr/bin/{c}"),
+            self.assertLogs("vocalinux.text_injection.text_injector", level="DEBUG") as logs,
+        ):
+            obj._check_dependencies()
+            obj._warn_if_pin_not_honoured(*obj._backend_pin)
+
+        # Autodetection prefers ydotool when its daemon is ready; the saved wtype
+        # pin would have won had the explicit auto not discarded it.
+        self.assertEqual(obj.wayland_tool, "ydotool")
+        self.assertFalse(
+            [line for line in logs.output if "backend pin requested" in line],
+            f"an explicit auto still reported a pin: {logs.output}",
+        )
+        self.assertFalse(self._not_applied(logs.output))
+
     def _run_ibus_pin(self, bridges, desktop="Hyprland", env=None):
         """Drive _check_dependencies with an ibus pin; return (logs, bridge_call_count)."""
         from vocalinux.text_injection.text_injector import DesktopEnvironment, TextInjector
@@ -473,8 +564,15 @@ class TestCheckDependencies(unittest.TestCase):
         output, _ = self._run_ibus_pin(bridges=True, env=DesktopEnvironment.X11)
         self.assertFalse([line for line in output if line.startswith("WARNING")])
 
-    def _run_with_pin(self, pin, tools, ibus_available=True, bridges=True, env=None):
-        """Construct through _check_dependencies with a pin; return (injector, logs)."""
+    def _run_with_pin(
+        self, pin, tools, ibus_available=True, bridges=True, env=None, ydotoold_ready=None
+    ):
+        """Construct through _check_dependencies with a pin; return (injector, logs).
+
+        ydotoold_ready defaults to whether ydotool is installed, which is what
+        every caller wanted before the daemonless fallback needed exercising.
+        Pass it explicitly to have ydotool present but its daemon unavailable.
+        """
         from vocalinux.text_injection.text_injector import DesktopEnvironment, TextInjector
 
         obj = _make_injector(env or DesktopEnvironment.WAYLAND)
@@ -501,7 +599,11 @@ class TestCheckDependencies(unittest.TestCase):
             patch.object(TextInjector, "_wayland_compositor_bridges_ibus", lambda s: bridges),
             patch("vocalinux.text_injection.text_injector.IBusTextInjector"),
             patch.object(TextInjector, "_start_ibus_initialization", lambda s: None),
-            patch.object(TextInjector, "_ensure_ydotoold", lambda s: "ydotool" in tools),
+            patch.object(
+                TextInjector,
+                "_ensure_ydotoold",
+                lambda s: ("ydotool" in tools) if ydotoold_ready is None else ydotoold_ready,
+            ),
             patch("shutil.which", side_effect=lambda c: f"/usr/bin/{c}" if c in tools else None),
             self.assertLogs("vocalinux.text_injection.text_injector", level="DEBUG") as logs,
         ):
@@ -631,6 +733,78 @@ class TestCheckDependencies(unittest.TestCase):
         self.assertTrue(warned, f"expected a not-applied warning, got: {logs.output}")
         self.assertNotIn("not available", warned[0])
         self.assertNotIn("not installed", warned[0])
+
+    def test_ydotool_pin_with_missing_binary_warns_and_names_the_reason(self):
+        """The wtype case has a counterpart: every selectable tool can be absent.
+
+        Contrast with test_pin_with_missing_binary_warns_and_names_the_reason,
+        which pins the tool the fallback then chooses; here the pin and the
+        fallback are swapped, so a check keyed on one name would still pass.
+        """
+        _, output = self._run_with_pin("ydotool", tools=("wtype",))
+        warned = self._not_applied(output)
+        self.assertTrue(warned, f"expected a not-applied warning, got: {output}")
+        self.assertIn("ydotool is not installed", warned[0])
+        self.assertIn("using wtype instead", warned[0])
+
+    def test_wtype_pin_without_wtype_falls_back_to_daemonless_ydotool(self):
+        """ydotool present but ydotoold not ready is its own branch, and a pin reaches it.
+
+        Both diagnostics have to survive together: the fallback says the daemon
+        is missing, and the pin check says the pin is not what ended up typing.
+        """
+        obj, output = self._run_with_pin("wtype", tools=("ydotool",), ydotoold_ready=False)
+        self.assertEqual(obj.wayland_tool, "ydotool")
+        self.assertTrue(
+            [line for line in output if "ydotoold not ready" in line],
+            f"expected the daemonless-ydotool warning, got: {output}",
+        )
+        warned = self._not_applied(output)
+        self.assertTrue(warned, f"expected a not-applied warning, got: {output}")
+        self.assertIn("using ydotool instead", warned[0])
+
+    def test_ibus_pin_survives_the_x11_missing_xdotool_early_return(self):
+        """_check_dependencies returns early here, before any tool is selected.
+
+        The pin is still honoured -- IBus is what types -- so the pin check must
+        not report a failure just because the usual selection chain was skipped.
+        """
+        from vocalinux.text_injection.text_injector import DesktopEnvironment
+
+        obj, output = self._run_with_pin("ibus", tools=(), env=DesktopEnvironment.X11)
+        self.assertIsNotNone(obj._ibus_injector)
+        self.assertFalse(
+            self._not_applied(output),
+            f"honoured ibus pin reported as not applied: {output}",
+        )
+
+    def test_ibus_pin_survives_the_no_tools_early_return(self):
+        """The other early return: Wayland with nothing installed but IBus asked for.
+
+        Without the early return this path raises RuntimeError, so reaching the
+        pin check at all is part of what this asserts.
+        """
+        obj, output = self._run_with_pin("ibus", tools=())
+        self.assertIsNotNone(obj._ibus_injector)
+        self.assertFalse(
+            self._not_applied(output),
+            f"honoured ibus pin reported as not applied: {output}",
+        )
+
+    def test_pin_log_states_the_request_without_claiming_the_outcome(self):
+        """The pin line runs before anything is checked, so it may not claim success.
+
+        A pin that is not installed is reported by this line and then
+        contradicted by the not-applied warning, which is what made an
+        outcome-shaped word wrong here.
+        """
+        _, output = self._run_with_pin("wtype", tools=("ydotool",))
+        requested = [line for line in output if "backend pin requested" in line]
+        self.assertTrue(requested, f"expected the pin-requested line, got: {output}")
+        self.assertFalse(
+            [line for line in output if "overriding" in line],
+            f"pin line still claims an outcome it cannot know: {output}",
+        )
 
     def test_force_backend_ydotool_skips_ibus_and_wtype(self):
         """VOCALINUX_FORCE_BACKEND=ydotool pins ydotool even when wtype is available."""

--- a/tests/test_text_injector_ext.py
+++ b/tests/test_text_injector_ext.py
@@ -395,6 +395,83 @@ class TestCheckDependencies(unittest.TestCase):
         self.assertEqual(obj.wayland_tool, "wtype")
         mock_ibus_class.assert_not_called()
 
+    def _run_ibus_pin(self, bridges, desktop="Hyprland", env=None):
+        """Drive _check_dependencies with an ibus pin; return (logs, bridge_call_count)."""
+        from vocalinux.text_injection.text_injector import DesktopEnvironment, TextInjector
+
+        obj = _make_injector(env or DesktopEnvironment.WAYLAND)
+        calls = []
+
+        def fake_bridges(self):
+            calls.append(1)
+            return bridges
+
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "XDG_SESSION_TYPE": "wayland",
+                    "XDG_CURRENT_DESKTOP": desktop,
+                    "VOCALINUX_FORCE_BACKEND": "ibus",
+                },
+                clear=True,
+            ),
+            patch.object(TextInjector, "_wayland_compositor_bridges_ibus", fake_bridges),
+            patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=True),
+            patch(
+                "vocalinux.text_injection.text_injector.is_ibus_active_input_method",
+                return_value=True,
+            ),
+            patch(
+                "vocalinux.text_injection.text_injector.is_ibus_daemon_running", return_value=True
+            ),
+            patch("vocalinux.text_injection.text_injector.IBusTextInjector"),
+            patch.object(TextInjector, "_start_ibus_initialization", lambda s: None),
+            patch("shutil.which", side_effect=lambda c: f"/usr/bin/{c}"),
+            self.assertLogs("vocalinux.text_injection.text_injector", level="DEBUG") as logs,
+        ):
+            obj._check_dependencies()
+        return logs.output, len(calls)
+
+    def test_ibus_pin_on_unbridged_compositor_warns_about_silent_failure(self):
+        """Pinning ibus can re-enable the silent drop the denylist exists to stop."""
+        output, _ = self._run_ibus_pin(bridges=False)
+        warnings = [line for line in output if line.startswith("WARNING")]
+        self.assertTrue(
+            any("may silently do nothing" in line for line in warnings),
+            f"expected a silent-failure warning, got: {output}",
+        )
+
+    def test_ibus_pin_on_bridged_compositor_does_not_warn(self):
+        """The guard must key off the compositor, not merely off the pin.
+
+        A bridged desktop -- including a denylisted compositor with the
+        ibus-wayland bridge running -- is not a bypass and must stay quiet.
+        """
+        output, _ = self._run_ibus_pin(bridges=True)
+        self.assertFalse(
+            [line for line in output if line.startswith("WARNING")],
+            f"expected no warning on a bridged compositor, got: {output}",
+        )
+
+    def test_ibus_pin_never_double_checks_the_compositor(self):
+        """The bridging check shells out (pgrep / gdbus), so it must run at most once.
+
+        The elif chain short-circuits on ``not force_ibus``, so a pinned run
+        reaches the new guard without having evaluated the check already. If a
+        future edit drops that short-circuit, this catches the extra subprocess.
+        """
+        for bridges in (False, True):
+            _, call_count = self._run_ibus_pin(bridges=bridges)
+            self.assertEqual(call_count, 1, f"bridges={bridges}: expected 1 call, got {call_count}")
+
+    def test_ibus_pin_on_x11_does_not_warn(self):
+        """The denylist is a Wayland concern; X11 reaches apps through XIM."""
+        from vocalinux.text_injection.text_injector import DesktopEnvironment
+
+        output, _ = self._run_ibus_pin(bridges=True, env=DesktopEnvironment.X11)
+        self.assertFalse([line for line in output if line.startswith("WARNING")])
+
     def test_force_backend_ydotool_skips_ibus_and_wtype(self):
         """VOCALINUX_FORCE_BACKEND=ydotool pins ydotool even when wtype is available."""
         from vocalinux.text_injection.text_injector import DesktopEnvironment

--- a/tests/test_text_injector_ext.py
+++ b/tests/test_text_injector_ext.py
@@ -7,7 +7,7 @@ import threading
 import unittest
 from typing import Any, cast
 from unittest import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -353,6 +353,36 @@ class TestCheckDependencies(unittest.TestCase):
                 {"XDG_SESSION_TYPE": "wayland", "VOCALINUX_FORCE_BACKEND": "wtype"},
                 clear=True,
             ),
+            patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=True),
+            patch("vocalinux.text_injection.text_injector.IBusTextInjector") as mock_ibus_class,
+            patch(
+                "shutil.which",
+                side_effect=lambda cmd: f"/usr/bin/{cmd}" if cmd in ("wtype", "ydotool") else None,
+            ),
+        ):
+            obj._check_dependencies()
+
+        self.assertEqual(obj.wayland_tool, "wtype")
+        mock_ibus_class.assert_not_called()
+
+    def test_config_backend_wtype_skips_ibus(self):
+        """text_injection.backend=wtype pins wtype with no environment variable set.
+
+        The environment variable is a one-off; this is the persisted setting from
+        issue #476, so it has to survive a restart on its own.
+        """
+        import json as _json
+
+        from vocalinux.text_injection.text_injector import DesktopEnvironment
+
+        obj = _make_injector(DesktopEnvironment.WAYLAND)
+        config = _json.dumps({"text_injection": {"backend": "wtype"}})
+
+        with (
+            patch.dict(os.environ, {"XDG_SESSION_TYPE": "wayland"}, clear=True),
+            patch("vocalinux.text_injection.text_injector.config_dir", return_value="/fake/config"),
+            patch("os.path.exists", return_value=True),
+            patch("builtins.open", mock_open(read_data=config)),
             patch("vocalinux.text_injection.text_injector.is_ibus_available", return_value=True),
             patch("vocalinux.text_injection.text_injector.IBusTextInjector") as mock_ibus_class,
             patch(


### PR DESCRIPTION


Closes #476.

## Problem

Autodetection has to infer whether IBus commits actually reach the focused
application, and it cannot verify that: `commit_text()` returns success even when the
compositor drops the text. When the inference is wrong the failure is silent --
dictation works in XWayland windows and does nothing in native ones, with no error.
That is the shape of #478, #485, #501, #511 and #574.

`VOCALINUX_FORCE_BACKEND` (added alongside #614) already provides an escape hatch, but
it is an environment variable: it covers one run, it is undocumented outside the test
suite, and a user whose compositor is misdetected has to wrap the launcher in a shell
script to make the choice stick. That is exactly what `luginf` reported doing on #476,
on X11, where there is no denylist to fall back on at all.

## Fix

A persistent `text_injection.backend` setting accepting the same values as the
variable:

```json
{ "text_injection": { "backend": "wtype" } }
```

`_backend_preference()` resolves the variable first, then the setting. The startup log
now names which of the two pinned the backend, so a stale setting is visible in
`--debug` output rather than being a mystery.

## Scope

The resolution order is the only new behaviour; nothing else in selection changed.

- **Strictly additive.** Default is `auto`, which resolves to exactly today's
  autodetection. With no setting and no variable, behaviour is byte-for-byte unchanged
  -- relevant given how often this path has regressed (#481, #504).
- **Contained.** `_forced_backend()` is untouched and still environment-only, so its
  existing tests still pin its behaviour on their own. The denylist,
  `_ibus_wayland_bridge_running()` and the KDE VirtualKeyboard path (#574) are not
  read or modified.
- **Fails safe.** An unreadable or corrupt config falls back to autodetection instead
  of blocking startup; an unrecognised value is ignored with a warning, so a typo
  cannot silently pin the wrong backend.
- **Cost** is one config read per `TextInjector` construction, not per injection.

Read from disk rather than through `ConfigManager`, keeping `text_injection`
independent of the UI layer -- the same approach `_should_copy_to_clipboard()` already
uses in this file.

## Testing

- `TestConfiguredBackend` (5): recognised values, whitespace/case normalisation,
  `auto`/empty/absent-section/absent-file all meaning `auto`, unknown value warns and
  falls back, corrupt JSON does not raise.
- `TestBackendPreference` (4): variable overrides setting, setting used when the
  variable is unset, `auto` when neither is set, and an invalid variable still falls
  back to a valid saved setting rather than discarding it.
- `test_config_backend_wtype_skips_ibus` (ext): end-to-end through
  `_check_dependencies()` -- with the setting alone and no variable, `wayland_tool` is
  `wtype` and `IBusTextInjector` is never constructed.

```console
$ pytest tests/test_text_injector.py tests/test_text_injector_ext.py
174 passed

$ black --check src/ tests/
111 files would be left unchanged.

$ isort --check-only --profile black src/ tests/
$ flake8 src/ tests/ --count --select=E9,F63,F7,F82
0
```

All 54 added lines are covered with no partial branches, so `codecov/patch` should be
green.

The new tests mock the config file rather than using a real temp directory:
`tests/test_ibus_engine_core.py` patches `tempfile.mkdtemp` globally, which made an
earlier filesystem-based version pass alone and fail in a full run.

## Manual verification

Fedora 43, Hyprland 0.51.1, IBus 1.5.33, vocalinux `main` @ `4a1d3ed`:

```console
$ python -c "...; print(ti._wayland_compositor_bridges_ibus())"
False                     # denylist already selects wtype/ydotool here

$ pgrep -x ibus-wayland   # bridge absent, so the denylist stands
$ rpm -q --whatprovides /usr/libexec/ibus-wayland
ibus-wayland-1.5.33-6.fc43.x86_64   # separate package on Fedora, not installed

# setting alone, no environment variable
_backend_preference() = wtype
# variable wins when both are present
env overrides config   = ydotool
```

`wtype` injects into native Wayland windows correctly on this compositor (verified by
typing into a `kitty` window reading stdin), so the backend this pins is a working one.

X11 was checked too, since #476's second reporter is on X11: pinning any non-`ibus`
value skips IBus and dictates through `xdotool`, which is the behaviour that reporter
was getting by blanking `GTK_IM_MODULE`/`QT_IM_MODULE`/`XMODIFIERS` in a wrapper
script. Documented in the user guide.

## Notes

Deliberately narrower than #402, which also rebuilt the injector at runtime and added
Settings/tray UI across 9 files. This is the persistent setting the acceptance criteria
ask for and nothing else. Happy to add the Settings toggle in a follow-up, or here if
you would rather have it in one PR.

`xdotool` is not an accepted value, to keep parity with the existing variable's enum;
adding it would mean touching X11 selection, which seemed worth keeping out of this
change.
