### PR TITLE
docs(agents): require humanizer pass for all human-facing text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,23 @@ docs(readme): update installation instructions
 - **All changes require a PR** - Even small fixes and documentation updates
 - **Wait for CI to pass** before merging PRs
 - **Squash merge** PRs to keep history clean
+- **Humanize all human-facing text** - See the rule below
+
+## Human-facing text: always humanize
+
+Any prose a person will read must go through the `humanizer` skill (`~/.cursor/skills/humanizer/SKILL.md`) before you post or hand it off. Run the humanizer pass every time, as a rule, not just when asked.
+
+This applies to:
+
+- Pull request titles and descriptions
+- Replies and review comments on pull requests
+- Comments and replies on issues
+- Commit message bodies
+- Any Markdown or plain text you generate for a human to copy and paste
+
+Use the skill's embedded mode for these: run the draft, audit, and final rewrite internally, then output only the final text. Do not paste the audit bullets into the PR, issue, or handoff.
+
+This rule is about prose only. Do not humanize code, code comments, logs, configuration, test fixtures, or other machine-facing output.
 
 ## Cursor Cloud specific instructions
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds a standing rule to `AGENTS.md`: any prose a person will read must go through the `humanizer` skill before it is posted or handed off. This covers PR titles and descriptions, PR review replies, issue comments, commit message bodies, and any Markdown or text generated for someone to copy and paste. The rule says to use the skill's embedded mode so only the final text is produced, and it explicitly excludes code, comments, logs, config, and other machine-facing output.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📖 Documentation update
- [ ] 🧹 Code refactoring
- [ ] ✅ Test update

## Checklist

- [x] My code follows the code style of this project (black, isort)
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass locally
- [x] Pre-commit hooks pass

## Additional Notes

Docs-only change to `AGENTS.md`. This PR description was itself written through the humanizer pass the rule describes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3d7fb29-af4d-42a2-a9c0-d4fb40de673c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3d7fb29-af4d-42a2-a9c0-d4fb40de673c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

