### PR TITLE
fix(tray): reuse open Settings/Logs dialog instead of duplicating it

### DIFF
--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -147,6 +147,8 @@ class TrayIndicator:
         # Must exist before _init_indicator: tests run idle_add synchronously.
         self._pending_update: Optional[ReleaseInfo] = None
         self._update_menu_item = None
+        self._settings_dialog: Optional[Gtk.Dialog] = None
+        self._logging_dialog: Optional[Gtk.Dialog] = None
 
         # Initialize the indicator (in the GTK main thread)
         GLib.idle_add(self._init_indicator)
@@ -568,6 +570,12 @@ class TrayIndicator:
 
     def _show_settings_page(self, page_name: Optional[str]):
         """Open settings, optionally focused on a specific sidebar page."""
+        if self._settings_dialog is not None:
+            if page_name:
+                self._settings_dialog.navigate_to_page(page_name)
+            self._settings_dialog.present()
+            return
+
         dialog = SettingsDialog(
             parent=None,
             config_manager=self.config_manager,
@@ -581,7 +589,13 @@ class TrayIndicator:
             ),
         )
         dialog.connect("response", self._on_settings_dialog_response)
+        dialog.connect("destroy", self._on_settings_dialog_destroy)
+        self._settings_dialog = dialog
         dialog.show()
+
+    def _on_settings_dialog_destroy(self, dialog):
+        """Drop the tracked instance once the dialog is gone."""
+        self._settings_dialog = None
 
     def _get_update_channel(self) -> str:
         """Return the configured release channel for background update checks."""
@@ -660,12 +674,22 @@ class TrayIndicator:
         """Handle click on the View Logs menu item."""
         logger.debug("View Logs clicked")
 
+        if self._logging_dialog is not None:
+            self._logging_dialog.present()
+            return
+
         # Import here to avoid circular imports
         from .logging_dialog import LoggingDialog
 
         # Create and show the logging dialog
         dialog = LoggingDialog(parent=None)
+        dialog.connect("destroy", self._on_logging_dialog_destroy)
+        self._logging_dialog = dialog
         dialog.show()
+
+    def _on_logging_dialog_destroy(self, dialog):
+        """Drop the tracked instance once the dialog is gone."""
+        self._logging_dialog = None
 
     def _on_settings_dialog_response(self, dialog, response):
         """Handle responses from the settings dialog."""

--- a/tests/test_tray_indicator.py
+++ b/tests/test_tray_indicator.py
@@ -264,6 +264,35 @@ class TestTrayIndicator(unittest.TestCase):
             mock_dialog_class.assert_called_once()
             mock_dialog_instance.show.assert_called_once()
 
+    def test_settings_dialog_reused_on_repeated_click(self):
+        """Repeated Settings clicks focus the open dialog instead of duplicating it."""
+        self.tray_indicator._on_settings_clicked(None)
+        self.tray_indicator._on_settings_clicked(None)
+
+        self.mock_settings_dialog_class.assert_called_once()
+        self.mock_settings_dialog.show.assert_called_once()
+        self.mock_settings_dialog.present.assert_called_once()
+
+    def test_settings_dialog_destroy_allows_a_fresh_one(self):
+        """Once the tracked dialog is destroyed, the next click builds a new one."""
+        self.tray_indicator._on_settings_clicked(None)
+        self.assertIs(self.tray_indicator._settings_dialog, self.mock_settings_dialog)
+
+        self.tray_indicator._on_settings_dialog_destroy(self.mock_settings_dialog)
+        self.assertIsNone(self.tray_indicator._settings_dialog)
+
+        self.tray_indicator._on_settings_clicked(None)
+        self.assertEqual(self.mock_settings_dialog_class.call_count, 2)
+
+    def test_about_reuses_open_settings_dialog(self):
+        """About click on an already-open Settings dialog navigates it, no duplicate."""
+        self.tray_indicator._on_settings_clicked(None)
+        self.tray_indicator._on_about_clicked(None)
+
+        self.mock_settings_dialog_class.assert_called_once()
+        self.mock_settings_dialog.navigate_to_page.assert_called_once_with("about")
+        self.mock_settings_dialog.present.assert_called_once()
+
     def test_about_dialog(self):
         """Test About opens Settings focused on the About page."""
         with patch("vocalinux.ui.tray_indicator.SettingsDialog") as mock_dialog_class:
@@ -558,6 +587,38 @@ class TestTrayIndicator(unittest.TestCase):
 
             mock_logging_dialog_class.assert_called_once_with(parent=None)
             mock_dialog.show.assert_called_once()
+
+    def test_on_logs_clicked_reused_on_repeated_click(self):
+        """Repeated View Logs clicks focus the open dialog instead of duplicating it."""
+        mock_dialog = MagicMock()
+        mock_logging_dialog_class = MagicMock(return_value=mock_dialog)
+        mock_logging_module = MagicMock()
+        mock_logging_module.LoggingDialog = mock_logging_dialog_class
+
+        with patch.dict(sys.modules, {"vocalinux.ui.logging_dialog": mock_logging_module}):
+            self.tray_indicator._on_logs_clicked(None)
+            self.tray_indicator._on_logs_clicked(None)
+
+            mock_logging_dialog_class.assert_called_once_with(parent=None)
+            mock_dialog.show.assert_called_once()
+            mock_dialog.present.assert_called_once()
+
+    def test_on_logging_dialog_destroy_allows_a_fresh_one(self):
+        """Once the tracked logs dialog is destroyed, the next click builds a new one."""
+        mock_dialog = MagicMock()
+        mock_logging_dialog_class = MagicMock(return_value=mock_dialog)
+        mock_logging_module = MagicMock()
+        mock_logging_module.LoggingDialog = mock_logging_dialog_class
+
+        with patch.dict(sys.modules, {"vocalinux.ui.logging_dialog": mock_logging_module}):
+            self.tray_indicator._on_logs_clicked(None)
+            self.assertIs(self.tray_indicator._logging_dialog, mock_dialog)
+
+            self.tray_indicator._on_logging_dialog_destroy(mock_dialog)
+            self.assertIsNone(self.tray_indicator._logging_dialog)
+
+            self.tray_indicator._on_logs_clicked(None)
+            self.assertEqual(mock_logging_dialog_class.call_count, 2)
 
     def test_on_settings_dialog_response_close(self):
         """Test settings dialog response handler for CLOSE."""


### PR DESCRIPTION
## Problem

`_show_settings_page()` (used by Settings and About) and `_on_logs_clicked()`
each construct a brand-new dialog on every menu click, with no reference kept
to a previously opened one and no `.present()` call. Clicking Settings, About,
or View Logs twice opens a second window instead of raising the first.

## Fix

Track one live instance per dialog on `TrayIndicator` (`_settings_dialog`,
`_logging_dialog`), clear it when the dialog's own `destroy` signal fires,
and on a repeat click call `.navigate_to_page()`/`.present()` on the existing
instance instead of building another.

## Verification

- `tests/test_tray_indicator.py`: added 5 tests pinning the reuse behavior
  (repeated Settings click, repeated Logs click, About reusing an open
  Settings dialog and navigating it, and the tracked reference clearing on
  `destroy` so a later click builds a fresh dialog). All 5 fail against
  `main` and pass with this change.
- Full `pytest` suite (113 files under `src/`, all of `tests/`) passes; one
  unrelated permission-based test in `test_autostart_manager_ext.py` only
  fails when run as root (pre-existing, reproduced identically on `main`).
- `flake8 --select=E9,F63,F7,F82`, `black --check`, `isort --check-only`
  (the repo's lint gates) all pass.
- Not verified: real GTK window-manager focus behavior end-to-end (no
  display server in this environment) — the fix is verified at the level
  the existing test suite already covers this file (mocked GTK, dialog
  construction/signal wiring).