### PR TITLE
fix(settings): separate Close from dictation test controls

### DIFF
--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -2918,6 +2918,15 @@ class SettingsDialog(Gtk.Dialog):
 
         footer.pack_start(self.test_output_revealer, False, False, 0)
 
+        # Separate Close from the dictation-test controls so it reads as
+        # dialog chrome, not as part of Test Dictation (#651).
+        close_separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
+        close_separator.set_margin_start(8)
+        close_separator.set_margin_end(8)
+        close_separator.set_margin_top(2)
+        close_separator.set_margin_bottom(2)
+        footer.pack_start(close_separator, False, False, 0)
+
         # In-window Close so the dialog can always be dismissed, even on WMs
         # that hide the title-bar close button for Gtk.Dialog windows (#323).
         close_button = Gtk.Button(label="Close")

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -859,6 +859,14 @@ class TestSettingsNavigation(unittest.TestCase):
         # No persistent bottom strip below the pages
         self.assertNotIn("def _build_status_strip(self):", self.source_code)
 
+    def test_close_button_separated_from_dictation_test(self):
+        """Close sits below a separator so it reads as dialog chrome (#651)."""
+        footer_body = self.source_code.split("def _build_sidebar_footer")[1].split("\n    def ")[0]
+        after_test = footer_body.split("footer.pack_start(self.test_output_revealer")[1]
+        before_close = after_test.split('close_button = Gtk.Button(label="Close")')[0]
+        self.assertIn("Gtk.Separator", before_close)
+        self.assertIn("footer.pack_start(close_separator", before_close)
+
     def test_sidebar_icons_use_adwaita_names(self):
         """Sidebar icons must resolve in the stock Adwaita theme."""
         for icon in [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

The Settings sidebar Close button sat directly under Test Dictation, the level bar, and the transcription output, so it looked like part of that section. It is the dialog-wide close action from #323 (for window managers that do not draw a title-bar close button).

This adds a horizontal separator between the dictation-test controls and Close, matching the existing sidebar separator above the footer.

## Related Issue

Fixes #651

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧹 Code refactoring
- [x] ✅ Test update

## Checklist

- [x] My code follows the code style of this project (black, isort)
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass locally
- [ ] Pre-commit hooks pass

## Screenshots (if applicable)

Cropped sidebar footer after the change. Test Dictation stays with the Idle / level-bar controls; Close sits below a separator as dialog chrome:

![Settings sidebar footer with a separator between Test Dictation and Close](https://cursor.com/artifacts/c/art-943dd844-30d5-45de-b3d5-29173a62e803)

Full Settings dialog for context:

![Full Vocalinux Settings dialog showing the sidebar footer separator](https://cursor.com/artifacts/c/art-a33bf56e-a3e1-49a2-a03e-9c182e82d602)

## Additional Notes

Close stays in the sidebar footer so the #323 in-window dismiss path is unchanged. Clicking Close still emits `Gtk.ResponseType.CLOSE`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c87ff547-44db-41d7-8935-ff548570632d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c87ff547-44db-41d7-8935-ff548570632d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

