### PR TITLE
fix(settings): size the unused downloads list to its real rows

### DIFF
--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -2438,6 +2438,12 @@ class SettingsDialog(Gtk.Dialog):
         list_holder.pack_start(self.unused_models_group.listbox, False, False, 0)
         self.unused_models_scroll.add(list_holder)
         self.unused_expander.add(self.unused_models_scroll)
+        # Backstop: the refresh measures while the expander is collapsed and
+        # the dialog may not be mapped yet. Remeasure when the user expands,
+        # so a short first measurement can never leave the list clipped.
+        self.unused_expander.connect(
+            "notify::expanded", lambda *_args: self._fit_unused_downloads_height()
+        )
         self.unused_models_group.pack_start(self.unused_expander, False, False, 0)
         self.content_box.pack_start(self.unused_models_group, False, False, 0)
 

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -143,6 +143,9 @@ ENGINE_MODELS = {
     "remote_api": [],  # Remote API does not need local models
 }
 
+# Tallest the "Unused downloads" list may grow before it starts scrolling
+_UNUSED_DOWNLOADS_MAX_HEIGHT = 220
+
 # Engine display name mapping
 ENGINE_DISPLAY_NAMES = {
     "vosk": "Vosk",
@@ -2417,7 +2420,10 @@ class SettingsDialog(Gtk.Dialog):
         self.unused_models_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.unused_models_scroll.set_shadow_type(Gtk.ShadowType.NONE)
         self.unused_models_scroll.set_propagate_natural_height(True)
-        self.unused_models_scroll.set_max_content_height(220)
+        self.unused_models_scroll.set_max_content_height(_UNUSED_DOWNLOADS_MAX_HEIGHT)
+        # Keep the scrollbar in the layout: an overlay one stays invisible until
+        # hovered, so a list clipped by the cap looks like it has no more rows.
+        self.unused_models_scroll.set_overlay_scrolling(False)
 
         # ListBox is GtkScrollable, so wrapping it in a Box forces a Viewport
         # and lets the expander child report a real height.
@@ -4386,7 +4392,6 @@ class SettingsDialog(Gtk.Dialog):
         count = len(unused)
         leftover = "leftover model" if count == 1 else "leftover models"
         self.unused_expander.set_label(f"Unused downloads ({count} {leftover})")
-        self.unused_models_scroll.set_min_content_height(min(220, 56 * count))
 
         was_expanded = self.unused_expander.get_expanded()
         for model_id, title, size_label in unused:
@@ -4409,6 +4414,20 @@ class SettingsDialog(Gtk.Dialog):
 
         self.unused_models_group.show_all()
         self.unused_expander.set_expanded(was_expanded)
+        self._fit_unused_downloads_height()
+
+    def _fit_unused_downloads_height(self):
+        """Size the list from the rows it actually holds.
+
+        A per-row estimate cannot know how tall a row renders: with margins and
+        a Delete button the rows are taller than the estimate, so the last one
+        was cut off below the edge of the viewport while the header still
+        counted it (#683).
+        """
+        _, natural_height = self.unused_models_group.listbox.get_preferred_height()
+        self.unused_models_scroll.set_min_content_height(
+            min(_UNUSED_DOWNLOADS_MAX_HEIGHT, natural_height)
+        )
 
     def _confirm_model_delete(self, text: str, secondary: str) -> bool:
         """Ask before deleting model files from disk."""

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -146,6 +146,12 @@ ENGINE_MODELS = {
 # Tallest the "Unused downloads" list may grow before it starts scrolling
 _UNUSED_DOWNLOADS_MAX_HEIGHT = 220
 
+
+def _clamp_unused_downloads_height(natural_height: int) -> int:
+    """Clamp a measured list height to the height the page gives the list."""
+    return min(_UNUSED_DOWNLOADS_MAX_HEIGHT, natural_height)
+
+
 # Engine display name mapping
 ENGINE_DISPLAY_NAMES = {
     "vosk": "Vosk",
@@ -4426,7 +4432,7 @@ class SettingsDialog(Gtk.Dialog):
         """
         _, natural_height = self.unused_models_group.listbox.get_preferred_height()
         self.unused_models_scroll.set_min_content_height(
-            min(_UNUSED_DOWNLOADS_MAX_HEIGHT, natural_height)
+            _clamp_unused_downloads_height(natural_height)
         )
 
     def _confirm_model_delete(self, text: str, secondary: str) -> bool:

--- a/tests/test_unused_downloads_height.py
+++ b/tests/test_unused_downloads_height.py
@@ -1,0 +1,52 @@
+"""Tests for sizing the "Unused downloads" list to the rows it holds."""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
+
+def _load_settings_dialog():
+    """Import settings_dialog with real base classes for its GTK subclasses."""
+    repository = sys.modules["gi.repository"]
+    bases = {name: type(name, (), {}) for name in ("Box", "ListBoxRow", "Dialog")}
+    saved = sys.modules.pop("vocalinux.ui.settings_dialog", None)
+    try:
+        with patch.object(repository, "Gtk", MagicMock(**bases)):
+            module = importlib.import_module("vocalinux.ui.settings_dialog")
+    finally:
+        sys.modules.pop("vocalinux.ui.settings_dialog", None)
+        if saved is not None:
+            sys.modules["vocalinux.ui.settings_dialog"] = saved
+    return module
+
+
+settings_dialog = _load_settings_dialog()
+SettingsDialog = settings_dialog.SettingsDialog
+MAX_HEIGHT = settings_dialog._UNUSED_DOWNLOADS_MAX_HEIGHT
+
+
+def _dialog_stub(natural_height):
+    dialog = Mock()
+    dialog.unused_models_group.listbox.get_preferred_height.return_value = (
+        natural_height,
+        natural_height,
+    )
+    return dialog
+
+
+def test_list_is_as_tall_as_its_rows_render():
+    """Two rows that render 132px tall must not be squeezed into an estimate."""
+    dialog = _dialog_stub(132)
+
+    SettingsDialog._fit_unused_downloads_height(dialog)
+
+    dialog.unused_models_scroll.set_min_content_height.assert_called_once_with(132)
+
+
+def test_long_lists_stop_growing_at_the_cap():
+    """Beyond the cap the list scrolls instead of pushing the page down."""
+    dialog = _dialog_stub(MAX_HEIGHT * 3)
+
+    SettingsDialog._fit_unused_downloads_height(dialog)
+
+    dialog.unused_models_scroll.set_min_content_height.assert_called_once_with(MAX_HEIGHT)

--- a/tests/test_unused_downloads_height.py
+++ b/tests/test_unused_downloads_height.py
@@ -59,3 +59,14 @@ def test_scrollbar_stays_in_the_layout():
     """An overlay scrollbar hides until hovered, so a capped list looks whole."""
     src = inspect.getsource(settings_dialog)
     assert "self.unused_models_scroll.set_overlay_scrolling(False)" in src
+
+
+def test_expanding_the_list_remeasures_it():
+    """The refresh measures while collapsed and possibly unmapped; expanding
+    must remeasure so a short first measurement can never leave rows clipped."""
+    src = inspect.getsource(settings_dialog)
+    assert re.search(
+        r"self\.unused_expander\.connect\(\s*\"notify::expanded\","
+        r"\s*lambda \*_args: self\._fit_unused_downloads_height\(\)",
+        src,
+    )

--- a/tests/test_unused_downloads_height.py
+++ b/tests/test_unused_downloads_height.py
@@ -1,52 +1,61 @@
-"""Tests for sizing the "Unused downloads" list to the rows it holds."""
+"""Tests for sizing the "Unused downloads" list to the rows it holds.
 
-import importlib
-import sys
-from unittest.mock import MagicMock, Mock, patch
+The settings dialog cannot be instantiated under the mocked-GTK harness (see
+test_settings_mode_change.py), so the arithmetic lives in a module-level
+helper that is unit-tested directly, and the wiring around it is asserted
+against the source of the two methods.
+"""
 
+import inspect
+import re
 
-def _load_settings_dialog():
-    """Import settings_dialog with real base classes for its GTK subclasses."""
-    repository = sys.modules["gi.repository"]
-    bases = {name: type(name, (), {}) for name in ("Box", "ListBoxRow", "Dialog")}
-    saved = sys.modules.pop("vocalinux.ui.settings_dialog", None)
-    try:
-        with patch.object(repository, "Gtk", MagicMock(**bases)):
-            module = importlib.import_module("vocalinux.ui.settings_dialog")
-    finally:
-        sys.modules.pop("vocalinux.ui.settings_dialog", None)
-        if saved is not None:
-            sys.modules["vocalinux.ui.settings_dialog"] = saved
-    return module
+from vocalinux.ui import settings_dialog
+from vocalinux.ui.settings_dialog import (
+    _UNUSED_DOWNLOADS_MAX_HEIGHT,
+    _clamp_unused_downloads_height,
+)
 
 
-settings_dialog = _load_settings_dialog()
-SettingsDialog = settings_dialog.SettingsDialog
-MAX_HEIGHT = settings_dialog._UNUSED_DOWNLOADS_MAX_HEIGHT
-
-
-def _dialog_stub(natural_height):
-    dialog = Mock()
-    dialog.unused_models_group.listbox.get_preferred_height.return_value = (
-        natural_height,
-        natural_height,
-    )
-    return dialog
+def _method_source(name: str) -> str:
+    src = inspect.getsource(settings_dialog)
+    match = re.search(rf"\n    def {name}\(.*?(?=\n    def )", src, re.DOTALL)
+    assert match, f"could not locate method {name}"
+    return match.group(0)
 
 
 def test_list_is_as_tall_as_its_rows_render():
-    """Two rows that render 132px tall must not be squeezed into an estimate."""
-    dialog = _dialog_stub(132)
+    """Two rows that measure 116px must not be squeezed into an estimate.
 
-    SettingsDialog._fit_unused_downloads_height(dialog)
-
-    dialog.unused_models_scroll.set_min_content_height.assert_called_once_with(132)
+    56px per row was the old guess; real rows render taller than that once
+    margins and the Delete button are counted, which cut off the last row
+    while the header still counted it (#683).
+    """
+    assert _clamp_unused_downloads_height(116) == 116
 
 
 def test_long_lists_stop_growing_at_the_cap():
     """Beyond the cap the list scrolls instead of pushing the page down."""
-    dialog = _dialog_stub(MAX_HEIGHT * 3)
+    assert _clamp_unused_downloads_height(_UNUSED_DOWNLOADS_MAX_HEIGHT * 3) == (
+        _UNUSED_DOWNLOADS_MAX_HEIGHT
+    )
 
-    SettingsDialog._fit_unused_downloads_height(dialog)
 
-    dialog.unused_models_scroll.set_min_content_height.assert_called_once_with(MAX_HEIGHT)
+def test_refresh_sizes_the_list_after_building_the_rows():
+    """A measured height is worthless if the refresh never asks for one."""
+    body = _method_source("_refresh_unused_downloads")
+    assert "self._fit_unused_downloads_height()" in body
+    # The per-row estimate is what clipped the list; it must not come back.
+    assert "56 *" not in body
+
+
+def test_fit_measures_the_listbox_and_feeds_the_scroll():
+    body = _method_source("_fit_unused_downloads_height")
+    assert "self.unused_models_group.listbox.get_preferred_height()" in body
+    assert "self.unused_models_scroll.set_min_content_height(" in body
+    assert "_clamp_unused_downloads_height(natural_height)" in body
+
+
+def test_scrollbar_stays_in_the_layout():
+    """An overlay scrollbar hides until hovered, so a capped list looks whole."""
+    src = inspect.getsource(settings_dialog)
+    assert "self.unused_models_scroll.set_overlay_scrolling(False)" in src


### PR DESCRIPTION
Fixes #683.

## Problem

`_refresh_unused_downloads()` sized the list from a per-row estimate, before the rows existed:

```python
self.unused_models_scroll.set_min_content_height(min(220, 56 * count))
```

A `PreferenceRow` does not render in 56px — 12px top and bottom margins around a title/subtitle stack next to a Delete button make it noticeably taller. With two leftover whisper.cpp models the expander header correctly said "2 leftover models" while the viewport only had room for the first row: the second was clipped below the edge, so it could neither be seen nor deleted. Nothing signalled the clipping either, because `AUTOMATIC` policy draws an overlay scrollbar that stays invisible until hovered.

The header and the rows come from the same list, so the count was always right — only the height was guessed.

## Change

- Measure the list after its rows are in place (`get_preferred_height()`) and cap that at the existing 220px, now a named constant. The clamp itself is a module-level helper, `_clamp_unused_downloads_height()`.
- Turn off overlay scrolling for this list, so when a genuinely long list does hit the cap the scrollbar takes part in the layout and the clipping is visible.
- Backstop for the collapsed-measure question from review: the refresh measures while the expander is collapsed and the dialog may not be mapped yet. `notify::expanded` now remeasures, so even if that first `get_preferred_height()` ever came back short, expanding the list fixes the height before the user can see clipped rows.

## Tests

The previous revision reimported `vocalinux.ui.settings_dialog` at collection time and restored only `sys.modules`, which is what broke `test_model_deletion` on 3.9/3.10. That is gone: `tests/test_unused_downloads_height.py` now touches no interpreter state at all. The arithmetic lives in the pure helper and is tested directly; the wiring is asserted with `inspect.getsource`, the existing idiom from `test_settings_mode_change.py`:

- a list whose rows render taller than the old 56px estimate gets its full measured height, and a very long list is capped instead of pushing the page down;
- `_refresh_unused_downloads` calls `_fit_unused_downloads_height()` and the per-row estimate does not come back;
- `_fit_unused_downloads_height` measures the listbox and feeds the scroll;
- overlay scrolling stays off; expanding the expander remeasures.

Each wiring test goes red when its hunk is reverted. Full suite diffed against the `main` baseline: no new failures. flake8/black/isort as CI runs them: clean.

