### PR TITLE
docs: add Discord and VocaHQ README shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
+[![Discord](https://img.shields.io/discord/1538633755877580810?logo=discord&logoColor=white&label=Discord)](https://discord.gg/UMJduhcqn)
+[![VocaHQ](https://img.shields.io/badge/VocaHQ-vocahq.com-1a7f4e)](https://vocahq.com)
 
 <!-- Identity + quality (medium) -->
 [![GitHub release](https://img.shields.io/github/v/release/jatinkrmalik/vocalinux)](https://github.com/jatinkrmalik/vocalinux/releases)


### PR DESCRIPTION
Adds two badges next to the existing README shields.

- Discord: live shields.io badge for guild 1538633755877580810. The badge links to https://discord.gg/UMJduhcqn so people can join. Online count shows once Server Widget is enabled on the Discord server.
- VocaHQ: links to https://vocahq.com for the rest of the product family.

README only.