### PR TITLE
fix(docs): VocaGateway rename and homepage GITHUB_REPO_URL reuse

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,7 +337,7 @@ Contributions are licensed under the [GNU Affero General Public License v3.0](LI
 (AGPL-3.0), matching the other [VocaHQ](https://github.com/VocaHQ) distribution
 projects ([VocaMac](https://github.com/VocaHQ/vocamac),
 [VocaPhone](https://github.com/VocaHQ/vocaphone),
-[VocaServer](https://github.com/VocaHQ/vocaserver)). By opening a pull request, you
+[VocaGateway](https://github.com/VocaHQ/vocagateway)). By opening a pull request, you
 agree that your contribution may be distributed under that license.
 
 ---

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ This project is licensed under the **GNU Affero General Public License v3.0**
 ([AGPL-3.0](LICENSE)), aligning with the other [VocaHQ](https://github.com/VocaHQ)
 distribution projects ([VocaMac](https://github.com/VocaHQ/vocamac),
 [VocaPhone](https://github.com/VocaHQ/vocaphone),
-[VocaServer](https://github.com/VocaHQ/vocaserver)).
+[VocaGateway](https://github.com/VocaHQ/vocagateway)).
 
 You may use, study, modify, and redistribute the software under AGPL-3.0. If you
 run a modified version as a network service, AGPL also requires that you make the

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -16,17 +16,22 @@ import {
 import { ThemeToggle } from "@/components/theme-toggle";
 import { VocalinuxLogo } from "@/components/optimized-image";
 import { ThemeScreenshotImage } from "@/components/theme-screenshot";
+import { GITHUB_REPO_URL } from "@/lib/seo";
+
+const GITHUB_REPO_PATH = GITHUB_REPO_URL.replace("https://github.com/", "");
+const GITHUB_RAW_BASE = `https://raw.githubusercontent.com/${GITHUB_REPO_PATH}`;
+const GITHUB_API_REPO_URL = `https://api.github.com/repos/${GITHUB_REPO_PATH}`;
 
 // Always uses main/install.sh. The installer dynamically resolves the latest release tag via GitHub API
 const installCommands = {
-  interactiveInstallCommand: `curl -fsSL https://raw.githubusercontent.com/VocaHQ/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --interactive`,
+  interactiveInstallCommand: `curl -fsSL ${GITHUB_RAW_BASE}/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh --interactive`,
   interactiveInstallDisplayCommand: `curl -fsSL \\
-  https://raw.githubusercontent.com/VocaHQ/vocalinux/main/install.sh \\
+  ${GITHUB_RAW_BASE}/main/install.sh \\
   -o /tmp/vl.sh && \\
 bash /tmp/vl.sh --interactive`,
-  uninstallCommand: `curl -fsSL https://raw.githubusercontent.com/VocaHQ/vocalinux/main/uninstall.sh -o /tmp/vul.sh && bash /tmp/vul.sh`,
+  uninstallCommand: `curl -fsSL ${GITHUB_RAW_BASE}/main/uninstall.sh -o /tmp/vul.sh && bash /tmp/vul.sh`,
   uninstallDisplayCommand: `curl -fsSL \\
-  https://raw.githubusercontent.com/VocaHQ/vocalinux/main/uninstall.sh \\
+  ${GITHUB_RAW_BASE}/main/uninstall.sh \\
   -o /tmp/vul.sh && \\
 bash /tmp/vul.sh`,
 };
@@ -40,7 +45,7 @@ const homeJsonLd = [
     applicationCategory: "UtilitiesApplication",
     operatingSystem: "Linux",
     isAccessibleForFree: true,
-    license: "https://github.com/VocaHQ/vocalinux/blob/main/LICENSE",
+    license: `${GITHUB_REPO_URL}/blob/main/LICENSE`,
     offers: {
       "@type": "Offer",
       price: "0",
@@ -55,7 +60,7 @@ const homeJsonLd = [
       url: "https://github.com/jatinkrmalik",
     },
     url: "https://vocalinux.com/",
-    downloadUrl: "https://github.com/VocaHQ/vocalinux",
+    downloadUrl: GITHUB_REPO_URL,
     screenshot: "https://vocalinux.com/og-image.png",
     featureList: [
       "100% offline speech recognition",
@@ -320,7 +325,7 @@ export default function HomePage() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   useEffect(() => {
-    fetch("https://api.github.com/repos/VocaHQ/vocalinux")
+    fetch(GITHUB_API_REPO_URL)
       .then((res) => res.json())
       .then((data) => {
         if (data.stargazers_count) setStars(data.stargazers_count);
@@ -380,7 +385,7 @@ export default function HomePage() {
               ),
             )}
             <a
-              href="https://github.com/VocaHQ/vocalinux"
+              href={GITHUB_REPO_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
@@ -433,7 +438,7 @@ export default function HomePage() {
                 ),
               )}
               <a
-                href="https://github.com/VocaHQ/vocalinux"
+                href={GITHUB_REPO_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-md px-2 py-2.5 text-sm font-medium"
@@ -480,7 +485,7 @@ export default function HomePage() {
                 Install Vocalinux
               </a>
               <a
-                href="https://github.com/VocaHQ/vocalinux"
+                href={GITHUB_REPO_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="btn-secondary w-full sm:w-auto"
@@ -572,7 +577,7 @@ export default function HomePage() {
               <code className="font-mono text-emerald-400">vocalinux</code>
             </span>
             <a
-              href="https://github.com/VocaHQ/vocalinux/releases"
+              href={`${GITHUB_REPO_URL}/releases`}
               className="text-zinc-100 underline-offset-4 hover:underline"
             >
               AppImage downloads
@@ -1072,7 +1077,7 @@ export default function HomePage() {
                 status: "You are here",
                 body: "System tray app with whisper.cpp, Vulkan, and full offline support on Linux.",
                 site: "#install",
-                gh: "https://github.com/VocaHQ/vocalinux",
+                gh: GITHUB_REPO_URL,
                 primary: true,
               },
               {
@@ -1139,7 +1144,7 @@ export default function HomePage() {
               Install Vocalinux
             </a>
             <a
-              href="https://github.com/VocaHQ/vocalinux"
+              href={GITHUB_REPO_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="btn-secondary"
@@ -1165,7 +1170,7 @@ export default function HomePage() {
                 Free open-source voice dictation for Linux. Offline by default.
               </p>
               <a
-                href="https://github.com/VocaHQ/vocalinux"
+                href={GITHUB_REPO_URL}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-zinc-400 transition-colors hover:text-white"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Follow-up nits after #696 (point GitHub URLs at VocaHQ):

1. **Sibling product rename** — README and CONTRIBUTING still said **VocaServer** and linked `VocaHQ/vocaserver` (301s to vocagateway). Updated to **VocaGateway** / `VocaHQ/vocagateway`. Repo-wide search found no other current-facing `VocaServer`/`vocaserver` leftovers.
2. **Homepage URL DRY** — `GITHUB_REPO_URL` already existed in `web/src/lib/seo.ts` and was used in `layout.tsx`, but `web/src/app/page.tsx` still hard-coded `github.com/VocaHQ/vocalinux` (and derived raw/API URLs). Homepage links, install/uninstall commands, JSON-LD, and the stars API fetch now derive from `GITHUB_REPO_URL`.

Personal identity surfaces (jatinkrmalik email/X/Codeberg/Sponsors) are untouched.

## Related Issue

Follow-up to #696 review nits (non-blocking).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📖 Documentation update
- [x] 🧹 Code refactoring
- [ ] ✅ Test update

## Checklist

- [x] My code follows the code style of this project (black, isort)
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass locally
- [ ] Pre-commit hooks pass

## Test plan

- [x] `rg 'VocaServer|vocaserver'` → no matches
- [x] `rg 'github.com/VocaHQ/vocalinux' web/src/app/page.tsx` → no hardcoded leftovers (uses `GITHUB_REPO_URL`)
- [x] `cd web && npm run typecheck` → pass
- [x] `cd web && npm test` → 8 suites / 70 tests pass

## Additional Notes

Please review and approve; do not auto-merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0688d15f-1852-4c7f-8de2-6e5dcd05475e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0688d15f-1852-4c7f-8de2-6e5dcd05475e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

