### PR TITLE
Point Discord and X community links at VocaHQ

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,6 +322,7 @@ We follow [Semantic Versioning](https://semver.org/):
 
 ### Getting Help
 
+- 💬 [Discord](https://discord.gg/t6muquAJbm) — fastest place to talk with maintainers and other contributors
 - 💬 [GitHub Discussions](https://github.com/VocaHQ/vocalinux/discussions) - Ask questions
 - 🐛 [GitHub Issues](https://github.com/VocaHQ/vocalinux/issues) - Report bugs
 
@@ -329,7 +330,7 @@ We follow [Semantic Versioning](https://semver.org/):
 
 - ⭐ Star the repository to show support
 - 👀 Watch for updates
-- 🐦 Follow [@jatinkrmalik](https://twitter.com/jatinkrmalik) on Twitter
+- 🐦 Follow [@vocahq](https://x.com/vocahq) on X
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
-[![Discord](https://img.shields.io/discord/1538633755877580810?logo=discord&logoColor=white&label=Discord)](https://discord.gg/UMJduhcqn)
+[![Discord](https://img.shields.io/discord/1538633755877580810?logo=discord&logoColor=white&label=Discord)](https://discord.gg/t6muquAJbm)
 [![VocaHQ](https://img.shields.io/badge/VocaHQ-vocahq.com-1a7f4e)](https://vocahq.com)
 
 <!-- Identity + quality (medium) -->
@@ -23,7 +23,7 @@
 [![AUR](https://img.shields.io/aur/version/vocalinux)](https://aur.archlinux.org/packages/vocalinux)
 [![Vocalinux CI](https://github.com/VocaHQ/vocalinux/actions/workflows/unified-pipeline.yml/badge.svg?branch=main)](https://github.com/VocaHQ/vocalinux/actions/workflows/unified-pipeline.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/VocaHQ/vocalinux/branch/main/graph/badge.svg)](https://codecov.io/gh/VocaHQ/vocalinux)
-[![Follow on X](https://img.shields.io/badge/Follow%20%40jatinkrmalik-000000?style=flat&logo=x&logoColor=white)](https://x.com/intent/user?screen_name=jatinkrmalik)
+[![Follow on X](https://img.shields.io/badge/Follow%20%40vocahq-000000?style=flat&logo=x&logoColor=white)](https://x.com/vocahq)
 
 <!-- Distros (widest; base plate above the hero) -->
 [![Ubuntu](https://img.shields.io/badge/Ubuntu-22.04+-E95420?logo=ubuntu&logoColor=white)](docs/DISTRO_COMPATIBILITY.md)

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1222,6 +1222,7 @@ export default function HomePage() {
                   links: [
                     { href: "/faq/", label: "FAQ" },
                     { href: "/troubleshooting/", label: "Troubleshooting" },
+                    { href: "https://discord.gg/t6muquAJbm", label: "Discord" },
                     { href: "/alternatives/", label: "Alternatives" },
                     { href: "/privacy/", label: "Privacy" },
                   ],
@@ -1235,9 +1236,13 @@ export default function HomePage() {
                 <ul className="space-y-2.5 text-sm">
                   {col.links.map((link) => (
                     <li key={link.href + link.label}>
-                      {link.href.startsWith("#") ? (
+                      {link.href.startsWith("#") ||
+                      link.href.startsWith("http") ? (
                         <a
                           href={link.href}
+                          {...(link.href.startsWith("http")
+                            ? { target: "_blank", rel: "noopener noreferrer" }
+                            : {})}
                           className="text-zinc-400 transition-colors hover:text-white"
                         >
                           {link.label}

--- a/web/src/lib/seo.ts
+++ b/web/src/lib/seo.ts
@@ -4,7 +4,7 @@ export const SITE_URL = "https://vocalinux.com";
 export const SITE_NAME = "Vocalinux";
 export const DEFAULT_OG_IMAGE_PATH = "/og-image.png";
 export const DEFAULT_OG_IMAGE_ALT = "Vocalinux - Voice Dictation for Linux";
-export const TWITTER_HANDLE = "@jatinkrmalik";
+export const TWITTER_HANDLE = "@vocahq";
 export const VOCAHQ_URL = "https://vocahq.com";
 export const GITHUB_REPO_URL = "https://github.com/VocaHQ/vocalinux";
 


### PR DESCRIPTION
## Why

We are standing up a shared VocaHQ community so contributors and testers can talk to us without waiting on GitHub issues. The old Discord invite is stale.

## What changed

- Discord invite is now https://discord.gg/t6muquAJbm
- X / Twitter follow shields and public follow links now point at [@vocahq](https://x.com/vocahq) instead of @jatinkrmalik
- Discord is also in contributing/support docs and site footers where people look for help

Personal GitHub credits, old Homebrew tap names, and maintainer emails are unchanged.

## Review

Please approve and merge if the invite and @vocahq handle look right.

Touched: README badges, CONTRIBUTING.md, vocalinux.com footer, twitter:site handle.