### PR TITLE
fix(copy): VocaWin is Beta, still unsigned

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ Vocalinux is part of [VocaHQ](https://vocahq.com). Same privacy-first, offline v
 |----------|---------|---------|--------|--------|
 | 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [VocaHQ/vocalinux](https://github.com/VocaHQ/vocalinux) | ✅ Stable v0.16.0 |
 | 🍎 macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [VocaHQ/vocamac](https://github.com/VocaHQ/vocamac) | 🚀 Beta |
-| 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [VocaHQ/vocawin](https://github.com/VocaHQ/vocawin) | 🚀 Beta |
+| 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [VocaHQ/vocawin](https://github.com/VocaHQ/vocawin) | 🚀 Beta v0.1.0-beta.1 |
 
 > VocaWin is unsigned. SmartScreen may warn about an unknown publisher. It is not a Microsoft Store ship.
 >

--- a/README.md
+++ b/README.md
@@ -462,8 +462,10 @@ Vocalinux is part of [VocaHQ](https://vocahq.com). Same privacy-first, offline v
 |----------|---------|---------|--------|--------|
 | 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [VocaHQ/vocalinux](https://github.com/VocaHQ/vocalinux) | ✅ Stable v0.16.0 |
 | 🍎 macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [VocaHQ/vocamac](https://github.com/VocaHQ/vocamac) | 🚀 Beta |
-| 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [VocaHQ/vocawin](https://github.com/VocaHQ/vocawin) | 📋 Planned |
+| 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [VocaHQ/vocawin](https://github.com/VocaHQ/vocawin) | 🚀 Beta |
 
+> VocaWin is unsigned. SmartScreen may warn about an unknown publisher. It is not a Microsoft Store ship.
+>
 > Each platform uses native technologies for the best possible integration, while sharing the same privacy-first philosophy and offline-only architecture.
 
 ## 🤝 Contributing

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -3645,7 +3645,7 @@ class SettingsDialog(Gtk.Dialog):
             title="Part of VocaHQ",
             description=(
                 "Vocalinux is part of VocaHQ. The same private dictation idea also ships "
-                "as VocaMac (macOS, beta), VocaWin (Windows, unsigned developer alpha), "
+                "as VocaMac (macOS, beta), VocaWin (Windows, unsigned beta), "
                 "and VocaPhone (Android beta / iOS source build). VocaGateway is optional "
                 "self-hosted compute. It is not on-device."
             ),

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -3645,7 +3645,7 @@ class SettingsDialog(Gtk.Dialog):
             title="Part of VocaHQ",
             description=(
                 "Vocalinux is part of VocaHQ. The same private dictation idea also ships "
-                "as VocaMac (macOS, beta), VocaWin (Windows, unsigned beta), "
+                "as VocaMac (macOS, beta), VocaWin (Windows, unsigned beta, v0.1.0-beta.1), "
                 "and VocaPhone (Android beta / iOS source build). VocaGateway is optional "
                 "self-hosted compute. It is not on-device."
             ),

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1040,7 +1040,7 @@ class TestAboutPage(unittest.TestCase):
     def test_product_status_and_honest_network_copy(self):
         self.assertIn("Available now on Linux (X11 and Wayland)", self.about)
         self.assertIn("After a model is downloaded", self.about)
-        self.assertIn("unsigned beta", self.about)
+        self.assertIn("unsigned beta, v0.1.0-beta.1", self.about)
         self.assertIn("Android beta / iOS source build", self.about)
         self.assertIn("optional", self.about.lower())
         self.assertIn("self-hosted compute", self.about)
@@ -1048,6 +1048,7 @@ class TestAboutPage(unittest.TestCase):
         self.assertNotIn("100% offline", self.about)
         self.assertNotIn("fully offline", self.about)
         self.assertNotIn("Coming soon", self.about)
+        self.assertNotIn("releases/download", self.about)
 
     def test_family_and_talk_urls(self):
         for url in (

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1040,7 +1040,7 @@ class TestAboutPage(unittest.TestCase):
     def test_product_status_and_honest_network_copy(self):
         self.assertIn("Available now on Linux (X11 and Wayland)", self.about)
         self.assertIn("After a model is downloaded", self.about)
-        self.assertIn("unsigned developer alpha", self.about)
+        self.assertIn("unsigned beta", self.about)
         self.assertIn("Android beta / iOS source build", self.about)
         self.assertIn("optional", self.about.lower())
         self.assertIn("self-hosted compute", self.about)

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -958,8 +958,8 @@ export default function HomePage() {
               </div>
               <h3>VocaWin</h3>
               <p>
-                Unsigned Windows speech-to-text. SmartScreen may warn about an
-                unknown publisher.
+                Unsigned Windows speech-to-text, v0.1.0-beta.1. SmartScreen may
+                warn about an unknown publisher.
               </p>
             </a>
             <a className="family-card" href="https://vocaphone.vocahq.com">

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -954,7 +954,7 @@ export default function HomePage() {
                   />
                   Windows
                 </span>
-                <span className="chip">Developer alpha</span>
+                <span className="chip">Beta</span>
               </div>
               <h3>VocaWin</h3>
               <p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

VocaWin is Beta on vocalinux.com, in the About family blurb, and in the README family table. Same status word as VocaMac. Not Developer beta.

The Windows card still says the build is unsigned and that SmartScreen may warn about an unknown publisher. About now reads `VocaWin (Windows, unsigned beta, v0.1.0-beta.1)`. README status is Beta v0.1.0-beta.1 instead of Planned, with a note that SmartScreen is expected and this is not a Microsoft Store ship.

v0.1.0-beta.1 is a git tag on VocaHQ/vocawin (374472b). There is no GitHub Release for that tag, so nothing here points at a `/releases/download` URL. People go to https://vocawin.com or https://github.com/VocaHQ/vocawin.

The About test pins `unsigned beta, v0.1.0-beta.1` and rejects a fake download path. Historical changelog lines (including UPDATE.md #717) were left alone. `_VOCAHQ_FAMILY_LINKS` still has no vocawin.com row.

## Related Issue

Jatin locked this copy change.

## Type of Change

- [x] Documentation update
- [x] Test update

## Checklist

- [x] Code follows the project style (black, isort)
- [x] Documentation updated
- [x] Tests cover the About wording
- [x] About page tests pass locally (9 passed)
- [ ] Pre-commit hooks pass

## Additional Notes

Unsigned NSIS/MSI. Unknown publisher is expected. Not a store ship. Git tag only, no Releases asset.

![VocaWin family card on vocalinux.com, chip Beta, body cites v0.1.0-beta.1 and SmartScreen](https://cursor.com/artifacts/c/art-5c9846ab-547e-413c-a858-c42a1811d600)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca174bd9-9d06-4fef-a297-3d41aa2b99d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca174bd9-9d06-4fef-a297-3d41aa2b99d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

