### PR TITLE
fix(injection): use Ctrl+Shift+V when pasting into terminals

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -40,6 +40,12 @@ Vocalinux supports login autostart using the standard Linux desktop-session mech
 
 Vocalinux capitalizes the start of dictation and letters after `.`, `!`, or `?`. Each completed utterance also leaves a trailing space so the next push-to-talk or toggle session does not glue onto the previous sentence (`Hello.This` → `Hello. This`).
 
+### Dictating into terminals
+
+When Vocalinux injects through the clipboard (the usual Wayland / ydotool path), it sends **Ctrl+V** in ordinary text fields and **Ctrl+Shift+V** in terminal emulator windows. Auto-detect covers standalone terminals such as GNOME Terminal, Konsole, Kitty, Alacritty, foot, WezTerm, and Ghostty.
+
+Nested terminal panels inside an IDE are often invisible to window-class detection. If paste lands as a literal `^V` or does nothing, open **Settings → Dictation → Clipboard Paste Shortcut** and choose **Ctrl+Shift+V**. Choose **Ctrl+V** if a window was mis-detected as a terminal.
+
 ### Understanding the Status Icons
 
 - **Microphone off** (gray): Voice typing is inactive

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -42,7 +42,7 @@ Vocalinux capitalizes the start of dictation and letters after `.`, `!`, or `?`.
 
 ### Dictating into terminals
 
-When Vocalinux injects through the clipboard (the usual Wayland / ydotool path), it sends **Ctrl+V** in ordinary text fields and **Ctrl+Shift+V** in terminal emulator windows. Auto-detect covers standalone terminals such as GNOME Terminal, Konsole, Kitty, Alacritty, foot, WezTerm, and Ghostty.
+When Vocalinux injects through the clipboard (the usual Wayland / ydotool path), it sends **Ctrl+V** in ordinary text fields and **Ctrl+Shift+V** in terminal emulator windows. Auto-detect works on X11 and on Hyprland, Sway, and niri. On GNOME or KDE Wayland, set **Settings → Dictation → Clipboard Paste Shortcut** to **Ctrl+Shift+V**.
 
 Nested terminal panels inside an IDE are often invisible to window-class detection. If paste lands as a literal `^V` or does nothing, open **Settings → Dictation → Clipboard Paste Shortcut** and choose **Ctrl+Shift+V**. Choose **Ctrl+V** if a window was mis-detected as a terminal.
 

--- a/src/vocalinux/text_injection/focused_window.py
+++ b/src/vocalinux/text_injection/focused_window.py
@@ -1,0 +1,329 @@
+"""
+Focused-window identity for choosing a clipboard paste shortcut.
+
+Clipboard injection uses Ctrl+V in ordinary text fields and Ctrl+Shift+V in
+terminal emulators. This module identifies the focused window on X11 and on
+common Wayland compositors so injection can pick the right chord.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_PROBE_TIMEOUT = 1.0
+_TOKEN_SPLIT = re.compile(r"[^a-z0-9]+")
+
+# Exact app-id / WM_CLASS / process basename tokens. Keep these specific so
+# editors with a "Terminal" panel or a file named terminal.py are not treated
+# as terminal emulators.
+TERMINAL_APP_TOKENS: frozenset[str] = frozenset(
+    {
+        "alacritty",
+        "blackbox",
+        "console",
+        "contour",
+        "coolretroterm",
+        "deepinterminal",
+        "electerm",
+        "eterm",
+        "foot",
+        "footclient",
+        "ghostty",
+        "gnometerminal",
+        "gnometerminalserver",
+        "guake",
+        "hyper",
+        "kgx",
+        "kitty",
+        "konsole",
+        "lxterminal",
+        "mateterminal",
+        "ptyxis",
+        "qterminal",
+        "rio",
+        "rxvt",
+        "rxvtunicode",
+        "sakura",
+        "st",
+        "stterm",
+        "tabby",
+        "terminator",
+        "terminology",
+        "tilix",
+        "tilda",
+        "urxvt",
+        "uxterm",
+        "warp",
+        "wezterm",
+        "weztermgui",
+        "xfce4terminal",
+        "xterm",
+        "yakuake",
+    }
+)
+
+# Broader class/app-id fragments that still mean "this is a terminal app".
+# Applied only to app_id / wm_class / process name, never to the window title.
+_TERMINAL_IDENTITY_HINTS: tuple[str, ...] = (
+    "terminal",
+    "konsole",
+    "alacritty",
+    "wezterm",
+    "ghostty",
+    "kitty",
+)
+
+# IDEs and editors whose window title often contains "Terminal" for a nested
+# panel. Auto-detect must not treat those as standalone terminal emulators.
+_NESTED_TERMINAL_HOSTS: frozenset[str] = frozenset(
+    {
+        "atom",
+        "code",
+        "codeoss",
+        "codium",
+        "cursor",
+        "gnomebuilder",
+        "jetbrains",
+        "sublime",
+        "sublimetext",
+        "vscodium",
+        "zed",
+        "zededitor",
+    }
+)
+
+
+@dataclass(frozen=True)
+class FocusedWindow:
+    """Identity of the currently focused window, when it can be determined."""
+
+    app_id: str = ""
+    wm_class: str = ""
+    title: str = ""
+    process_name: str = ""
+
+    def identity_blob(self) -> str:
+        """Return a lowercase blob of app identity fields, excluding the title."""
+        parts = [self.app_id, self.wm_class, self.process_name]
+        return " ".join(part for part in parts if part).lower()
+
+
+def _normalize_token(value: str) -> str:
+    """Collapse a class, app-id, or process name to an alphanumeric token."""
+    return _TOKEN_SPLIT.sub("", value.lower())
+
+
+def _identity_tokens(window: FocusedWindow) -> set[str]:
+    """Return normalized tokens from app identity fields."""
+    tokens: set[str] = set()
+    for raw in (window.app_id, window.wm_class, window.process_name):
+        if not raw:
+            continue
+        lowered = raw.lower()
+        tokens.add(_normalize_token(lowered))
+        tokens.update(part for part in _TOKEN_SPLIT.split(lowered) if part)
+        # org.gnome.Terminal -> also keep the last dotted component.
+        if "." in lowered:
+            tokens.add(_normalize_token(lowered.rsplit(".", 1)[-1]))
+    tokens.discard("")
+    return tokens
+
+
+def looks_like_terminal(window: FocusedWindow) -> bool:
+    """Return True when the window identity is a standalone terminal emulator.
+
+    Nested terminal panels inside IDEs are left to the Settings override,
+    because window title matching is too noisy (``terminal.py``, "Terminal"
+    sidebars, and similar).
+    """
+    tokens = _identity_tokens(window)
+    if tokens & _NESTED_TERMINAL_HOSTS:
+        return False
+    if tokens & TERMINAL_APP_TOKENS:
+        return True
+    identity = window.identity_blob()
+    return any(hint in identity for hint in _TERMINAL_IDENTITY_HINTS)
+
+
+def _run_text(cmd: list[str], env: Optional[dict[str, str]] = None) -> str:
+    """Run a short command and return stripped stdout, or empty on failure."""
+    try:
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=_PROBE_TIMEOUT,
+            check=False,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return (result.stdout or "").strip()
+
+
+def _process_name_for_pid(pid: str) -> str:
+    """Read ``/proc/<pid>/comm`` when the pid looks numeric."""
+    if not pid.isdigit():
+        return ""
+    try:
+        with open(f"/proc/{pid}/comm", "r", encoding="utf-8") as handle:
+            return handle.read().strip()
+    except OSError:
+        return ""
+
+
+def _x11_probe_env() -> dict[str, str]:
+    """Return an env mapping that can talk to X11 or XWayland."""
+    env = os.environ.copy()
+    if not env.get("DISPLAY"):
+        env["DISPLAY"] = ":0"
+    return env
+
+
+def _focused_window_x11() -> Optional[FocusedWindow]:
+    """Identify the active X11 / XWayland window via xdotool."""
+    if not shutil.which("xdotool"):
+        return None
+    env = _x11_probe_env()
+    window_id = _run_text(["xdotool", "getactivewindow"], env)
+    if not window_id:
+        return None
+    wm_class = _run_text(["xdotool", "getwindowclassname", window_id], env)
+    title = _run_text(["xdotool", "getwindowname", window_id], env)
+    pid = _run_text(["xdotool", "getwindowpid", window_id], env)
+    if shutil.which("xprop") and not wm_class:
+        xprop = _run_text(["xprop", "-id", window_id, "WM_CLASS"], env)
+        quoted = re.findall(r'"([^"]+)"', xprop)
+        if quoted:
+            wm_class = " ".join(quoted)
+    return FocusedWindow(
+        wm_class=wm_class,
+        title=title,
+        process_name=_process_name_for_pid(pid),
+    )
+
+
+def _first_string(payload: dict[str, Any], *keys: str) -> str:
+    """Return the first non-empty string value for the given keys."""
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ""
+
+
+def _pid_from_payload(payload: dict[str, Any]) -> str:
+    """Return a pid string from common compositor JSON fields."""
+    value = payload.get("pid")
+    if isinstance(value, int) and value > 0:
+        return str(value)
+    if isinstance(value, str) and value.isdigit():
+        return value
+    return ""
+
+
+def _focused_from_json_object(payload: dict[str, Any]) -> FocusedWindow:
+    """Build a FocusedWindow from a compositor JSON object."""
+    wm_class = _first_string(payload, "class", "app_id")
+    window_properties = payload.get("window_properties")
+    if isinstance(window_properties, dict):
+        wm_class = wm_class or _first_string(window_properties, "class", "instance")
+    pid = _pid_from_payload(payload)
+    return FocusedWindow(
+        app_id=_first_string(payload, "app_id", "class"),
+        wm_class=wm_class,
+        title=_first_string(payload, "title", "name"),
+        process_name=_process_name_for_pid(pid),
+    )
+
+
+def _find_focused_sway_node(node: Any) -> Optional[dict[str, Any]]:
+    """Walk a Sway/i3 tree and return the focused container."""
+    if not isinstance(node, dict):
+        return None
+    if node.get("focused"):
+        return node
+    for key in ("nodes", "floating_nodes"):
+        children = node.get(key)
+        if not isinstance(children, list):
+            continue
+        for child in children:
+            found = _find_focused_sway_node(child)
+            if found is not None:
+                return found
+    return None
+
+
+def _load_json_command(cmd: list[str]) -> Any:
+    """Run a command that prints JSON, or return None."""
+    if not shutil.which(cmd[0]):
+        return None
+    raw = _run_text(cmd)
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        logger.debug("Could not parse JSON from %s", cmd[0])
+        return None
+
+
+def _focused_window_wayland() -> Optional[FocusedWindow]:
+    """Identify the focused window on Hyprland, Sway, or niri."""
+    hypr = _load_json_command(["hyprctl", "activewindow", "-j"])
+    if isinstance(hypr, dict) and hypr:
+        return _focused_from_json_object(hypr)
+
+    niri = _load_json_command(["niri", "msg", "-j", "focused-window"])
+    if isinstance(niri, dict) and niri:
+        return _focused_from_json_object(niri)
+
+    sway_tree = _load_json_command(["swaymsg", "-t", "get_tree"])
+    if sway_tree is None:
+        sway_tree = _load_json_command(["i3-msg", "-t", "get_tree"])
+    if isinstance(sway_tree, dict):
+        focused = _find_focused_sway_node(sway_tree)
+        if focused is not None:
+            return _focused_from_json_object(focused)
+    return None
+
+
+def get_focused_window() -> Optional[FocusedWindow]:
+    """Return focused-window identity, or None when it cannot be determined."""
+    try:
+        if os.environ.get("WAYLAND_DISPLAY"):
+            wayland = _focused_window_wayland()
+            if wayland is not None:
+                return wayland
+        return _focused_window_x11()
+    except Exception as exc:
+        logger.debug("Focused window probe failed: %s", exc)
+        return None
+
+
+def is_focused_window_terminal() -> bool:
+    """Return True when the focused window looks like a terminal emulator."""
+    window = get_focused_window()
+    if window is None:
+        return False
+    is_terminal = looks_like_terminal(window)
+    if is_terminal:
+        logger.debug(
+            "Focused window looks like a terminal: app_id=%r class=%r process=%r",
+            window.app_id,
+            window.wm_class,
+            window.process_name,
+        )
+    return is_terminal

--- a/src/vocalinux/text_injection/focused_window.py
+++ b/src/vocalinux/text_injection/focused_window.py
@@ -113,12 +113,18 @@ class FocusedWindow:
 
     def identity_blob(self) -> str:
         """Return a lowercase blob of app identity fields, excluding the title."""
-        parts = [self.app_id, self.wm_class, self.process_name]
-        return " ".join(part for part in parts if part).lower()
+        parts = [
+            part
+            for part in (self.app_id, self.wm_class, self.process_name)
+            if isinstance(part, str) and part
+        ]
+        return " ".join(parts).lower()
 
 
 def _normalize_token(value: str) -> str:
     """Collapse a class, app-id, or process name to an alphanumeric token."""
+    if not isinstance(value, str):
+        return ""
     return _TOKEN_SPLIT.sub("", value.lower())
 
 
@@ -126,7 +132,7 @@ def _identity_tokens(window: FocusedWindow) -> set[str]:
     """Return normalized tokens from app identity fields."""
     tokens: set[str] = set()
     for raw in (window.app_id, window.wm_class, window.process_name):
-        if not raw:
+        if not isinstance(raw, str) or not raw:
             continue
         lowered = raw.lower()
         tokens.add(_normalize_token(lowered))
@@ -170,12 +176,15 @@ def _run_text(cmd: list[str], env: Optional[dict[str, str]] = None) -> str:
         return ""
     if result.returncode != 0:
         return ""
-    return (result.stdout or "").strip()
+    stdout = result.stdout
+    if not isinstance(stdout, str):
+        return ""
+    return stdout.strip()
 
 
 def _process_name_for_pid(pid: str) -> str:
     """Read ``/proc/<pid>/comm`` when the pid looks numeric."""
-    if not pid.isdigit():
+    if not isinstance(pid, str) or not pid.isdigit():
         return ""
     try:
         with open(f"/proc/{pid}/comm", "r", encoding="utf-8") as handle:

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -17,6 +17,7 @@ from enum import Enum
 from typing import Optional  # noqa: F401
 
 from ..utils.paths import config_dir
+from .focused_window import is_focused_window_terminal
 from .ibus_engine import (
     IBusTextInjector,
     is_ibus_active_input_method,
@@ -976,7 +977,7 @@ class TextInjector:
                     "-a",
                     "Vocalinux",
                     "Text copied to clipboard",
-                    "Text injection failed - paste with Ctrl+V",
+                    "Text injection failed — paste with Ctrl+V " "(Ctrl+Shift+V in a terminal)",
                 ],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -1308,14 +1309,44 @@ class TextInjector:
 
         return "" if saw_empty else None
 
+    def _paste_shortcut_preference(self) -> str:
+        """Return the configured clipboard-paste shortcut id."""
+        from ..ui.config_manager import DEFAULT_PASTE_SHORTCUT, normalize_paste_shortcut
+
+        try:
+            import json
+
+            config_path = os.path.join(config_dir(), "config.json")
+            if os.path.exists(config_path):
+                with open(config_path, "r") as handle:
+                    config = json.load(handle)
+                return normalize_paste_shortcut(
+                    config.get("text_injection", {}).get("paste_shortcut")
+                )
+        except Exception as exc:
+            logger.debug(f"Could not read paste_shortcut setting: {exc}")
+        return DEFAULT_PASTE_SHORTCUT
+
+    def _should_use_terminal_paste(self) -> bool:
+        """Return True when clipboard injection should send Ctrl+Shift+V."""
+        preference = self._paste_shortcut_preference()
+        if preference == "ctrl+shift+v":
+            return True
+        if preference == "ctrl+v":
+            return False
+        return is_focused_window_terminal()
+
     def _inject_via_clipboard_paste(self, text: str) -> bool:
         """
-        Inject text by copying to clipboard and simulating Ctrl+V with ydotool.
+        Inject text by copying to clipboard and simulating a paste with ydotool.
 
-        Workaround for ydotool's US-ASCII-only key events (see issue #362).
-        Saves the previous clipboard and restores it after a short delay.
-        Overlapping pastes share one restore target (pre-first-injection content)
-        and a generation counter so stale restore threads exit.
+        Ordinary text fields receive Ctrl+V. Terminal emulators typically bind
+        paste to Ctrl+Shift+V, so auto-detect (or the Settings override) picks
+        that chord instead. Workaround for ydotool's US-ASCII-only key events
+        (see issue #362). Saves the previous clipboard and restores it after a
+        short delay. Overlapping pastes share one restore target
+        (pre-first-injection content) and a generation counter so stale restore
+        threads exit.
 
         Returns:
             True if successful, False otherwise
@@ -1342,13 +1373,18 @@ class TextInjector:
             self._clipboard_restore_generation += 1
             generation = self._clipboard_restore_generation
 
-        # Simulate Ctrl+V via ydotool. Syntax differs by major version:
+        # Simulate paste via ydotool. Syntax differs by major version:
         # - 0.1.x (distro packages): named sequences, e.g. ctrl+v
-        # - 1.x (Flatpak build): keycode:value  (29=LEFTCTRL, 47=V)
+        # - 1.x (Flatpak build): keycode:value  (29=LEFTCTRL, 42=LEFTSHIFT, 47=V)
         # Passing 1.x codes to 0.1.x does not paste; it types garbage (e.g. "2442").
         try:
-            cmd = self._ydotool_ctrl_v_command()
-            logger.debug(f"Simulating paste with: {cmd}")
+            use_terminal_paste = self._should_use_terminal_paste()
+            cmd = self._ydotool_ctrl_v_command(terminal=use_terminal_paste)
+            logger.debug(
+                "Simulating %s paste with: %s",
+                "terminal" if use_terminal_paste else "standard",
+                cmd,
+            )
             subprocess.run(
                 cmd,
                 check=True,
@@ -1402,32 +1438,25 @@ class TextInjector:
 
         return True
 
-    # ydotool 1.x (Flatpak pins v1.0.4): KEY_LEFTCTRL=29, KEY_V=47 press/release.
+    # ydotool 1.x (Flatpak pins v1.0.4): KEY_LEFTCTRL=29, KEY_LEFTSHIFT=42, KEY_V=47.
     _YDOTOOL_V1_CTRL_V = ["ydotool", "key", "29:1", "47:1", "47:0", "29:0"]
+    _YDOTOOL_V1_CTRL_SHIFT_V = ["ydotool", "key", "29:1", "42:1", "47:1", "47:0", "42:0", "29:0"]
     # ydotool 0.1.x (common distro packages): named key sequences.
     _YDOTOOL_LEGACY_CTRL_V = ["ydotool", "key", "ctrl+v"]
+    _YDOTOOL_LEGACY_CTRL_SHIFT_V = ["ydotool", "key", "ctrl+shift+v"]
 
-    def _ydotool_ctrl_v_command(self) -> list:
-        """Return argv to simulate Ctrl+V for the installed ydotool.
-
-        ydotool 0.1.x expects ``key ctrl+v``. ydotool 1.x expects
-        ``key 29:1 47:1 47:0 29:0`` (evdev press/release).
-
-        Flatpak always ships pinned ydotool 1.0.4 under /app, so we use the
-        keycode form there without probing. Host installs probe ``key --help``.
-        """
-        cached = getattr(self, "_ydotool_ctrl_v_cmd", None)
+    def _ydotool_uses_legacy_named_keys(self) -> bool:
+        """Return True when the installed ydotool expects named key sequences."""
+        cached = getattr(self, "_ydotool_legacy_named_keys", None)
         if cached is not None:
-            return list(cached)
+            return bool(cached)
 
-        # Flatpak package pins ydotool v1.0.4 (see packaging/flatpak manifest).
         ydotool_path = shutil.which("ydotool")
         if not isinstance(ydotool_path, str):
             ydotool_path = ""
         if os.environ.get("FLATPAK_ID") or ydotool_path.startswith("/app/"):
-            cmd = list(self._YDOTOOL_V1_CTRL_V)
-            self._ydotool_ctrl_v_cmd = cmd
-            return list(cmd)
+            self._ydotool_legacy_named_keys = False
+            return False
 
         help_text = ""
         try:
@@ -1443,16 +1472,42 @@ class TextInjector:
 
         # 0.1.x help: "separated by plus (+)" / examples like alt+r, CTRL+alt+f3
         if "plus (+)" in help_text or "separated by plus" in help_text.lower():
-            cmd = list(self._YDOTOOL_LEGACY_CTRL_V)
+            uses_legacy = True
         elif ":1" in help_text or "keycode" in help_text.lower():
-            cmd = list(self._YDOTOOL_V1_CTRL_V)
+            uses_legacy = False
         else:
             # Unknown help text: prefer named sequence (safe on 0.1.x; fails
             # loudly on 1.x rather than typing digit garbage).
-            logger.debug("Unrecognized ydotool key --help; defaulting to legacy ctrl+v syntax")
-            cmd = list(self._YDOTOOL_LEGACY_CTRL_V)
+            logger.debug("Unrecognized ydotool key --help; defaulting to legacy named keys")
+            uses_legacy = True
 
-        self._ydotool_ctrl_v_cmd = cmd
+        self._ydotool_legacy_named_keys = uses_legacy
+        return uses_legacy
+
+    def _ydotool_ctrl_v_command(self, *, terminal: bool = False) -> list:
+        """Return argv to simulate paste for the installed ydotool.
+
+        ydotool 0.1.x expects ``key ctrl+v`` or ``key ctrl+shift+v``. ydotool 1.x
+        expects evdev press/release keycodes (29=LEFTCTRL, 42=LEFTSHIFT, 47=V).
+
+        Flatpak always ships pinned ydotool 1.0.4 under /app, so we use the
+        keycode form there without probing. Host installs probe ``key --help``.
+        """
+        cache_attr = "_ydotool_terminal_paste_cmd" if terminal else "_ydotool_ctrl_v_cmd"
+        cached = getattr(self, cache_attr, None)
+        if cached is not None:
+            return list(cached)
+
+        if self._ydotool_uses_legacy_named_keys():
+            cmd = (
+                list(self._YDOTOOL_LEGACY_CTRL_SHIFT_V)
+                if terminal
+                else list(self._YDOTOOL_LEGACY_CTRL_V)
+            )
+        else:
+            cmd = list(self._YDOTOOL_V1_CTRL_SHIFT_V) if terminal else list(self._YDOTOOL_V1_CTRL_V)
+
+        setattr(self, cache_attr, cmd)
         return list(cmd)
 
     # evdev keycodes for modifier keys. If any of these is still physically held

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -1328,13 +1328,21 @@ class TextInjector:
         return DEFAULT_PASTE_SHORTCUT
 
     def _should_use_terminal_paste(self) -> bool:
-        """Return True when clipboard injection should send Ctrl+Shift+V."""
-        preference = self._paste_shortcut_preference()
-        if preference == "ctrl+shift+v":
-            return True
-        if preference == "ctrl+v":
+        """Return True when clipboard injection should send Ctrl+Shift+V.
+
+        Detection is best-effort. A probe error must not abort injection — the
+        caller falls back to Ctrl+V.
+        """
+        try:
+            preference = self._paste_shortcut_preference()
+            if preference == "ctrl+shift+v":
+                return True
+            if preference == "ctrl+v":
+                return False
+            return bool(is_focused_window_terminal())
+        except Exception as exc:
+            logger.debug(f"Terminal paste detection failed: {exc}")
             return False
-        return is_focused_window_terminal()
 
     def _inject_via_clipboard_paste(self, text: str) -> bool:
         """

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -36,6 +36,21 @@ SOUND_EFFECT_TONES: tuple[tuple[str, str], ...] = (
 SOUND_EFFECT_TONE_IDS = frozenset(tone_id for tone_id, _label in SOUND_EFFECT_TONES)
 DEFAULT_SOUND_EFFECT_TONE = "voca"
 
+PASTE_SHORTCUTS: tuple[tuple[str, str], ...] = (
+    ("auto", "Auto-detect"),
+    ("ctrl+v", "Ctrl+V"),
+    ("ctrl+shift+v", "Ctrl+Shift+V"),
+)
+PASTE_SHORTCUT_IDS = frozenset(shortcut_id for shortcut_id, _label in PASTE_SHORTCUTS)
+DEFAULT_PASTE_SHORTCUT = "auto"
+
+
+def normalize_paste_shortcut(shortcut: Any) -> str:
+    """Return a paste-shortcut id. Missing or unknown values become auto."""
+    if isinstance(shortcut, str) and shortcut in PASTE_SHORTCUT_IDS:
+        return shortcut
+    return DEFAULT_PASTE_SHORTCUT
+
 
 def normalize_sound_effect_tone(tone: Any) -> str:
     """Return a catalog id. Missing, blank, or unknown values become voca."""
@@ -107,6 +122,9 @@ DEFAULT_CONFIG = {
         # the next dictation session (push-to-talk / toggle) continues cleanly
         # without glueing onto the previous sentence ("Hello.This").
         "append_trailing_space": True,
+        # Clipboard-paste chord: auto-detect terminals, or force Ctrl+V /
+        # Ctrl+Shift+V when a nested terminal panel is not detected.
+        "paste_shortcut": "auto",
     },
     "advanced": {
         "power_user_mode": False,
@@ -459,6 +477,16 @@ class ConfigManager:
         if "sound_effects" not in self.config:
             self.config["sound_effects"] = {}
         self.config["sound_effects"]["tone"] = normalize_sound_effect_tone(tone)
+
+    def get_paste_shortcut(self) -> str:
+        """Return the clipboard-paste shortcut id (auto when unset or unknown)."""
+        return normalize_paste_shortcut(self.config.get("text_injection", {}).get("paste_shortcut"))
+
+    def set_paste_shortcut(self, shortcut: str) -> None:
+        """Save a paste-shortcut id. Unknown ids are stored as auto."""
+        if "text_injection" not in self.config:
+            self.config["text_injection"] = {}
+        self.config["text_injection"]["paste_shortcut"] = normalize_paste_shortcut(shortcut)
 
     def _update_dict_recursive(self, target: dict, source: dict):
         """

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -75,7 +75,9 @@ from ..utils.whispercpp_model_info import (
 from ..version import __copyright__, __url__, __version__  # noqa: E402
 from .config_manager import (  # noqa: E402
     DEFAULT_CONFIG,
+    DEFAULT_PASTE_SHORTCUT,
     DEFAULT_SOUND_EFFECT_TONE,
+    PASTE_SHORTCUTS,
     SOUND_EFFECT_TONES,
 )
 from .keyboard_backends import (  # noqa: E402
@@ -2347,6 +2349,16 @@ class SettingsDialog(Gtk.Dialog):
         self.config_manager.set("text_injection", "append_trailing_space", enabled)
         self.config_manager.save_settings()
         logger.info(f"Append trailing space {'enabled' if enabled else 'disabled'}")
+
+    def _on_paste_shortcut_changed(self, widget):
+        """Handle clipboard paste-shortcut combo changes."""
+        if self._initializing or self._applying_settings:
+            return
+
+        shortcut_id = self.paste_shortcut_combo.get_active_id() or DEFAULT_PASTE_SHORTCUT
+        self.config_manager.set_paste_shortcut(shortcut_id)
+        self.config_manager.save_settings()
+        logger.info(f"Paste shortcut set to {self.config_manager.get_paste_shortcut()}")
         return False
 
     def _on_sound_effects_toggled(self, widget, state):
@@ -2700,12 +2712,31 @@ class SettingsDialog(Gtk.Dialog):
         )
         output_group.add_row(append_trailing_space_row)
 
+        self.paste_shortcut_combo = Gtk.ComboBoxText()
+        self.paste_shortcut_combo.set_size_request(_CONTROL_WIDTH, -1)
+        self.paste_shortcut_combo.set_tooltip_text(
+            "Clipboard injection uses Ctrl+V in ordinary fields and Ctrl+Shift+V "
+            "in terminal windows. Override this when a nested terminal panel "
+            "(for example in an IDE) is not detected."
+        )
+        _prevent_scroll_on_hover(self.paste_shortcut_combo)
+        for shortcut_id, display_name in PASTE_SHORTCUTS:
+            self.paste_shortcut_combo.append(shortcut_id, display_name)
+        paste_shortcut_row = PreferenceRow(
+            title="Clipboard Paste Shortcut",
+            subtitle="Auto-detect terminals, or force Ctrl+V / Ctrl+Shift+V",
+            widget=self.paste_shortcut_combo,
+            keywords=("paste", "terminal", "ctrl", "clipboard"),
+        )
+        output_group.add_row(paste_shortcut_row)
+
         self.recognition_settings_tab.pack_start(output_group, False, False, 0)
         self.copy_to_clipboard_switch.connect("state-set", self._on_copy_to_clipboard_toggled)
         self.auto_capitalize_switch.connect("state-set", self._on_auto_capitalize_toggled)
         self.append_trailing_space_switch.connect(
             "state-set", self._on_append_trailing_space_toggled
         )
+        self.paste_shortcut_combo.connect("changed", self._on_paste_shortcut_changed)
 
         if not silero_active:
             vad_info_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
@@ -4141,6 +4172,7 @@ class SettingsDialog(Gtk.Dialog):
         copy_to_clipboard = text_injection_settings.get("copy_to_clipboard", False)
         auto_capitalize = text_injection_settings.get("auto_capitalize", True)
         append_trailing_space = text_injection_settings.get("append_trailing_space", True)
+        paste_shortcut = self.config_manager.get_paste_shortcut()
 
         self.autostart_switch.set_active(autostart_enabled)
         self.start_minimized_switch.set_active(start_minimized)
@@ -4148,6 +4180,8 @@ class SettingsDialog(Gtk.Dialog):
         self.copy_to_clipboard_switch.set_active(copy_to_clipboard)
         self.auto_capitalize_switch.set_active(auto_capitalize)
         self.append_trailing_space_switch.set_active(append_trailing_space)
+        if not self.paste_shortcut_combo.set_active_id(paste_shortcut):
+            self.paste_shortcut_combo.set_active_id(DEFAULT_PASTE_SHORTCUT)
         self.sound_effects_switch.set_active(self.config_manager.is_sound_effects_enabled())
         tone_id = self.config_manager.get_sound_effects_tone()
         if not self.sound_tone_combo.set_active_id(tone_id):

--- a/tests/test_focused_window.py
+++ b/tests/test_focused_window.py
@@ -1,0 +1,153 @@
+"""Tests for focused-window identity and terminal detection."""
+
+import json
+import unittest
+from unittest.mock import MagicMock, mock_open, patch
+
+from vocalinux.text_injection.focused_window import (
+    FocusedWindow,
+    get_focused_window,
+    is_focused_window_terminal,
+    looks_like_terminal,
+)
+
+
+class TestLooksLikeTerminal(unittest.TestCase):
+    """Unit tests for standalone terminal identity matching."""
+
+    def test_known_terminal_process(self):
+        self.assertTrue(looks_like_terminal(FocusedWindow(process_name="kitty")))
+
+    def test_gnome_terminal_app_id(self):
+        self.assertTrue(looks_like_terminal(FocusedWindow(app_id="org.gnome.Terminal")))
+
+    def test_ghostty_class(self):
+        self.assertTrue(looks_like_terminal(FocusedWindow(wm_class="com.mitchellh.ghostty")))
+
+    def test_xfce_terminal_class(self):
+        self.assertTrue(looks_like_terminal(FocusedWindow(wm_class="Xfce4-terminal")))
+
+    def test_st_is_exact_token_only(self):
+        self.assertTrue(looks_like_terminal(FocusedWindow(process_name="st")))
+        self.assertFalse(looks_like_terminal(FocusedWindow(process_name="steam")))
+
+    def test_editor_is_not_a_terminal(self):
+        self.assertFalse(
+            looks_like_terminal(
+                FocusedWindow(app_id="code", title="terminal.py — Visual Studio Code")
+            )
+        )
+
+    def test_cursor_nested_terminal_panel_is_not_auto_detected(self):
+        self.assertFalse(
+            looks_like_terminal(FocusedWindow(app_id="cursor", title="bash — Terminal"))
+        )
+
+    def test_browser_is_not_a_terminal(self):
+        self.assertFalse(looks_like_terminal(FocusedWindow(app_id="firefox", title="Terminal")))
+
+    def test_empty_window_is_not_a_terminal(self):
+        self.assertFalse(looks_like_terminal(FocusedWindow()))
+
+
+class TestGetFocusedWindow(unittest.TestCase):
+    """Probe helpers should fail closed and parse compositor JSON."""
+
+    def test_wayland_hyprland_active_window(self):
+        payload = {"class": "kitty", "title": "zsh", "pid": 4242}
+        with patch.dict("os.environ", {"WAYLAND_DISPLAY": "wayland-0"}, clear=False):
+            with patch("vocalinux.text_injection.focused_window.shutil.which") as mock_which:
+                mock_which.side_effect = lambda cmd: "/usr/bin/" + cmd if cmd == "hyprctl" else None
+                with patch("vocalinux.text_injection.focused_window.subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(payload))
+                    with patch(
+                        "vocalinux.text_injection.focused_window.open",
+                        mock_open(read_data="kitty\n"),
+                    ):
+                        window = get_focused_window()
+        self.assertIsNotNone(window)
+        assert window is not None
+        self.assertEqual(window.wm_class, "kitty")
+        self.assertEqual(window.process_name, "kitty")
+        self.assertTrue(looks_like_terminal(window))
+
+    def test_wayland_niri_focused_window(self):
+        payload = {"app_id": "Alacritty", "title": "nvim", "pid": 99}
+        with patch.dict("os.environ", {"WAYLAND_DISPLAY": "wayland-1"}, clear=False):
+            with patch("vocalinux.text_injection.focused_window.shutil.which") as mock_which:
+                mock_which.side_effect = lambda cmd: "/usr/bin/" + cmd if cmd == "niri" else None
+                with patch("vocalinux.text_injection.focused_window.subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(payload))
+                    window = get_focused_window()
+        self.assertIsNotNone(window)
+        assert window is not None
+        self.assertEqual(window.app_id, "Alacritty")
+        self.assertTrue(looks_like_terminal(window))
+
+    def test_wayland_sway_walks_tree_for_focused_node(self):
+        tree = {
+            "nodes": [
+                {
+                    "app_id": "firefox",
+                    "focused": False,
+                    "nodes": [
+                        {
+                            "app_id": "foot",
+                            "name": "zsh",
+                            "focused": True,
+                            "floating_nodes": [],
+                            "nodes": [],
+                        }
+                    ],
+                    "floating_nodes": [],
+                }
+            ],
+            "floating_nodes": [],
+        }
+        with patch.dict("os.environ", {"WAYLAND_DISPLAY": "wayland-0"}, clear=False):
+            with patch("vocalinux.text_injection.focused_window.shutil.which") as mock_which:
+                mock_which.side_effect = lambda cmd: "/usr/bin/" + cmd if cmd == "swaymsg" else None
+                with patch("vocalinux.text_injection.focused_window.subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps(tree))
+                    window = get_focused_window()
+        self.assertIsNotNone(window)
+        assert window is not None
+        self.assertEqual(window.app_id, "foot")
+        self.assertTrue(looks_like_terminal(window))
+
+    def test_x11_uses_xdotool_class(self):
+        with patch.dict("os.environ", {"WAYLAND_DISPLAY": ""}, clear=False):
+            with patch("vocalinux.text_injection.focused_window.shutil.which") as mock_which:
+                mock_which.side_effect = lambda cmd: "/usr/bin/" + cmd if cmd == "xdotool" else None
+                with patch("vocalinux.text_injection.focused_window.subprocess.run") as mock_run:
+
+                    def _run(cmd, **_kwargs):
+                        mapping = {
+                            ("xdotool", "getactivewindow"): "12345",
+                            ("xdotool", "getwindowclassname", "12345"): "konsole",
+                            ("xdotool", "getwindowname", "12345"): "zsh",
+                            ("xdotool", "getwindowpid", "12345"): "77",
+                        }
+                        return MagicMock(returncode=0, stdout=mapping.get(tuple(cmd), ""))
+
+                    mock_run.side_effect = _run
+                    with patch(
+                        "vocalinux.text_injection.focused_window.open",
+                        mock_open(read_data="konsole\n"),
+                    ):
+                        window = get_focused_window()
+        self.assertIsNotNone(window)
+        assert window is not None
+        self.assertEqual(window.wm_class, "konsole")
+        self.assertTrue(looks_like_terminal(window))
+
+    def test_probe_failure_returns_none(self):
+        with patch("vocalinux.text_injection.focused_window.shutil.which", return_value=None):
+            self.assertIsNone(get_focused_window())
+
+    def test_is_focused_window_terminal_false_when_unknown(self):
+        with patch(
+            "vocalinux.text_injection.focused_window.get_focused_window",
+            return_value=None,
+        ):
+            self.assertFalse(is_focused_window_terminal())

--- a/tests/test_focused_window.py
+++ b/tests/test_focused_window.py
@@ -49,6 +49,11 @@ class TestLooksLikeTerminal(unittest.TestCase):
     def test_empty_window_is_not_a_terminal(self):
         self.assertFalse(looks_like_terminal(FocusedWindow()))
 
+    def test_non_string_identity_is_ignored(self):
+        mock_value = MagicMock()
+        window = FocusedWindow(app_id=mock_value, wm_class=mock_value, process_name=mock_value)
+        self.assertFalse(looks_like_terminal(window))
+
 
 class TestGetFocusedWindow(unittest.TestCase):
     """Probe helpers should fail closed and parse compositor JSON."""

--- a/tests/test_paste_shortcut.py
+++ b/tests/test_paste_shortcut.py
@@ -1,0 +1,160 @@
+"""Tests for clipboard paste-shortcut preference and ydotool chords."""
+
+import json
+import os
+import tempfile
+import threading
+import unittest
+from typing import Any, cast
+from unittest.mock import MagicMock, mock_open, patch
+
+from vocalinux.ui.config_manager import (
+    DEFAULT_PASTE_SHORTCUT,
+    ConfigManager,
+    normalize_paste_shortcut,
+)
+
+
+def _make_injector() -> Any:
+    from vocalinux.text_injection.text_injector import DesktopEnvironment, TextInjector
+
+    obj = cast(Any, TextInjector.__new__(TextInjector))
+    obj._ibus_injector = None
+    obj.environment = DesktopEnvironment.WAYLAND
+    obj._session_environment = DesktopEnvironment.WAYLAND
+    obj._ibus_ready = False
+    obj._ibus_init_failed = False
+    obj._ibus_init_thread = None
+    obj._state_lock = threading.Lock()
+    obj._clipboard_tool_health = {}
+    obj._clipboard_timeout = 0.35
+    obj._clipboard_restore_generation = 0
+    obj._clipboard_restore_target = None
+    return obj
+
+
+class TestNormalizePasteShortcut(unittest.TestCase):
+    """Unknown or missing values fall back to auto-detect."""
+
+    def test_known_ids(self):
+        self.assertEqual(normalize_paste_shortcut("auto"), "auto")
+        self.assertEqual(normalize_paste_shortcut("ctrl+v"), "ctrl+v")
+        self.assertEqual(normalize_paste_shortcut("ctrl+shift+v"), "ctrl+shift+v")
+
+    def test_unknown_values_become_auto(self):
+        self.assertEqual(normalize_paste_shortcut(None), DEFAULT_PASTE_SHORTCUT)
+        self.assertEqual(normalize_paste_shortcut(""), DEFAULT_PASTE_SHORTCUT)
+        self.assertEqual(normalize_paste_shortcut("enter"), DEFAULT_PASTE_SHORTCUT)
+
+    def test_config_manager_round_trip(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = os.path.join(temp_dir, "config.json")
+            with (
+                patch("vocalinux.ui.config_manager.CONFIG_DIR", temp_dir),
+                patch("vocalinux.ui.config_manager.CONFIG_FILE", config_file),
+            ):
+                manager = ConfigManager()
+                self.assertEqual(manager.get_paste_shortcut(), "auto")
+                manager.set_paste_shortcut("ctrl+shift+v")
+                manager.save_config()
+                reloaded = ConfigManager()
+                self.assertEqual(reloaded.get_paste_shortcut(), "ctrl+shift+v")
+                manager.set_paste_shortcut("not-a-shortcut")
+                self.assertEqual(manager.get_paste_shortcut(), "auto")
+
+
+class TestShouldUseTerminalPaste(unittest.TestCase):
+    """Settings override wins; auto-detect is used only for the default."""
+
+    def test_forced_terminal_shortcut(self):
+        obj = _make_injector()
+        with patch.object(obj, "_paste_shortcut_preference", return_value="ctrl+shift+v"):
+            with patch(
+                "vocalinux.text_injection.text_injector.is_focused_window_terminal",
+                return_value=False,
+            ) as mock_detect:
+                self.assertTrue(obj._should_use_terminal_paste())
+                mock_detect.assert_not_called()
+
+    def test_forced_standard_shortcut(self):
+        obj = _make_injector()
+        with patch.object(obj, "_paste_shortcut_preference", return_value="ctrl+v"):
+            with patch(
+                "vocalinux.text_injection.text_injector.is_focused_window_terminal",
+                return_value=True,
+            ) as mock_detect:
+                self.assertFalse(obj._should_use_terminal_paste())
+                mock_detect.assert_not_called()
+
+    def test_auto_uses_focused_window(self):
+        obj = _make_injector()
+        with patch.object(obj, "_paste_shortcut_preference", return_value="auto"):
+            with patch(
+                "vocalinux.text_injection.text_injector.is_focused_window_terminal",
+                return_value=True,
+            ):
+                self.assertTrue(obj._should_use_terminal_paste())
+
+    def test_reads_config_from_disk(self):
+        obj = _make_injector()
+        with patch("vocalinux.text_injection.text_injector.config_dir", return_value="/tmp/cfg"):
+            with patch("os.path.exists", return_value=True):
+                with patch(
+                    "builtins.open",
+                    mock_open(
+                        read_data=json.dumps({"text_injection": {"paste_shortcut": "ctrl+shift+v"}})
+                    ),
+                ):
+                    self.assertEqual(obj._paste_shortcut_preference(), "ctrl+shift+v")
+
+
+class TestYdotoolTerminalPasteCommand(unittest.TestCase):
+    """Terminal paste must use Ctrl+Shift+V in both ydotool dialects."""
+
+    @patch("vocalinux.text_injection.text_injector.subprocess.run")
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    def test_legacy_named_sequence(self, mock_which, mock_run):
+        mock_which.return_value = "/usr/bin/ydotool"
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="",
+            stderr="Each key sequence can be any number of modifiers and keys, separated by plus (+)\n",
+        )
+        injector = _make_injector()
+        os.environ.pop("FLATPAK_ID", None)
+        self.assertEqual(
+            injector._ydotool_ctrl_v_command(terminal=True),
+            ["ydotool", "key", "ctrl+shift+v"],
+        )
+        self.assertEqual(injector._ydotool_ctrl_v_command(), ["ydotool", "key", "ctrl+v"])
+
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    def test_flatpak_uses_shift_keycodes(self, mock_which):
+        mock_which.return_value = "/app/bin/ydotool"
+        injector = _make_injector()
+        with patch.dict("os.environ", {"FLATPAK_ID": "com.vocalinux.Vocalinux"}):
+            self.assertEqual(
+                injector._ydotool_ctrl_v_command(terminal=True),
+                ["ydotool", "key", "29:1", "42:1", "47:1", "47:0", "42:0", "29:0"],
+            )
+            self.assertEqual(
+                injector._ydotool_ctrl_v_command(),
+                ["ydotool", "key", "29:1", "47:1", "47:0", "29:0"],
+            )
+
+    @patch("vocalinux.text_injection.text_injector.shutil.which")
+    @patch("vocalinux.text_injection.text_injector.subprocess.run")
+    def test_clipboard_paste_sends_terminal_chord(self, mock_run, mock_which):
+        mock_which.side_effect = lambda cmd: cmd in ("wl-copy", "ydotool")
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        injector = _make_injector()
+        with patch.object(injector, "_should_use_terminal_paste", return_value=True):
+            with patch.object(injector, "_copy_to_clipboard", return_value=True):
+                with patch.object(injector, "_read_clipboard", return_value="old"):
+                    with patch.object(
+                        injector,
+                        "_ydotool_ctrl_v_command",
+                        return_value=["ydotool", "key", "ctrl+shift+v"],
+                    ) as mock_cmd:
+                        self.assertTrue(injector._inject_via_clipboard_paste("hello"))
+                        mock_cmd.assert_called_once_with(terminal=True)

--- a/tests/test_paste_shortcut.py
+++ b/tests/test_paste_shortcut.py
@@ -158,3 +158,24 @@ class TestYdotoolTerminalPasteCommand(unittest.TestCase):
                     ) as mock_cmd:
                         self.assertTrue(injector._inject_via_clipboard_paste("hello"))
                         mock_cmd.assert_called_once_with(terminal=True)
+
+    def test_clipboard_paste_survives_mocked_subprocess_run(self):
+        """Patching text_injector.subprocess.run also shadows stdlib subprocess.
+
+        Existing clipboard-restore tests do that. Window detection must fail
+        closed instead of raising TypeError on MagicMock stdout.
+        """
+        injector = _make_injector()
+        with patch.object(injector, "_copy_to_clipboard", return_value=True):
+            with patch.object(injector, "_read_clipboard", return_value="old"):
+                with patch.object(
+                    injector,
+                    "_ydotool_ctrl_v_command",
+                    return_value=["ydotool", "key", "ctrl+v"],
+                ):
+                    with patch.object(injector, "_should_copy_to_clipboard", return_value=False):
+                        with patch(
+                            "vocalinux.text_injection.text_injector.subprocess.run",
+                            return_value=MagicMock(returncode=0),
+                        ):
+                            self.assertTrue(injector._inject_via_clipboard_paste("hello"))


### PR DESCRIPTION
## Summary

- Clipboard injection (the usual Wayland / ydotool path) always sent Ctrl+V. Most terminal emulators bind paste to Ctrl+Shift+V, so dictated text never landed in Kitty, GNOME Terminal, Konsole, Alacritty, foot, WezTerm, Ghostty, and similar apps.
- Auto-detect the focused window on X11 (xdotool) and on Hyprland / Sway / niri, and send Ctrl+Shift+V only for standalone terminal emulators. Nested IDE terminal panels are left alone because window titles are too noisy (`terminal.py`, a Terminal sidebar).
- Add **Settings → Dictation → Clipboard Paste Shortcut** (`auto` / `Ctrl+V` / `Ctrl+Shift+V`) so users can force the chord when auto-detect cannot see a nested panel.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an existing problem)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📖 Documentation update
- [ ] 🧹 Code refactoring
- [x] ✅ Test update

## Checklist

- [x] My code follows the code style of this project (black, isort)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass locally
- [ ] Pre-commit hooks pass

## Test plan

- [ ] Dictate into a GTK/Qt text field on Wayland (ydotool clipboard path) and confirm Ctrl+V still pastes
- [ ] Dictate into GNOME Terminal, Kitty, or Alacritty and confirm text appears (Ctrl+Shift+V)
- [ ] Open an IDE integrated terminal, set **Clipboard Paste Shortcut** to Ctrl+Shift+V, and confirm paste works
- [ ] Set the shortcut back to Auto-detect and confirm a normal editor still uses Ctrl+V
- [ ] Force Ctrl+V while focused on a terminal and confirm the override wins

## Additional Notes

Default remains `auto`. Existing configs pick that up through the usual default merge; no migration of user files is required.

Made with [Cursor](https://cursor.com)