### PR TITLE
fix(web): call the screenshots page v0.16

### DIFF
--- a/web/src/app/screenshots/page.tsx
+++ b/web/src/app/screenshots/page.tsx
@@ -150,14 +150,14 @@ export default function ScreenshotsPage() {
       <section>
         <p className="border-primary/30 bg-primary/10 mb-4 inline-flex items-center gap-2 rounded-full border px-4 py-1.5 text-sm font-medium text-primary">
           <Camera className="h-4 w-4" />
-          v0.15 UI
+          v0.16 UI
         </p>
         <h1 className="mb-5 font-display text-4xl font-semibold tracking-tight sm:text-5xl">
           Vocalinux Screenshots
         </h1>
         <p className="mb-8 max-w-4xl text-lg text-muted-foreground">
           A look at offline voice dictation on Linux: tray controls, debugging
-          tools, and the searchable sidebar settings UI from v0.15. Flip light
+          tools, and the searchable sidebar settings UI from v0.16. Flip light
           and dark app shots. Click any image to expand it.
         </p>
       </section>


### PR DESCRIPTION
The /screenshots/ badge and intro still said v0.15 after 0.16.0 shipped. Both now say v0.16. No new captures in this PR.