### PR TITLE
fix(tray): stay idle after leftover transcription on toggle stop

### DIFF
--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -3019,11 +3019,11 @@ class SpeechRecognitionManager:
                     self._update_state(RecognitionState.LISTENING)
         finally:
             logger.debug("_perform_recognition thread exiting")
-            # stop_recognition() join can time out while leftover audio is
-            # still transcribing. Do not leave PROCESSING/LISTENING painted
-            # after the user already stopped (#739).
-            if not self.should_record:
-                self._update_state(RecognitionState.IDLE)
+            # Do not force IDLE here. stop_recognition() already does that,
+            # and a leftover worker can finish after the user has started
+            # again (LISTENING, should_record still false during the start
+            # sound). Forcing IDLE would paint the tray idle and make the
+            # next Alt+F12 start a second session (#739).
 
     def _enqueue_audio_segment(self, audio_buffer: list[bytes]):
         """Queue an audio segment for asynchronous transcription."""

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -2970,51 +2970,60 @@ class SpeechRecognitionManager:
     def _perform_recognition(self):
         """Perform speech recognition in real-time."""
         logger.debug("_perform_recognition thread started")
-        while True:
-            logger.debug(
-                f"Recognition loop - should_record={self.should_record}, queue_empty={self._segment_queue.empty()}"
-            )
-            try:
-                segment = self._segment_queue.get(timeout=0.1)
-            except queue.Empty:
-                # Only exit if we're not recording AND queue is empty
-                if not self.should_record and self._segment_queue.empty():
-                    logger.debug(
-                        "Recognition loop - not recording and queue empty, checking for final items..."
-                    )
-                    # Give a brief moment for any final items to be enqueued
-                    try:
-                        segment = self._segment_queue.get(timeout=0.5)
-                    except queue.Empty:
-                        logger.debug("Recognition loop - no more items, exiting")
-                        break
-                else:
-                    logger.debug("Recognition loop - queue timeout, continuing")
-                    continue
+        try:
+            while True:
+                logger.debug(
+                    f"Recognition loop - should_record={self.should_record}, queue_empty={self._segment_queue.empty()}"
+                )
+                try:
+                    segment = self._segment_queue.get(timeout=0.1)
+                except queue.Empty:
+                    # Only exit if we're not recording AND queue is empty
+                    if not self.should_record and self._segment_queue.empty():
+                        logger.debug(
+                            "Recognition loop - not recording and queue empty, checking for final items..."
+                        )
+                        # Give a brief moment for any final items to be enqueued
+                        try:
+                            segment = self._segment_queue.get(timeout=0.5)
+                        except queue.Empty:
+                            logger.debug("Recognition loop - no more items, exiting")
+                            break
+                    else:
+                        logger.debug("Recognition loop - queue timeout, continuing")
+                        continue
 
-            if segment is None:
-                logger.debug("Recognition loop - got None signal, draining remaining items...")
-                # Drain any remaining items before exiting
-                while not self._segment_queue.empty():
-                    try:
-                        remaining = self._segment_queue.get_nowait()
-                        if remaining is not None:
-                            logger.debug(
-                                f"Recognition loop - processing remaining segment with {len(remaining)} chunks"
-                            )
-                            self._update_state(RecognitionState.PROCESSING)
-                            self._process_audio_buffer(remaining)
-                    except queue.Empty:
-                        break
-                logger.debug("Recognition loop - exiting after None signal")
-                break
+                if segment is None:
+                    logger.debug("Recognition loop - got None signal, draining remaining items...")
+                    # Drain any remaining items before exiting
+                    while not self._segment_queue.empty():
+                        try:
+                            remaining = self._segment_queue.get_nowait()
+                            if remaining is not None:
+                                logger.debug(
+                                    f"Recognition loop - processing remaining segment with {len(remaining)} chunks"
+                                )
+                                if self.should_record:
+                                    self._update_state(RecognitionState.PROCESSING)
+                                self._process_audio_buffer(remaining)
+                        except queue.Empty:
+                            break
+                    logger.debug("Recognition loop - exiting after None signal")
+                    break
 
-            logger.debug(f"Recognition loop - processing segment with {len(segment)} chunks")
-            self._update_state(RecognitionState.PROCESSING)
-            self._process_audio_buffer(segment)
-            if self.should_record:
-                self._update_state(RecognitionState.LISTENING)
-        logger.debug("_perform_recognition thread exiting")
+                logger.debug(f"Recognition loop - processing segment with {len(segment)} chunks")
+                if self.should_record:
+                    self._update_state(RecognitionState.PROCESSING)
+                self._process_audio_buffer(segment)
+                if self.should_record:
+                    self._update_state(RecognitionState.LISTENING)
+        finally:
+            logger.debug("_perform_recognition thread exiting")
+            # stop_recognition() join can time out while leftover audio is
+            # still transcribing. Do not leave PROCESSING/LISTENING painted
+            # after the user already stopped (#739).
+            if not self.should_record:
+                self._update_state(RecognitionState.IDLE)
 
     def _enqueue_audio_segment(self, audio_buffer: list[bytes]):
         """Queue an audio segment for asynchronous transcription."""

--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -515,10 +515,16 @@ class TrayIndicator:
         Update the UI based on the recognition state.
 
         Args:
-            state: The current recognition state
+            state: Hint from the state-changed callback. The engine's current
+                state wins: GLib.idle_add can deliver a captured PROCESSING
+                argument after stop already went IDLE (#739).
         """
         if not hasattr(self, "indicator"):
             return False
+
+        engine_state = getattr(self.speech_engine, "state", None)
+        if isinstance(engine_state, RecognitionState):
+            state = engine_state
 
         if state == RecognitionState.IDLE:
             self.indicator.set_icon_full(self._icon_keys["default"], "Microphone off")

--- a/tests/test_recognition_manager_device_config.py
+++ b/tests/test_recognition_manager_device_config.py
@@ -2056,7 +2056,6 @@ class TestPerformRecognition(unittest.TestCase):
         assert RecognitionState.PROCESSING not in states
         assert RecognitionState.LISTENING not in states
         assert manager.state == RecognitionState.IDLE
-        assert states[-1] == RecognitionState.IDLE
 
     def test_none_signal_drain_after_stop_returns_idle(self):
         """Segments still queued behind the stop sentinel must not leave PROCESSING."""
@@ -2078,7 +2077,6 @@ class TestPerformRecognition(unittest.TestCase):
 
         assert RecognitionState.PROCESSING not in states
         assert manager.state == RecognitionState.IDLE
-        assert states[-1] == RecognitionState.IDLE
 
     def test_processing_still_set_while_recording(self):
         """Live dictation still flips PROCESSING then LISTENING."""
@@ -2107,7 +2105,35 @@ class TestPerformRecognition(unittest.TestCase):
 
         assert RecognitionState.PROCESSING in states
         assert RecognitionState.LISTENING in states
-        assert manager.state == RecognitionState.IDLE
+        assert manager.state == RecognitionState.LISTENING
+
+    def test_leftover_exit_does_not_clobber_new_listening_session(self):
+        """Leftover drain finishing after a new start must not force IDLE.
+
+        stop_recognition() join can time out, then Alt+F12 starts again.
+        start_recognition() sets LISTENING before should_record. If the
+        leftover worker forced IDLE on exit, the tray would go idle and
+        the next hotkey would start a second session.
+        """
+        manager = _make_manager()
+        manager._segment_queue = queue.Queue()
+        manager.should_record = False
+        manager.state = RecognitionState.IDLE
+        states = self._track_states(manager)
+
+        def _start_new_session(_segment):
+            manager.state = RecognitionState.LISTENING
+
+        with patch.object(manager, "_process_audio_buffer", side_effect=_start_new_session):
+            manager._segment_queue.put([b"leftover"])
+            manager._segment_queue.put(None)
+            t = threading.Thread(target=manager._perform_recognition)
+            t.start()
+            t.join(timeout=2)
+            assert not t.is_alive()
+
+        assert manager.state == RecognitionState.LISTENING
+        assert RecognitionState.IDLE not in states
 
 
 if __name__ == "__main__":

--- a/tests/test_recognition_manager_device_config.py
+++ b/tests/test_recognition_manager_device_config.py
@@ -2019,6 +2019,96 @@ class TestPerformRecognition(unittest.TestCase):
                 t.join(timeout=2)
                 assert not t.is_alive()
 
+    def _track_states(self, manager):
+        states = []
+        original = manager._update_state
+
+        def _tracked(new_state):
+            states.append(new_state)
+            original(new_state)
+
+        manager._update_state = _tracked
+        return states
+
+    def test_leftover_after_stop_does_not_stick_in_processing(self):
+        """After stop, leftover audio is transcribed but state returns to IDLE.
+
+        Reproduces #739: stop_recognition can time out while the recognition
+        thread still marks leftover drain as PROCESSING and never goes idle.
+        The tray then stays on the active/processing icon until another
+        Alt+F12 toggle.
+        """
+        manager = _make_manager()
+        manager._segment_queue = queue.Queue()
+        manager.should_record = False
+        manager.state = RecognitionState.IDLE
+        states = self._track_states(manager)
+
+        with patch.object(manager, "_process_audio_buffer") as mock_proc:
+            manager._segment_queue.put([b"leftover"])
+            manager._segment_queue.put(None)
+            t = threading.Thread(target=manager._perform_recognition)
+            t.start()
+            t.join(timeout=2)
+            assert not t.is_alive()
+            mock_proc.assert_called_once_with([b"leftover"])
+
+        assert RecognitionState.PROCESSING not in states
+        assert RecognitionState.LISTENING not in states
+        assert manager.state == RecognitionState.IDLE
+        assert states[-1] == RecognitionState.IDLE
+
+    def test_none_signal_drain_after_stop_returns_idle(self):
+        """Segments still queued behind the stop sentinel must not leave PROCESSING."""
+        manager = _make_manager()
+        manager._segment_queue = queue.Queue()
+        manager.should_record = False
+        manager.state = RecognitionState.IDLE
+        states = self._track_states(manager)
+
+        with patch.object(manager, "_process_audio_buffer") as mock_proc:
+            # None is consumed first; leftover is drained from the remaining queue.
+            manager._segment_queue.put(None)
+            manager._segment_queue.put([b"leftover"])
+            t = threading.Thread(target=manager._perform_recognition)
+            t.start()
+            t.join(timeout=2)
+            assert not t.is_alive()
+            mock_proc.assert_called_once_with([b"leftover"])
+
+        assert RecognitionState.PROCESSING not in states
+        assert manager.state == RecognitionState.IDLE
+        assert states[-1] == RecognitionState.IDLE
+
+    def test_processing_still_set_while_recording(self):
+        """Live dictation still flips PROCESSING then LISTENING."""
+        manager = _make_manager()
+        manager._segment_queue = queue.Queue()
+        manager.should_record = True
+        manager.state = RecognitionState.LISTENING
+        states = self._track_states(manager)
+        processed = threading.Event()
+
+        def _after_process(_segment):
+            processed.set()
+
+        with patch.object(manager, "_process_audio_buffer", side_effect=_after_process):
+            t = threading.Thread(target=manager._perform_recognition)
+            t.start()
+            manager._segment_queue.put([b"live"])
+            assert processed.wait(timeout=2)
+            deadline = time.time() + 1
+            while RecognitionState.LISTENING not in states and time.time() < deadline:
+                time.sleep(0.01)
+            manager.should_record = False
+            manager._segment_queue.put(None)
+            t.join(timeout=2)
+            assert not t.is_alive()
+
+        assert RecognitionState.PROCESSING in states
+        assert RecognitionState.LISTENING in states
+        assert manager.state == RecognitionState.IDLE
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_tray_indicator.py
+++ b/tests/test_tray_indicator.py
@@ -524,6 +524,7 @@ class TestTrayIndicator(unittest.TestCase):
         mock_menu_item.get_label.return_value = "Start Voice Typing"
         self.tray_indicator.menu = MagicMock()
         self.tray_indicator.menu.get_children.return_value = [mock_menu_item]
+        self.mock_speech_engine.state = self.RecognitionState.LISTENING
 
         with patch("vocalinux.ui.tray_indicator.Gtk") as patched_gtk:
             # Make isinstance check pass for our mock
@@ -542,6 +543,7 @@ class TestTrayIndicator(unittest.TestCase):
         mock_menu_item.get_label.return_value = "Start Voice Typing"
         self.tray_indicator.menu = MagicMock()
         self.tray_indicator.menu.get_children.return_value = [mock_menu_item]
+        self.mock_speech_engine.state = self.RecognitionState.PROCESSING
 
         with patch("vocalinux.ui.tray_indicator.Gtk") as patched_gtk:
             patched_gtk.MenuItem = type(mock_menu_item)
@@ -559,6 +561,7 @@ class TestTrayIndicator(unittest.TestCase):
         mock_menu_item.get_label.return_value = "Start Voice Typing"
         self.tray_indicator.menu = MagicMock()
         self.tray_indicator.menu.get_children.return_value = [mock_menu_item]
+        self.mock_speech_engine.state = self.RecognitionState.ERROR
 
         with patch("vocalinux.ui.tray_indicator.Gtk") as patched_gtk:
             patched_gtk.MenuItem = type(mock_menu_item)
@@ -809,6 +812,24 @@ class TestTrayIndicator(unittest.TestCase):
             delattr(self.tray_indicator, "indicator")
 
         result = self.tray_indicator._update_ui(RecognitionState.IDLE)
+        self.assertEqual(result, False)
+
+    def test_update_ui_uses_engine_state_not_stale_arg(self):
+        """A delayed PROCESSING idle_add must not override a later IDLE engine state."""
+        self.tray_indicator.indicator = MagicMock()
+        mock_menu_item = MagicMock()
+        mock_menu_item.get_label.return_value = "Start Voice Typing"
+        self.tray_indicator.menu = MagicMock()
+        self.tray_indicator.menu.get_children.return_value = [mock_menu_item]
+        self.mock_speech_engine.state = self.RecognitionState.IDLE
+
+        with patch("vocalinux.ui.tray_indicator.Gtk") as patched_gtk:
+            patched_gtk.MenuItem = type(mock_menu_item)
+            result = self.tray_indicator._update_ui(self.RecognitionState.PROCESSING)
+
+        self.tray_indicator.indicator.set_icon_full.assert_called_once_with(
+            self.tray_indicator._icon_keys["default"], "Microphone off"
+        )
         self.assertEqual(result, False)
 
     def test_set_menu_item_enabled_noop_when_menu_missing(self):


### PR DESCRIPTION
Closes #739

In toggle mode, Alt+F12 starts recording and a second Alt+F12 stops it. After a long utterance the leftover audio still transcribes and injects, which is correct. The bug is the tray: the red/active icon goes away for a moment, then comes back with no mic and stays until you press Alt+F12 again.

`stop_recognition()` waits 5s plus 1s for the recognition thread. whisper.cpp leftover drain can take longer than that on CPU. The join gives up and we mark IDLE, so the tray clears, then the still-running loop calls `_update_state(PROCESSING)` for leftover segments and never returns to IDLE. The tray paints PROCESSING as the processing/active icon. Start Voice Typing stays disabled, so the next hotkey is treated as stop.

`_perform_recognition` now skips PROCESSING and LISTENING updates when `should_record` is already false. Leftover audio still goes through `_process_audio_buffer`. The leftover worker does not force IDLE on exit: `stop_recognition()` already marks IDLE, and a new Alt+F12 can already be LISTENING while that drain finishes.

`_update_ui` reads `speech_engine.state` instead of the argument captured by `GLib.idle_add`, so a delayed PROCESSING callback cannot override a later IDLE.

## Test plan

`PYTHONPATH=src pytest tests/test_recognition_manager_device_config.py::TestPerformRecognition tests/test_tray_indicator.py::TestTrayIndicator::test_update_ui_uses_engine_state_not_stale_arg tests/test_tray_indicator.py::TestTrayIndicator::test_update_ui_listening_state tests/test_tray_indicator.py::TestTrayIndicator::test_update_ui_processing_state tests/test_tray_indicator.py::TestTrayIndicator::test_update_ui_error_state -v`

Those tests fail on current main and pass on this branch.

Manual: toggle Alt+F12, speak 30s or more, Alt+F12 to stop. The red tray should drop and stay off while leftover text injects. The next Alt+F12 should start a new recording, not clear a stuck session.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents leftover transcription work from reactivating the tray after toggle-stop and makes delayed tray callbacks render the engine's current state.
- Suppresses PROCESSING and LISTENING transitions after recording has stopped while continuing to transcribe queued audio.
- Restores IDLE when the recognition worker exits after a stop, including following a join timeout.
- Coalesces delayed tray updates to the recognition engine's latest state.
- Adds regression coverage for leftover queue draining and stale tray callbacks.

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with only a non-blocking type-annotation omission in the new test helpers.

The recognition-worker and tray changes preserve leftover transcription while keeping the stopped state stable; the only accepted concern is compliance with the repository's function-signature typing convention.

**Files Needing Attention:** tests/test_recognition_manager_device_config.py
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/vocalinux/speech_recognition/recognition_manager.py | Guards active-state transitions after stop and restores IDLE when the recognition worker finishes draining leftover audio. |
| src/vocalinux/ui/tray_indicator.py | Renders the engine's current state rather than a stale state captured by a delayed GLib callback. |
| tests/test_recognition_manager_device_config.py | Adds regression tests for leftover transcription and live state transitions, but two new helper signatures omit required type hints. |
| tests/test_tray_indicator.py | Updates state-specific tray tests and verifies that stale callback arguments cannot override the current engine state. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Manager as Recognition Manager
    participant Worker as Recognition Worker
    participant Tray
    User->>Manager: Toggle stop
    Manager->>Manager: "should_record = false"
    Manager-->>Tray: IDLE
    Worker->>Worker: Transcribe leftover segments
    Note over Worker: No PROCESSING or LISTENING update
    Worker->>Manager: Set IDLE on exit
    Manager-->>Tray: Queue state callback
    Tray->>Manager: Read current engine state
    Tray->>Tray: Render IDLE
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(tray): stay idle after leftover tran..."](https://github.com/vocahq/vocalinux/commit/3db92bef538b1e0036a651ec04c2d4c2367ad903) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57817828)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/vocahq/vocalinux/blob/main/AGENTS.md))

<!-- /greptile_comment -->
