### PR TITLE
fix(ibus): sync XWayland layout from GNOME after scoped inject

### DIFF
--- a/src/vocalinux/text_injection/ibus_engine.py
+++ b/src/vocalinux/text_injection/ibus_engine.py
@@ -622,6 +622,63 @@ def restore_xkb_layout(layout: str, variant: str = "", option: str = "") -> bool
     return False
 
 
+def _x11_display_available() -> bool:
+    """True when an X11 display is advertised (XWayland or native X)."""
+    display = os.environ.get("DISPLAY")
+    return bool(display and display.strip())
+
+
+def sync_xwayland_layout_from_gnome() -> bool:
+    """Push GNOME's current XKB source onto XWayland after scoped IBus inject.
+
+    On GNOME Wayland, Super+Space updates Mutter and IBus immediately, but
+    XWayland can keep the previous map after the Vocalinux engine round-trip
+    (issue #738). ``restore_xkb_layout()`` stays a no-op on Wayland (#474);
+    this helper reads the live GNOME source instead of a captured layout.
+
+    Native Wayland sessions with no X DISPLAY are left alone.
+    """
+    if not _is_wayland_session():
+        return False
+    if not _x11_display_available():
+        logger.debug("No X DISPLAY; skipping XWayland layout sync (see #738)")
+        return False
+
+    source = _get_gnome_current_source()
+    if not source:
+        return False
+
+    source_type, source_id = source
+    if source_type != "xkb" or not source_id:
+        logger.debug(
+            f"GNOME current source is {source_type}:{source_id}; "
+            "not an XKB map, skipping XWayland sync"
+        )
+        return False
+
+    layout, _, variant = source_id.partition("+")
+    if not layout:
+        return False
+
+    try:
+        cmd = ["setxkbmap", "-layout", layout]
+        if variant:
+            cmd.extend(["-variant", variant])
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+        if result.returncode == 0:
+            logger.debug(f"Synced XWayland layout to GNOME source '{source_id}' (see #738)")
+            return True
+        logger.debug(f"setxkbmap failed while syncing XWayland: {result.stderr}")
+    except (subprocess.SubprocessError, FileNotFoundError, OSError) as e:
+        logger.debug(f"Could not sync XWayland layout: {e}")
+    return False
+
+
 def _invoke_parent_destroy(parent_destroy: Callable[[], None], instance: object) -> None:
     """Call the parent engine destroy, working around PyGObject's GType binding.
 
@@ -1545,10 +1602,16 @@ class IBusTextInjector:
 
             # Engine switch can leave XKB on us even after restoring the IBus
             # engine (setxkbmap vs IBus). Re-apply the pre-switch map on X11;
-            # Wayland capture is empty so this is a no-op (#474, #664).
+            # Wayland capture is empty so restore_xkb_layout is a no-op (#474, #664).
             layout, variant, option = captured_xkb
             if layout:
                 restore_xkb_layout(layout, variant, option)
+            else:
+                # Compositor is source of truth. Copy GNOME's live XKB source
+                # onto XWayland so Super+Space during recording cannot leave
+                # X apps on the previous map (#738). Do not replay the empty
+                # capture and do not go through restore_xkb_layout.
+                sync_xwayland_layout_from_gnome()
 
         return False
 

--- a/tests/test_ibus_engine.py
+++ b/tests/test_ibus_engine.py
@@ -1056,6 +1056,101 @@ class TestIBusTextInjector(unittest.TestCase):
         self.assertTrue(injector.inject_text("hello"))
         mock_restore_xkb.assert_not_called()
 
+    @patch("vocalinux.text_injection.ibus_engine.sync_xwayland_layout_from_gnome")
+    @patch("vocalinux.text_injection.ibus_engine.restore_xkb_layout")
+    @patch(
+        "vocalinux.text_injection.ibus_engine.get_current_xkb_layout",
+        return_value=("", "", ""),
+    )
+    @patch("vocalinux.text_injection.ibus_engine.get_current_engine", return_value="xkb:us::eng")
+    @patch("vocalinux.text_injection.ibus_engine.is_engine_active", return_value=False)
+    @patch("vocalinux.text_injection.ibus_engine.switch_engine", return_value=True)
+    @patch("socket.socket")
+    @patch("vocalinux.text_injection.ibus_engine.SOCKET_PATH")
+    @patch("vocalinux.text_injection.ibus_engine.IBUS_AVAILABLE", True)
+    @patch("vocalinux.text_injection.ibus_engine.ensure_ibus_dir")
+    def test_inject_text_syncs_xwayland_from_gnome_when_layout_empty(
+        self,
+        mock_ensure_dir,
+        mock_socket_path,
+        mock_socket_cls,
+        mock_switch,
+        mock_is_active,
+        mock_get_current,
+        mock_get_xkb,
+        mock_restore_xkb,
+        mock_sync,
+    ):
+        """Wayland/empty capture syncs XWayland from GNOME after engine restore (#738)."""
+        from vocalinux.text_injection.ibus_engine import ENGINE_NAME, IBusTextInjector
+
+        mock_socket_path.exists.return_value = True
+        mock_sock = MagicMock()
+        mock_sock.__enter__.return_value = mock_sock
+        mock_sock.__exit__.return_value = None
+        mock_sock.recv.return_value = b"OK"
+        mock_socket_cls.return_value = mock_sock
+
+        parent = MagicMock()
+        parent.attach_mock(mock_get_xkb, "get_xkb")
+        parent.attach_mock(mock_switch, "switch")
+        parent.attach_mock(mock_restore_xkb, "restore_xkb")
+        parent.attach_mock(mock_sync, "sync")
+
+        injector = IBusTextInjector(auto_activate=False)
+        self.assertTrue(injector.inject_text("hello"))
+
+        mock_restore_xkb.assert_not_called()
+        mock_sync.assert_called_once_with()
+        self.assertEqual(
+            [call.args[0] for call in mock_switch.call_args_list],
+            [ENGINE_NAME, "xkb:us::eng"],
+        )
+        self.assertEqual(
+            [c[0] for c in parent.mock_calls],
+            ["get_xkb", "switch", "switch", "sync"],
+        )
+
+    @patch("vocalinux.text_injection.ibus_engine.sync_xwayland_layout_from_gnome")
+    @patch("vocalinux.text_injection.ibus_engine.restore_xkb_layout")
+    @patch(
+        "vocalinux.text_injection.ibus_engine.get_current_xkb_layout",
+        return_value=("br", "", ""),
+    )
+    @patch("vocalinux.text_injection.ibus_engine.get_current_engine", return_value="xkb:br::por")
+    @patch("vocalinux.text_injection.ibus_engine.is_engine_active", return_value=False)
+    @patch("vocalinux.text_injection.ibus_engine.switch_engine", return_value=True)
+    @patch("socket.socket")
+    @patch("vocalinux.text_injection.ibus_engine.SOCKET_PATH")
+    @patch("vocalinux.text_injection.ibus_engine.IBUS_AVAILABLE", True)
+    @patch("vocalinux.text_injection.ibus_engine.ensure_ibus_dir")
+    def test_inject_text_does_not_sync_xwayland_when_xkb_was_captured(
+        self,
+        mock_ensure_dir,
+        mock_socket_path,
+        mock_socket_cls,
+        mock_switch,
+        mock_is_active,
+        mock_get_current,
+        mock_get_xkb,
+        mock_restore_xkb,
+        mock_sync,
+    ):
+        """X11 captured layouts still go through restore_xkb_layout, not the Wayland sync."""
+        from vocalinux.text_injection.ibus_engine import IBusTextInjector
+
+        mock_socket_path.exists.return_value = True
+        mock_sock = MagicMock()
+        mock_sock.__enter__.return_value = mock_sock
+        mock_sock.__exit__.return_value = None
+        mock_sock.recv.return_value = b"OK"
+        mock_socket_cls.return_value = mock_sock
+
+        injector = IBusTextInjector(auto_activate=False)
+        self.assertTrue(injector.inject_text("ola"))
+        mock_restore_xkb.assert_called_once_with("br", "", "")
+        mock_sync.assert_not_called()
+
     @patch("vocalinux.text_injection.ibus_engine.get_current_engine", return_value="xkb:de::deu")
     @patch("vocalinux.text_injection.ibus_engine.is_engine_active", return_value=False)
     @patch("vocalinux.text_injection.ibus_engine.switch_engine", return_value=True)

--- a/tests/test_ibus_xkb_wayland.py
+++ b/tests/test_ibus_xkb_wayland.py
@@ -1,9 +1,13 @@
-"""Regression tests for issue #474.
+"""Regression tests for issues #474 and #738.
 
-On Wayland, Vocalinux must not call ``setxkbmap``. It only reaches the XWayland
-X11 server, so re-applying a layout there leaves XWayland (and XWayland/Electron
-apps) on the wrong layout while native Wayland apps and ``localectl`` stay
-correct — the "layout flips from de to us after dictation" symptom.
+``restore_xkb_layout`` must not call ``setxkbmap`` on Wayland. That tool only
+reaches the XWayland X11 server, so re-applying a captured (or default us)
+layout leaves XWayland apps on the wrong map while native Wayland apps and
+``localectl`` stay correct.
+
+After scoped IBus restore, ``sync_xwayland_layout_from_gnome`` may call
+``setxkbmap`` to copy GNOME's live XKB source onto XWayland when DISPLAY is
+set. That path must not go through ``restore_xkb_layout``.
 """
 
 import sys
@@ -53,6 +57,177 @@ class TestRestoreXkbLayoutWayland(unittest.TestCase):
     def test_empty_layout_is_noop(self, mock_run):
         self.assertFalse(restore_xkb_layout(""))
         mock_run.assert_not_called()
+
+
+class TestSyncXwaylandLayoutFromGnome(unittest.TestCase):
+    """XWayland must follow GNOME's live source after scoped inject (#738)."""
+
+    def _sync(self):
+        # Import at call time so patches hit the module other test files reloaded.
+        from vocalinux.text_injection.ibus_engine import sync_xwayland_layout_from_gnome
+
+        return sync_xwayland_layout_from_gnome()
+
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch("vocalinux.text_injection.ibus_engine._get_gnome_current_source")
+    @patch.dict("os.environ", {"XDG_SESSION_TYPE": "wayland"}, clear=True)
+    def test_no_display_does_not_call_setxkbmap(self, mock_source, mock_run):
+        self.assertFalse(self._sync())
+        mock_source.assert_not_called()
+        mock_run.assert_not_called()
+
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch(
+        "vocalinux.text_injection.ibus_engine._get_gnome_current_source",
+        return_value=("xkb", "us"),
+    )
+    @patch.dict(
+        "os.environ",
+        {"XDG_SESSION_TYPE": "wayland", "DISPLAY": "   "},
+        clear=True,
+    )
+    def test_blank_display_does_not_call_setxkbmap(self, mock_source, mock_run):
+        self.assertFalse(self._sync())
+        mock_source.assert_not_called()
+        mock_run.assert_not_called()
+
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch(
+        "vocalinux.text_injection.ibus_engine._get_gnome_current_source",
+        return_value=("xkb", "us"),
+    )
+    @patch.dict(
+        "os.environ",
+        {"XDG_SESSION_TYPE": "x11", "DISPLAY": ":0"},
+        clear=True,
+    )
+    def test_x11_does_not_sync(self, mock_source, mock_run):
+        self.assertFalse(self._sync())
+        mock_source.assert_not_called()
+        mock_run.assert_not_called()
+
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch("vocalinux.text_injection.ibus_engine._get_gnome_current_source", return_value=None)
+    @patch.dict(
+        "os.environ",
+        {"XDG_SESSION_TYPE": "wayland", "DISPLAY": ":0"},
+        clear=True,
+    )
+    def test_missing_gnome_source_is_noop(self, mock_source, mock_run):
+        self.assertFalse(self._sync())
+        mock_run.assert_not_called()
+
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch(
+        "vocalinux.text_injection.ibus_engine._get_gnome_current_source",
+        return_value=("ibus", "libpinyin"),
+    )
+    @patch.dict(
+        "os.environ",
+        {"XDG_SESSION_TYPE": "wayland", "DISPLAY": ":0"},
+        clear=True,
+    )
+    def test_ibus_source_does_not_call_setxkbmap(self, mock_source, mock_run):
+        self.assertFalse(self._sync())
+        mock_run.assert_not_called()
+
+    @patch("vocalinux.text_injection.ibus_engine.restore_xkb_layout")
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch(
+        "vocalinux.text_injection.ibus_engine._get_gnome_current_source",
+        return_value=("xkb", "us"),
+    )
+    @patch.dict(
+        "os.environ",
+        {"XDG_SESSION_TYPE": "wayland", "DISPLAY": ":0"},
+        clear=True,
+    )
+    def test_applies_gnome_layout_without_restore_xkb_layout(
+        self, mock_source, mock_run, mock_restore
+    ):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        self.assertTrue(self._sync())
+        mock_restore.assert_not_called()
+        mock_run.assert_called_once_with(
+            ["setxkbmap", "-layout", "us"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch(
+        "vocalinux.text_injection.ibus_engine._get_gnome_current_source",
+        return_value=("xkb", "us+altgr-intl"),
+    )
+    @patch.dict(
+        "os.environ",
+        {"XDG_SESSION_TYPE": "wayland", "DISPLAY": ":0"},
+        clear=True,
+    )
+    def test_applies_layout_variant(self, mock_source, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        self.assertTrue(self._sync())
+        mock_run.assert_called_once_with(
+            ["setxkbmap", "-layout", "us", "-variant", "altgr-intl"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch(
+        "vocalinux.text_injection.ibus_engine._get_gnome_current_source",
+        return_value=("xkb", "us"),
+    )
+    @patch.dict(
+        "os.environ",
+        {"XDG_SESSION_TYPE": "wayland", "DISPLAY": ":0"},
+        clear=True,
+    )
+    def test_setxkbmap_failure_returns_false(self, mock_source, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stderr="Cannot open display")
+        self.assertFalse(self._sync())
+
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch(
+        "vocalinux.text_injection.ibus_engine._get_gnome_current_source",
+        return_value=("xkb", "us"),
+    )
+    @patch.dict(
+        "os.environ",
+        {"XDG_SESSION_TYPE": "wayland", "DISPLAY": ":0"},
+        clear=True,
+    )
+    def test_missing_setxkbmap_returns_false(self, mock_source, mock_run):
+        mock_run.side_effect = FileNotFoundError("setxkbmap")
+        self.assertFalse(self._sync())
+
+    @patch("vocalinux.text_injection.ibus_engine.subprocess.run")
+    @patch.dict(
+        "os.environ",
+        {
+            "XDG_SESSION_TYPE": "wayland",
+            "DISPLAY": ":0",
+            "XDG_CURRENT_DESKTOP": "GNOME",
+        },
+        clear=True,
+    )
+    def test_uses_gnome_mru_sources(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(
+                returncode=0,
+                stdout="[('xkb', 'us'), ('xkb', 'ru')]",
+                stderr="",
+            ),
+            MagicMock(returncode=0, stderr=""),
+        ]
+        self.assertTrue(self._sync())
+        self.assertEqual(mock_run.call_args_list[0].args[0][-1], "mru-sources")
+        self.assertEqual(
+            mock_run.call_args_list[1].args[0],
+            ["setxkbmap", "-layout", "us"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On GNOME Wayland, Super+Space during a recording can leave XWayland behind GNOME and IBus. The indicator shows `us`, but X apps still type `ru`.

Scoped IBus inject restores `ibus engine xkb:us::eng` and then skips `setxkbmap`, because `restore_xkb_layout` is a no-op on Wayland (#474). That skip is still right for the compositor-owned layout. XWayland just never hears about the new source.

After the IBus restore, copy GNOME's current XKB source (the first `mru-sources` entry) onto XWayland with `setxkbmap` when `DISPLAY` is set. Empty captures are not replayed, and this path does not call `restore_xkb_layout`. Native Wayland sessions with no X display are left alone. The Vocalinux engine is still activated for `commit_text`.

Closes #738

## Test plan

- `PYTHONPATH=src:tests python3 -m unittest test_ibus_xkb_wayland test_xkb_layout test_ibus_engine test_ibus_engine_core test_ibus_engine_utils test_ibus_active_engine_guard` (265 passed, including `test_inject_text_skips_xkb_restore_when_layout_empty` and `tests/test_ibus_xkb_wayland.py`)
- On GNOME Wayland with Russian and English sources: focus an XWayland app, start dictation on `ru`, Super+Space to English, stop, then type. The indicator and the keys should both be English.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR synchronizes XWayland with GNOME’s current XKB source after scoped IBus injection on Wayland.
- Adds session, display, and source-type guards before invoking `setxkbmap`.
- Preserves the existing X11 captured-layout restoration path.
- Adds regression coverage for routing, layout variants, unsupported sources, missing displays, and subprocess failures.

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The new synchronization is constrained to GNOME Wayland sessions with an X display and a valid XKB source, handles subprocess failures without disrupting injection, and preserves the existing X11 restoration behavior.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/vocalinux/text_injection/ibus_engine.py | Adds a guarded GNOME Wayland-to-XWayland synchronization path while retaining captured-layout restoration for X11. |
| tests/test_ibus_engine.py | Verifies that empty Wayland captures use the new synchronization path and captured X11 layouts retain the existing restoration path. |
| tests/test_ibus_xkb_wayland.py | Adds focused coverage for session gating, source parsing, variants, subprocess failures, and GNOME MRU-source synchronization. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Scoped IBus injection finishes] --> B{Captured XKB layout exists?}
    B -->|Yes| C[Restore captured X11 layout]
    B -->|No| D{Wayland session and DISPLAY set?}
    D -->|No| E[Leave layout unchanged]
    D -->|Yes| F[Read GNOME MRU input source]
    F --> G{Current source is XKB?}
    G -->|No| E
    G -->|Yes| H[Apply layout and variant to XWayland]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ibus): sync XWayland layout from GNO..."](https://github.com/vocahq/vocalinux/commit/66166b5be16b9ba0d74ace35b97c63d4fb175bb0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57817834)</sub>

<!-- /greptile_comment -->