### PR TITLE
fix(tests): stop leaking Factory.new onto MagicMock

### DIFF
--- a/tests/test_ibus_engine_core.py
+++ b/tests/test_ibus_engine_core.py
@@ -49,10 +49,13 @@ class _FakeIBusEngine:
         """Parent implementation invoked through ``super().do_destroy``."""
 
 
-# Set up IBus mock - Engine is a plain class so the engine can subclass it
+# Set up IBus mock - Engine is a plain class so the engine can subclass it.
+# Bus and Factory must be instances. Assigning the MagicMock class and then
+# setting Factory.new puts `new` on unittest.mock.MagicMock itself, so every
+# MagicMock() in the pytest session shares it (#747).
 mock_ibus.Engine = _FakeIBusEngine
-mock_ibus.Bus = MagicMock
-mock_ibus.Factory = MagicMock
+mock_ibus.Bus = MagicMock()
+mock_ibus.Factory = MagicMock()
 mock_ibus.Factory.new = MagicMock(return_value=MagicMock())
 mock_ibus.Text = MagicMock()
 mock_ibus.Text.new_from_string = MagicMock(return_value=MagicMock())
@@ -69,6 +72,32 @@ sys.modules["gi.repository"] = MagicMock()
 sys.modules["gi.repository"].IBus = mock_ibus
 sys.modules["gi.repository"].GLib = mock_glib
 sys.modules["gi.repository"].GObject = mock_gobject
+
+
+class TestIBusMockIsolation(unittest.TestCase):
+    """Module-level IBus stubs must not leak onto unittest.mock.MagicMock."""
+
+    def test_factory_new_is_not_on_the_magicmock_class(self):
+        """Factory.new must live on the Factory mock, not on MagicMock itself (#747)."""
+        self.assertNotIn("new", vars(MagicMock))
+        a, b = MagicMock(), MagicMock()
+        self.assertIsNot(a.Notification.new, b.Whatever.new)
+
+    def test_fresh_interpreter_does_not_put_new_on_magicmock(self):
+        """Same check in a subprocess so session order cannot hide a leak (#747)."""
+        probe = (
+            "from unittest.mock import MagicMock; import runpy; "
+            "runpy.run_path(%r, run_name='_747'); "
+            "print('new' in vars(MagicMock))"
+        ) % os.path.abspath(__file__)
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "False")
 
 
 class TestIBusEngineModuleFunctions(unittest.TestCase):


### PR DESCRIPTION
## Description

@kacperpaczos caught this while adding notification tests on #687. `tests/test_ibus_engine_core.py` assigned `mock_ibus.Bus` and `mock_ibus.Factory` to the `MagicMock` class, then set `Factory.new`. That writes `new` onto `unittest.mock.MagicMock` itself, so every `MagicMock()` later in the pytest session hands out the same object for `.new`.

A `Notification.new.assert_not_called()` in another file can pass alone and fail in the full suite, with calls that actually came from the IBus fixtures and `main.py`. Nothing else asserts on `.new` today, which is why this looked like a flaky test rather than a fixture leak.

The engine only calls `IBus.Factory.new(conn)`. Nothing subclasses `Bus` or `Factory`; Engine already uses `_FakeIBusEngine`. `mock_ibus.Text` was already an instance plus `new_from_string`, so Bus and Factory now match that. `GLib.MainLoop = MagicMock` is still the class, with no attribute set on it afterwards, so it is not this leak.

A regression test in the same file fails on current main (`"new" in vars(MagicMock)` after import) and passes once the parentheses are there. A small subprocess does the same check so collection order cannot hide it.

Thanks @kacperpaczos for the diagnosis and the two-parenthesis fix.

## Related Issue

Closes #747

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧹 Code refactoring
- [x] ✅ Test update

## Checklist

- [x] My code follows the code style of this project (black, isort)
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass locally
- [ ] Pre-commit hooks pass

## Additional Notes

On 008fd31, importing the module put `new` on MagicMock. After this change it does not. IBus tests: 244 passed, including the two new isolation tests.