### PR TITLE
fix(ui): use the canonical VocaHQ Discord invite

### DIFF
--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -283,7 +283,7 @@ VOCAPHONE_SITE_URL = "https://vocaphone.vocahq.com"
 VOCAGATEWAY_SITE_URL = "https://vocagateway.vocahq.com"
 GITHUB_REPO_URL = __url__
 GITHUB_ISSUES_URL = "https://github.com/VocaHQ/vocalinux/issues"
-VOCAHQ_DISCORD_URL = "https://discord.gg/UMJduhcqn"
+VOCAHQ_DISCORD_URL = "https://discord.gg/t6muquAJbm"
 VOCAHQ_X_URL = "https://x.com/vocahq"
 VOCAHQ_MAILTO_URL = "mailto:hello@vocahq.com"
 

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1059,7 +1059,7 @@ class TestAboutPage(unittest.TestCase):
             "https://vocaphone.vocahq.com",
             "https://vocagateway.vocahq.com",
             "https://github.com/VocaHQ/vocalinux/issues",
-            "https://discord.gg/UMJduhcqn",
+            "https://discord.gg/t6muquAJbm",
             "https://x.com/vocahq",
             "mailto:hello@vocahq.com",
         ):
@@ -1069,7 +1069,7 @@ class TestAboutPage(unittest.TestCase):
         self.assertIn('"X"', self.about)
         self.assertIn('"Email"', self.about)
         self.assertIn("https://github.com/VocaHQ/vocalinux/issues", self.about)
-        self.assertIn("https://discord.gg/UMJduhcqn", self.source)
+        self.assertIn("https://discord.gg/t6muquAJbm", self.source)
         self.assertIn("https://x.com/vocahq", self.source)
         self.assertIn("mailto:hello@vocahq.com", self.source)
 


### PR DESCRIPTION
The About Discord button still used discord.gg/UMJduhcqn. That invite is dead. README and CONTRIBUTING already link discord.gg/t6muquAJbm, which does not expire. VOCAHQ_DISCORD_URL and the two About tests now match.