### PR TITLE
chore(release): prepare v0.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ It's a free, AGPL-3.0-licensed desktop app that lets you dictate text into *any*
 
 Models are downloaded once. After that, speech-to-text stays on your machine. No Voca account is required. Just speak and type.
 
-## 📚 What's New in v0.16.0
+## 📚 What's New in v0.16.1
 
-> **0.16.0** adds an in-app update checker with tray notifications, defaults new installs to hold Right Alt push-to-talk, makes the language list searchable, lets you delete unused downloaded models, and adds a family dictation tone picker. The project license is AGPL-3.0. The installer is hardened (Justfile, uv lockfiles, distro python3-gi). The app icon, tray states, and site favicons use the shared Voca family mic.
+> **0.16.1** is a stability patch on the 0.16 series. Startup uses the engine's own model instead of a leftover generic key, leftover transcription no longer leaves the tray stuck, terminals get Ctrl+Shift+V paste, and the AppImage is built against a glibc Debian 12 can run. The installer now requires Python 3.11 and verifies model downloads.
 
-### Highlights
+### 0.16 series highlights
 
 | Feature | Description |
 |---------|-------------|
@@ -58,19 +58,16 @@ Models are downloaded once. After that, speech-to-text stays on your machine. No
 | **Tone picker** | Settings → Audio: Lift, Flick, Ember, Step, Voca, Soft, Chirp, Scale, Drop, Glass, Off, plus Preview. New installs default to Voca. Catalog uses family preview WAVs (#707, #708) |
 | **Installer** | Justfile, uv lockfiles, distro python3-gi required (no pip sdist of PyGObject). Epic #701 still open (#700, #705, #706) |
 
-### Also in this release
+### Bug fixes in v0.16.1
 
-- IBus: safer scoped injection, engine restore after teardown, XKB layout restore on X11 (#623, #643, #665)
-- Audio: filter unsafe virtual capture devices; open stereo mics at native channel count; catalog tones are the family preview WAVs, not the synthesized #707 files (#629, #673, #708)
-- Clipboard: restore after ydotool paste; text-only reads and safer overlapping restore (#588, #646)
-- GPU / AppImage: honor bundled GPU libs and skip software Vulkan; ship transitive GI typelibs (AppImage fix already hotfixed onto the v0.15.0 AppImages) (#674, #637)
-- Settings / tray: separate Close from Test Dictation; reuse Settings/Logs windows; prefer Ayatana AppIndicator on KDE; optional missing-tray warning toggle (#670, #669, #621, #628)
-- Test Dictation: no longer reports no speech when recognition never started (#702)
-- Settings: About page groups this app, the VocaHQ family, and talk-to-us links (#718)
-- Installer / downloads / tests: gate `util-linux-extra` to Ubuntu 24.04+; report failed model downloads; stop tests from overwriting real `config.json` (#635, #690, #694)
-- Website: vocalinux.com restyled to the Voca family workbench; Discord and X links point at VocaHQ (#728, #729, #722, #717)
+- **Speech models**: start on the engine's own model size; write the model to config only after it loaded; leftover-download list shows every row (#684, #685, #686, fixes #681, #683)
+- **Config**: one ConfigManager for the process, so Settings writes are not overwritten by a stale cache (#691, fixes #689)
+- **Tray**: stay idle after leftover transcription on toggle stop; the missing-model notification can download the recommended model (#741, #687)
+- **Injection / IBus**: Ctrl+Shift+V paste in terminals; keep the GNOME XWayland layout after scoped inject (#734, #742)
+- **Installer / AppImage**: Python 3.11 floor, verified model downloads, no invented GPUs; AppImage glibc that boots on Debian 12 through current Fedora (#713, #736, #743, #744)
+- **Settings**: even dropdowns and a quieter About page with family platform marks (#754)
 
-See [docs/UPDATE.md](docs/UPDATE.md) and the [full changelog](https://github.com/VocaHQ/vocalinux/releases/tag/v0.16.0).
+See [docs/UPDATE.md](docs/UPDATE.md) and the [full changelog](https://github.com/VocaHQ/vocalinux/releases/tag/v0.16.1).
 
 ---
 
@@ -461,7 +458,7 @@ Vocalinux is part of [VocaHQ](https://vocahq.com). On-device speech-to-text firs
 
 | Platform | Project | Website | GitHub | Status |
 |----------|---------|---------|--------|--------|
-| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [VocaHQ/vocalinux](https://github.com/VocaHQ/vocalinux) | ✅ Available now (`v0.16.0`) |
+| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [VocaHQ/vocalinux](https://github.com/VocaHQ/vocalinux) | ✅ Available now (`v0.16.1`) |
 | 🍎 macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [VocaHQ/vocamac](https://github.com/VocaHQ/vocamac) | 🚀 Beta (`v0.9.0`) |
 | 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [VocaHQ/vocawin](https://github.com/VocaHQ/vocawin) | 🚀 Unsigned beta (`v0.1.0-beta.1`) |
 | 📱 Phone | **VocaPhone** | [vocaphone.vocahq.com](https://vocaphone.vocahq.com) | [VocaHQ/vocaphone](https://github.com/VocaHQ/vocaphone) | 🚀 Android beta / iOS [TestFlight](https://testflight.apple.com/join/wd85wQ3W) |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -414,6 +414,7 @@ git push origin v0.5.1-beta
 | 0.14.2 | 2026-07-17 | Stable | IBus engine launch + FocusIn gate; settings tabs scroll to fit monitor |
 | 0.15.0 | 2026-07-28 | Stable | Searchable settings + sidebar dictation footer, AppImage, expanded languages, dictation polish, auto-pause/keepalive, Vulkan device selection, ibus-wayland, Bluetooth mic + shortcut UI fixes |
 | 0.16.0 | 2026-08-23 | Stable | Update checker + tray notify, Right Alt PTT default (new installs), searchable language list, delete unused models, Voca tone picker (family preview WAVs), About page, AGPL-3.0, family mic icons, installer/just/uv pinning, Test Dictation missing-model message, IBus/audio/clipboard/GPU/AppImage reliability, vocalinux.com family workbench restyle |
+| 0.16.1 | 2026-08-30 | Stable | Patch: per-engine model at startup, leftover tray idle, terminal Ctrl+Shift+V paste, GNOME XWayland layout after IBus, Python 3.11 floor + verified downloads, AppImage glibc that boots on Debian 12, Settings/About polish |
 
 ## Questions?
 

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -2,6 +2,44 @@
 
 This guide explains how to update Vocalinux to the latest version.
 
+## What's New in v0.16.1
+
+0.16.1 is a **stability patch** on the 0.16 series. The feature set is the same as 0.16.x. This release fixes wrong-model startup, leftover tray state after toggle stop, paste into terminals, GNOME XWayland layout after inject, and AppImages that needed a glibc newer than Debian 12. The installer now requires Python 3.11 and verifies model downloads.
+
+### 0.16 series highlights
+
+| Feature | Description |
+|---------|-------------|
+| **Update checker** | Settings → About checks stable/nightly; tray shows Update Available for newer GitHub releases (#631, #645) |
+| **Right Alt PTT default** | New installs default to hold Right Alt (push-to-talk); existing configs keep their shortcut (#648) |
+| **Searchable languages** | Type to filter the Speech Model language list (#672) |
+| **Delete unused models** | Remove leftover downloaded speech models from Settings (#671) |
+| **AGPL-3.0** | License aligned with other VocaHQ projects (#660) |
+| **Family mic icons** | App icon, tray states, and site favicons use the shared Voca family mic (#704) |
+| **Tone picker** | Settings → Audio: Lift, Flick, Ember, Step, Voca, Soft, Chirp, Scale, Drop, Glass, Off, plus Preview. New installs default to Voca. Catalog uses family preview WAVs (#707, #708) |
+| **Installer** | Justfile, uv lockfiles, distro python3-gi required (no pip sdist of PyGObject). Epic #701 still open (#700, #705, #706) |
+
+### Bug fixes in v0.16.1
+
+- **Startup**: resolve model size per engine instead of the leftover generic `model_size` key, so a VOSK save does not make whisper.cpp look for a missing medium model (#684 by @kacperpaczos, fixes #681)
+- **Settings**: save the model only after the engine loaded it, so a cancelled or failed download does not leave config pointing at a file that is not on disk (#685 by @kacperpaczos)
+- **Settings**: unused downloads list sized to its real rows so leftover models are not clipped (#686 by @kacperpaczos, fixes #683)
+- **Config**: one ConfigManager for the process so Settings writes are not overwritten by a stale cache (#691 by @kacperpaczos, fixes #689)
+- **Tray**: stay idle after leftover transcription on toggle stop (#741)
+- **Tray**: the missing-model notification can download the recommended model (#687 by @kacperpaczos)
+- **Injection**: Ctrl+Shift+V when pasting into terminals, so Ctrl+V is not treated as verbatim insert (#734)
+- **IBus**: sync the XWayland layout from GNOME after scoped inject (#742)
+- **Installer**: survive a release without a checksum manifest; stop inventing GPUs (#736 by @sesav)
+- **Installer**: leftover engine repair, just `--no-sync`, ggml verify from #713 (#732)
+- **AppImage**: build against a glibc floor Debian 12 can run; boot tests on six distros (#743, #744 by @sesav)
+- **Installer**: Python 3.11 floor, uv tooling, verified model downloads (epic #701 phases 2.5 and 5) (#713 by @sesav)
+- **Settings / About**: even dropdowns, quieter About, family platform marks (#754)
+- **Docs**: canonical VocaHQ Discord invite; VocaWin is unsigned beta; screenshots page says v0.16; README family/on-device copy (#749, #733, #735, #737)
+
+See the [full changelog](https://github.com/VocaHQ/vocalinux/releases/tag/v0.16.1).
+
+---
+
 ## What's New in v0.16.0
 
 0.16.0 is a **minor** release on the stable line. It adds an in-app update checker with tray notifications, defaults new installs to hold Right Alt push-to-talk, makes the language picker searchable, lets you delete unused downloaded models, and adds a family dictation tone picker. The license is AGPL-3.0. The installer is hardened (Justfile, uv lockfiles, distro python3-gi). The app icon, tray states, and site favicons use the shared Voca family mic.
@@ -449,7 +487,7 @@ The installer will:
 ```bash
 cd vocalinux
 git fetch origin
-git checkout v0.16.0
+git checkout v0.16.1
 ./install.sh
 ```
 

--- a/packaging/aur/vocalinux/PKGBUILD
+++ b/packaging/aur/vocalinux/PKGBUILD
@@ -3,8 +3,8 @@
 
 pkgname=vocalinux
 # AUR pkgver cannot contain hyphens (v0.14.0-beta -> 0.14.0beta).
-pkgver=0.16.0
-_tag=0.16.0
+pkgver=0.16.1
+_tag=0.16.1
 pkgrel=1
 pkgdesc="Free, offline voice dictation for Linux"
 arch=('any')

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -78,7 +78,7 @@ pipx run flatpak-pip-generator \
    sources:
      - type: git
        url: https://github.com/VocaHQ/vocalinux.git
-       tag: v0.16.0
+       tag: v0.16.1
        commit: <release-commit-sha>
    ```
 

--- a/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
@@ -105,6 +105,11 @@
   </content_rating>
 
   <releases>
+    <release version="0.16.1" date="2026-08-30">
+      <description>
+        <p>Stability patch: per-engine model size at startup, save the model only after it loaded, leftover-download list shows every row, one ConfigManager so Settings writes stick, tray stays idle after leftover transcription and can download the recommended model from the missing-model notification, Ctrl+Shift+V paste in terminals, GNOME XWayland layout after scoped IBus inject, Python 3.11 installer floor with verified model downloads, AppImage glibc that boots on Debian 12, and Settings/About layout polish.</p>
+      </description>
+    </release>
     <release version="0.16.0" date="2026-08-23">
       <description>
         <p>In-app update checker with tray notifications, hold Right Alt push-to-talk default for new installs, searchable language list, delete unused downloaded speech models, family dictation tone picker (default Voca, family preview WAVs), Settings About page for this app, VocaHQ, and talk to us, AGPL-3.0 relicensing, shared Voca family mic for app/tray/site icons, hardened installer with Justfile and uv lockfiles (distro python3-gi required), Test Dictation missing-model message, and desktop reliability fixes for IBus, audio capture, clipboard restore, GPU/Vulkan selection, and AppImage GI typelibs.</p>

--- a/src/vocalinux/version.py
+++ b/src/vocalinux/version.py
@@ -2,8 +2,8 @@
 Version information for Vocalinux.
 """
 
-__version__ = "0.16.0"
-__version_info__ = (0, 16, 0)
+__version__ = "0.16.1"
+__version_info__ = (0, 16, 1)
 __author__ = "Jatin K Malik"
 __email__ = "jatinkrmalik@gmail.com"
 __license__ = "AGPL-3.0-only"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vocalinux-website",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vocalinux-website",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "dependencies": {
         "@types/node": "^20.14.10",
         "@types/react": "^18.3.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocalinux-website",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -15,6 +15,20 @@ import { absoluteUrl, buildPageMetadata } from "@/lib/seo";
 
 const releases = [
   {
+    version: "v0.16.1",
+    date: "2026-08-30",
+    type: "stable",
+    highlights: [
+      "Startup uses the engine's own model size instead of a leftover generic key; the model is saved only after it loaded (PR #684, #685, fixes #681)",
+      "Unused leftover-model list shows every row; one ConfigManager so Settings writes stick (PR #686, #691, fixes #683, #689)",
+      "Tray stays idle after leftover transcription on toggle stop, and the missing-model notification can download the recommended model (PR #741, #687)",
+      "Terminals get Ctrl+Shift+V paste; GNOME XWayland layout is restored after scoped IBus inject (PR #734, #742)",
+      "Installer requires Python 3.11, verifies model downloads, and no longer invents GPUs (PR #713, #736)",
+      "AppImage built against a glibc floor that boots on Debian 12 through current Fedora (PR #743, #744)",
+      "Settings dropdowns share a width; About is quieter with family platform marks (PR #754)",
+    ],
+  },
+  {
     version: "v0.16.0",
     date: "2026-08-23",
     type: "stable",

--- a/web/src/app/desktop-reliability/page.tsx
+++ b/web/src/app/desktop-reliability/page.tsx
@@ -55,6 +55,11 @@ const reliabilityFeatures = [
 
 const releaseMap = [
   {
+    version: "v0.16.1",
+    highlights:
+      "Per-engine model at startup, leftover tray idle after toggle stop, Ctrl+Shift+V paste in terminals, GNOME XWayland layout after scoped IBus inject, Python 3.11 installer floor with verified downloads, and AppImage glibc that boots on Debian 12.",
+  },
+  {
     version: "v0.16.0",
     highlights:
       "Update checker with tray notifications, Right Alt PTT default for new installs, searchable language list, unused model deletion, Test Dictation missing-model message, IBus/XKB restore fixes, safer audio capture, clipboard restore, installer python3-gi requirement, and AppImage/GPU packaging hardening.",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -40,7 +40,7 @@ const homeJsonLd = [
     },
     description:
       "Offline voice dictation and speech-to-text for Linux with whisper.cpp and VOSK.",
-    softwareVersion: "0.16.0",
+    softwareVersion: "0.16.1",
     author: {
       "@type": "Person",
       name: "Jatin K Malik",


### PR DESCRIPTION
## Summary

Prepares **v0.16.1**, a stability patch on the 0.16 series.

The feature set is the same as 0.16.x. This tag is the desktop and installer work that landed after v0.16.0: wrong-model startup, leftover tray state, terminal paste, GNOME XWayland layout after IBus, a Python 3.11 installer floor, and an AppImage glibc that Debian 12 can run.

### Already on main (this PR only bumps version + notes)

- **#684 / #685 / #686 / #691** by @kacperpaczos — per-engine model at startup, save the model only after it loaded, leftover-download list shows every row, one ConfigManager (fixes #681, #683, #689)
- **#687** by @kacperpaczos — missing-model notification can download the recommended model
- **#741** — tray stays idle after leftover transcription on toggle stop
- **#734** — Ctrl+Shift+V paste in terminals
- **#742** — sync GNOME XWayland layout after scoped IBus inject
- **#713 / #732 / #736** by @sesav (and follow-up) — Python 3.11 floor, verified model downloads, leftover engine repair, no invented GPUs
- **#743 / #744** by @sesav — AppImage glibc floor that boots on Debian 12 through current Fedora; boot tests on six distros
- **#754 / #749** — Settings dropdowns evened out; quieter About page; canonical VocaHQ Discord invite
- **#733 / #735 / #737** — VocaWin unsigned-beta copy, screenshots page says v0.16, README family/on-device copy
- **#748** — tests: stop leaking `Factory.new` onto MagicMock (CI only)

### Release prep in this PR

- Bump `0.16.0` → `0.16.1` (`version.py`, web package, AUR PKGBUILD with `sha256sums=('SKIP')`)
- Series-aware README / UPDATE: keep the 0.16 feature table, add "Bug fixes in this patch"
- Website changelog (delta only), schema `softwareVersion`, desktop-reliability map
- Flatpak AppStream short `<release>` + packaging README tag example
- Version history row in `docs/RELEASE_PROCESS.md` (2026-08-30)
- `SECURITY.md` stays on `0.16.x`

## After merge

1. Tag from `main`, not this branch: `git tag -a v0.16.1` then `git push origin v0.16.1`
2. Confirm GitHub Release / PyPI / website / AUR / AppImage automation
3. Paste the draft notes below onto the GitHub Release (the workflow stub is a starting point only)

Do not tag from this branch alone.

## Checklist

- [x] Version files updated
- [x] Series-aware README / UPDATE
- [x] Website + changelog
- [x] Flatpak metainfo
- [x] `just lint` clean
- [x] `just test`: 2549 passed; 1 host-only IBus failure (`test_is_ibus_active_not_active` when IBus is the session IM)
- [x] `just typecheck` still reports the same pre-existing mypy errors as main (not introduced here)
- [x] `just build` produced `vocalinux-0.16.1` sdist/wheel
- [x] `npm run build` in `web/` succeeded
- [ ] CI green
- [ ] Tag after merge

## Draft GitHub Release Notes

# Vocalinux v0.16.1

Vocalinux 0.16.1 is a patch on the 0.16 line. It fixes a handful of desktop and install bugs that showed up after 0.16.0: the wrong speech model at startup, leftover tray state after toggle stop, paste into terminals, GNOME XWayland layout after inject, and AppImages that needed a glibc newer than Debian 12. The installer now requires Python 3.11 and checks model downloads against pinned checksums.

---

## Highlights

| Area | Description |
|------|-------------|
| Speech models | Start on the engine's own model size; save the model only after it loaded |
| Tray | Stay idle after leftover transcription; download the recommended model from the missing-model notification |
| Injection | Ctrl+Shift+V paste in terminals; keep the GNOME XWayland layout after IBus |
| Installer | Python 3.11 floor, verified downloads, no invented GPUs |
| AppImage | glibc floor that boots on Debian 12 through current Fedora |
| Settings | Even dropdowns and a quieter About page |

---

## New Features

- Tray: the missing-model notification can download the recommended model. (#687 by @kacperpaczos)

---

## Bug Fixes

- Startup: resolve model size per engine instead of the leftover generic `model_size` key, so a VOSK save does not make whisper.cpp look for a missing medium model. (#684 by @kacperpaczos, fixes #681)
- Settings: save the model only after the engine loaded it, so a cancelled or failed download does not leave config pointing at a file that is not on disk. (#685 by @kacperpaczos)
- Settings: unused downloads list sized to its real rows so leftover models are not clipped. (#686 by @kacperpaczos, fixes #683)
- Config: one ConfigManager for the process so Settings writes are not overwritten by a stale cache. (#691 by @kacperpaczos, fixes #689)
- Tray: stay idle after leftover transcription on toggle stop. (#741 by @jatinkrmalik)
- Injection: Ctrl+Shift+V when pasting into terminals, so Ctrl+V is not treated as verbatim insert. (#734 by @jatinkrmalik)
- IBus: sync the XWayland layout from GNOME after scoped inject. (#742 by @jatinkrmalik)
- Installer: survive a release without a checksum manifest, and stop inventing GPUs. (#736 by @sesav)
- Installer: leftover engine repair, `just --no-sync`, ggml verify from #713. (#732 by @jatinkrmalik)

### Improvements

- Settings: even dropdown widths, quieter About page, family platform marks. (#754 by @jatinkrmalik)
- UI: use the canonical VocaHQ Discord invite. (#749 by @jatinkrmalik)

### Docs

- VocaWin is unsigned beta, still not a Store ship. (#733 by @jatinkrmalik)
- Screenshots page labeled v0.16. (#735 by @jatinkrmalik)
- README family status and on-device copy. (#737 by @jatinkrmalik)

### Packaging

- Python 3.11 floor, uv tooling, verified model downloads (epic #701 phases 2.5 and 5). Ubuntu 22.04 is out: jammy's python3 is 3.10. (#713 by @sesav)
- AppImage built against a glibc floor Debian 12 can run. (#743 by @sesav)
- AppImage boot tests on six distros. (#744 by @sesav)

### CI / maintenance

- Tests: stop leaking `Factory.new` onto MagicMock. (#748 by @jatinkrmalik)

---

## Thanks

Thank you **@kacperpaczos** for the per-engine model startup, save-after-load, leftover-download list, shared ConfigManager, and the recommended-model tray download (#684, #685, #686, #691, #687).

Thank you **@sesav** for the Python 3.11 floor, verified downloads, installer GPU/checksum fixes, and the AppImage glibc work that actually boots on Debian 12 (#713, #736, #743, #744).

Thanks to everyone who filed bugs and tested builds on the way to 0.16.1.

---

## Install / Upgrade

### Recommended (install.sh)

```bash
curl -fsSL https://raw.githubusercontent.com/VocaHQ/vocalinux/main/install.sh -o /tmp/vl.sh && bash /tmp/vl.sh
```

The installer needs Python 3.11 or newer and distro `python3-gi` / `python3-gobject`. It no longer pip-builds PyGObject from sdist. Ubuntu 22.04 is not supported.

### AppImage

Download `Vocalinux-0.16.1-x86_64.AppImage` or `Vocalinux-0.16.1-aarch64.AppImage` from this release:

```bash
chmod +x Vocalinux-0.16.1-x86_64.AppImage
./Vocalinux-0.16.1-x86_64.AppImage
```

Host text-injection tools (`xdotool`, `wtype`, or `ydotool`) are still required, same as a PyPI install. FUSE is needed to run the AppImage on most hosts.

### Arch Linux (AUR)

```bash
yay -S vocalinux
```

### PyPI

```bash
pip install -U vocalinux
```

PyPI is the Python package only. For system deps, desktop integration, and models, use `install.sh`.

### Flatpak

Local build notes live under `packaging/flatpak/`. Flathub may still trail this tag.

Upgrade details: [docs/UPDATE.md](https://github.com/VocaHQ/vocalinux/blob/main/docs/UPDATE.md)

**Full changelog:** https://github.com/VocaHQ/vocalinux/compare/v0.16.0...v0.16.1
