### PR TITLE
fix(site): VocaGateway family card is Beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ Vocalinux is part of [VocaHQ](https://vocahq.com). On-device speech-to-text firs
 | 🍎 macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [VocaHQ/vocamac](https://github.com/VocaHQ/vocamac) | 🚀 Beta (`v0.9.0`) |
 | 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [VocaHQ/vocawin](https://github.com/VocaHQ/vocawin) | 🚀 Unsigned beta (`v0.1.0-beta.1`) |
 | 📱 Phone | **VocaPhone** | [vocaphone.vocahq.com](https://vocaphone.vocahq.com) | [VocaHQ/vocaphone](https://github.com/VocaHQ/vocaphone) | 🚀 Android beta / iOS [TestFlight](https://testflight.apple.com/join/wd85wQ3W) |
-| 🖧 Gateway | **VocaGateway** | [vocagateway.vocahq.com](https://vocagateway.vocahq.com) | [VocaHQ/vocagateway](https://github.com/VocaHQ/vocagateway) | 🧪 Early · optional · not on-device |
+| 🖧 Gateway | **VocaGateway** | [vocagateway.vocahq.com](https://vocagateway.vocahq.com) | [VocaHQ/vocagateway](https://github.com/VocaHQ/vocagateway) | 🧪 Beta · optional · not on-device |
 
 > VocaWin is unsigned. SmartScreen may warn about an unknown publisher. It is not a Microsoft Store ship.
 >

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1003,7 +1003,7 @@ export default function HomePage() {
                   />
                   Infrastructure
                 </span>
-                <span className="chip">Early</span>
+                <span className="chip">Beta</span>
               </div>
               <h3>VocaGateway</h3>
               <p>


### PR DESCRIPTION
The family strip on vocalinux.com still called VocaGateway Early. PRODUCT.md (verified 2026-08-30) and vocagateway.vocahq.com already say Beta.

This flips that chip, and the README family table, Early to Beta. The Gateway line still says optional self-hosted, not on-device. Vocalinux spelling and iron-white are untouched.

See #764.