### PR TITLE
Feature/custom dictionary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,7 @@ src/vocalinux/
 ├── speech_recognition/
 │   ├── recognition_manager.py  # whisper.cpp / Whisper / Vosk / remote
 │   ├── command_processor.py    # voice commands
+│   ├── dictionary_corrector.py  # custom dictionary transcript corrections
 │   ├── silero_vad.py
 │   └── data/                   # bundled silero_vad.onnx
 ├── text_injection/
@@ -151,6 +152,7 @@ Also: `tests/`, `docs/`, `packaging/` (AppImage, AUR, Flatpak), `scripts/`, `ins
 | Task | Start here |
 |---|---|
 | Voice command | `speech_recognition/command_processor.py` |
+| Transcript corrections | `speech_recognition/dictionary_corrector.py` |
 | Engine / models | `speech_recognition/recognition_manager.py` |
 | Text injection | `text_injection/text_injector.py`, `ibus_engine.py` |
 | Settings | `ui/config_manager.py`, `ui/settings_dialog.py` |

--- a/src/vocalinux/speech_recognition/__init__.py
+++ b/src/vocalinux/speech_recognition/__init__.py
@@ -2,7 +2,7 @@
 Speech recognition module for Vocalinux
 """
 
-from . import command_processor, recognition_manager  # noqa: F401
+from . import command_processor, dictionary_corrector, recognition_manager  # noqa: F401
 
 
 def get_audio_input_devices():

--- a/src/vocalinux/speech_recognition/dictionary_corrector.py
+++ b/src/vocalinux/speech_recognition/dictionary_corrector.py
@@ -1,0 +1,108 @@
+"""
+Custom dictionary post-correction for Vocalinux.
+
+Applies user-configured phrase corrections to the final transcript so that
+commonly misheard words are replaced with the intended term, e.g. a
+dictionary entry of "super base" -> "Supabase" fixes the transcript even
+though the word is not in the speech model's vocabulary.
+"""
+
+import json
+import logging
+import os
+import re
+
+from ..utils.paths import config_dir
+
+logger = logging.getLogger(__name__)
+
+CONFIG_SECTION = "text_injection"
+CONFIG_KEY = "custom_dictionary"
+
+
+def load_custom_dictionary() -> list[dict]:
+    """Load validated dictionary entries from config.json on disk.
+
+    Reads the file on each call so Settings changes take effect on the next
+    transcription segment without a restart (same live-reload pattern as
+    ``main._should_append_trailing_space``). Malformed or empty entries are
+    dropped; on any read error the dictionary is treated as empty.
+
+    Returns:
+        List of ``{"spoken": str, "replacement": str}`` dicts.
+    """
+    try:
+        config_path = os.path.join(config_dir(), "config.json")
+        if not os.path.exists(config_path):
+            return []
+        with open(config_path, "r") as f:
+            config = json.load(f)
+        raw_entries = config.get(CONFIG_SECTION, {}).get(CONFIG_KEY, []) or []
+    except Exception as e:
+        logger.debug(f"Could not read {CONFIG_KEY} setting: {e}")
+        return []
+
+    if not isinstance(raw_entries, list):
+        logger.warning(f"{CONFIG_KEY} config is not a list; ignoring it")
+        return []
+
+    entries = []
+    for index, entry in enumerate(raw_entries):
+        if not isinstance(entry, dict):
+            logger.warning(f"Ignoring malformed {CONFIG_KEY} entry {index}: not a dict")
+            continue
+        spoken = str(entry.get("spoken", "")).strip()
+        replacement = str(entry.get("replacement", "")).strip()
+        if not spoken or not replacement:
+            logger.warning(f"Ignoring malformed {CONFIG_KEY} entry {index}: empty field")
+            continue
+        entries.append({"spoken": spoken, "replacement": replacement})
+    return entries
+
+
+def apply_dictionary(text: str, entries: list[dict]) -> str:
+    """Apply dictionary corrections to a transcript.
+
+    Matching is case-insensitive on whole words/phrases, and the replacement
+    is inserted exactly as configured. Longer phrases are matched first so
+    "super base" wins over a shorter phrase that shares a word. Lookarounds
+    are used instead of ``\\b`` so phrases that start or end with non-word
+    characters (e.g. "C++") still match correctly.
+
+    Args:
+        text: The transcript text to correct.
+        entries: Dictionary entries as returned by ``load_custom_dictionary``.
+
+    Returns:
+        The corrected text, or the input unchanged when there is nothing
+        to do.
+    """
+    if not text or not entries:
+        return text
+
+    valid_entries = [
+        (str(e.get("spoken", "")).strip(), str(e.get("replacement", "")).strip())
+        for e in entries
+        if isinstance(e, dict)
+        and str(e.get("spoken", "")).strip()
+        and str(e.get("replacement", "")).strip()
+    ]
+    if not valid_entries:
+        return text
+
+    # Longest first (word count, then length) so multi-word phrases take
+    # priority over shorter overlapping ones in the alternation.
+    ordered = sorted(
+        valid_entries, key=lambda pair: (len(pair[0].split()), len(pair[0])), reverse=True
+    )
+
+    pattern = re.compile(
+        r"(?<!\w)(?:" + "|".join(re.escape(spoken) for spoken, _ in ordered) + r")(?!\w)",
+        re.IGNORECASE,
+    )
+    corrections = {spoken.lower(): replacement for spoken, replacement in ordered}
+    corrected = pattern.sub(lambda m: corrections[m.group(0).lower()], text)
+
+    if corrected != text:
+        logger.debug(f"Applied {CONFIG_KEY} corrections: '{text[:60]}' -> '{corrected[:60]}'")
+    return corrected

--- a/src/vocalinux/speech_recognition/dictionary_corrector.py
+++ b/src/vocalinux/speech_recognition/dictionary_corrector.py
@@ -69,6 +69,60 @@ def load_custom_dictionary() -> list[dict]:
     return entries
 
 
+def _ordered_entries(entries: list[dict]) -> list[tuple[str, str]]:
+    """Return validated (spoken, replacement) pairs, longest phrase first."""
+    valid_entries = [
+        (str(e.get("spoken", "")).strip(), str(e.get("replacement", "")).strip())
+        for e in entries
+        if isinstance(e, dict)
+        and str(e.get("spoken", "")).strip()
+        and str(e.get("replacement", "")).strip()
+    ]
+    return sorted(
+        valid_entries, key=lambda pair: (len(pair[0].split()), len(pair[0])), reverse=True
+    )
+
+
+def mask_dictionary_phrases(text: str, entries: list[dict]) -> tuple[str, dict[str, str]]:
+    """Replace spoken phrases with sentinels that CommandProcessor will ignore.
+
+    Returns:
+        (masked_text, mapping) where mapping sends each sentinel to its
+        configured replacement. Apply ``unmask_dictionary_phrases`` after
+        command processing so replacements never fire as voice commands, while
+        unrelated commands in the same transcript still run.
+    """
+    if not text or not entries:
+        return text, {}
+
+    ordered = _ordered_entries(entries)
+    if not ordered:
+        return text, {}
+
+    mapping: dict[str, str] = {}
+    masked = text
+    for index, (spoken, replacement) in enumerate(ordered):
+        sentinel = f"\ufff0{index}\ufff1"
+        pattern = re.compile(
+            r"(?<!\w)" + re.escape(spoken) + r"(?!\w)",
+            re.IGNORECASE,
+        )
+        if not pattern.search(masked):
+            continue
+        mapping[sentinel] = replacement
+        masked = pattern.sub(sentinel, masked)
+    return masked, mapping
+
+
+def unmask_dictionary_phrases(text: str, mapping: dict[str, str]) -> str:
+    """Restore dictionary replacements after command processing."""
+    if not text or not mapping:
+        return text
+    for sentinel, replacement in mapping.items():
+        text = text.replace(sentinel, replacement)
+    return text
+
+
 def apply_dictionary(text: str, entries: list[dict]) -> str:
     """Apply dictionary corrections to a transcript.
 
@@ -89,21 +143,12 @@ def apply_dictionary(text: str, entries: list[dict]) -> str:
     if not text or not entries:
         return text
 
-    valid_entries = [
-        (str(e.get("spoken", "")).strip(), str(e.get("replacement", "")).strip())
-        for e in entries
-        if isinstance(e, dict)
-        and str(e.get("spoken", "")).strip()
-        and str(e.get("replacement", "")).strip()
-    ]
-    if not valid_entries:
+    ordered = _ordered_entries(entries)
+    if not ordered:
         return text
 
-    # Longest first (word count, then length) so multi-word phrases take
-    # priority over shorter overlapping ones in the alternation.
-    ordered = sorted(
-        valid_entries, key=lambda pair: (len(pair[0].split()), len(pair[0])), reverse=True
-    )
+    # Longest first already applied in _ordered_entries so multi-word phrases
+    # take priority over shorter overlapping ones in the alternation.
 
     pattern = re.compile(
         r"(?<!\w)(?:" + "|".join(re.escape(spoken) for spoken, _ in ordered) + r")(?!\w)",

--- a/src/vocalinux/speech_recognition/dictionary_corrector.py
+++ b/src/vocalinux/speech_recognition/dictionary_corrector.py
@@ -37,11 +37,20 @@ def load_custom_dictionary() -> list[dict]:
             return []
         with open(config_path, "r") as f:
             config = json.load(f)
-        raw_entries = config.get(CONFIG_SECTION, {}).get(CONFIG_KEY, []) or []
-    except Exception as e:
+    except (json.JSONDecodeError, OSError) as e:
         logger.debug(f"Could not read {CONFIG_KEY} setting: {e}")
         return []
 
+    if not isinstance(config, dict):
+        logger.warning(f"{CONFIG_KEY} config root is not a dict; ignoring it")
+        return []
+
+    section = config.get(CONFIG_SECTION, {})
+    if not isinstance(section, dict):
+        logger.warning(f"{CONFIG_SECTION} config is not a dict; ignoring {CONFIG_KEY}")
+        return []
+
+    raw_entries = section.get(CONFIG_KEY, []) or []
     if not isinstance(raw_entries, list):
         logger.warning(f"{CONFIG_KEY} config is not a list; ignoring it")
         return []

--- a/src/vocalinux/speech_recognition/dictionary_corrector.py
+++ b/src/vocalinux/speech_recognition/dictionary_corrector.py
@@ -83,6 +83,53 @@ def _ordered_entries(entries: list[dict]) -> list[tuple[str, str]]:
     )
 
 
+def mask_dictionary_phrases(text: str, entries: list[dict]) -> tuple[str, dict[str, str]]:
+    """Replace spoken phrases with word-like sentinels CommandProcessor ignores.
+
+    Sentinels use the form ``zzdictNzz`` so format commands that grab the next
+    word-character token still leave a recoverable placeholder, while action/text command regexes
+    cannot match the configured replacement until after unmasking.
+    """
+    if not text or not entries:
+        return text, {}
+
+    ordered = _ordered_entries(entries)
+    if not ordered:
+        return text, {}
+
+    mapping: dict[str, str] = {}
+    masked = text
+    for index, (spoken, replacement) in enumerate(ordered):
+        sentinel = f"zzdict{index}zz"
+        pattern = re.compile(
+            r"(?<!\w)" + re.escape(spoken) + r"(?!\w)",
+            re.IGNORECASE,
+        )
+        if not pattern.search(masked):
+            continue
+        mapping[sentinel] = replacement
+        masked = pattern.sub(sentinel, masked)
+    return masked, mapping
+
+
+def unmask_dictionary_phrases(text: str, mapping: dict[str, str]) -> str:
+    """Restore dictionary replacements after command processing.
+
+    Matching is case-insensitive so capitalize/uppercase/lowercase format
+    commands can alter sentinel casing without losing the replacement.
+    """
+    if not text or not mapping:
+        return text
+    for sentinel, replacement in mapping.items():
+        text = re.sub(
+            re.escape(sentinel),
+            lambda _m, r=replacement: r,
+            text,
+            flags=re.IGNORECASE,
+        )
+    return text
+
+
 def apply_dictionary(text: str, entries: list[dict]) -> str:
     """Apply dictionary corrections to a transcript.
 

--- a/src/vocalinux/speech_recognition/dictionary_corrector.py
+++ b/src/vocalinux/speech_recognition/dictionary_corrector.py
@@ -35,9 +35,9 @@ def load_custom_dictionary() -> list[dict]:
         config_path = os.path.join(config_dir(), "config.json")
         if not os.path.exists(config_path):
             return []
-        with open(config_path, "r") as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             config = json.load(f)
-    except (json.JSONDecodeError, OSError) as e:
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError) as e:
         logger.debug(f"Could not read {CONFIG_KEY} setting: {e}")
         return []
 
@@ -81,46 +81,6 @@ def _ordered_entries(entries: list[dict]) -> list[tuple[str, str]]:
     return sorted(
         valid_entries, key=lambda pair: (len(pair[0].split()), len(pair[0])), reverse=True
     )
-
-
-def mask_dictionary_phrases(text: str, entries: list[dict]) -> tuple[str, dict[str, str]]:
-    """Replace spoken phrases with sentinels that CommandProcessor will ignore.
-
-    Returns:
-        (masked_text, mapping) where mapping sends each sentinel to its
-        configured replacement. Apply ``unmask_dictionary_phrases`` after
-        command processing so replacements never fire as voice commands, while
-        unrelated commands in the same transcript still run.
-    """
-    if not text or not entries:
-        return text, {}
-
-    ordered = _ordered_entries(entries)
-    if not ordered:
-        return text, {}
-
-    mapping: dict[str, str] = {}
-    masked = text
-    for index, (spoken, replacement) in enumerate(ordered):
-        sentinel = f"\ufff0{index}\ufff1"
-        pattern = re.compile(
-            r"(?<!\w)" + re.escape(spoken) + r"(?!\w)",
-            re.IGNORECASE,
-        )
-        if not pattern.search(masked):
-            continue
-        mapping[sentinel] = replacement
-        masked = pattern.sub(sentinel, masked)
-    return masked, mapping
-
-
-def unmask_dictionary_phrases(text: str, mapping: dict[str, str]) -> str:
-    """Restore dictionary replacements after command processing."""
-    if not text or not mapping:
-        return text
-    for sentinel, replacement in mapping.items():
-        text = text.replace(sentinel, replacement)
-    return text
 
 
 def apply_dictionary(text: str, entries: list[dict]) -> str:

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -39,7 +39,7 @@ from ..utils.whisper_model_info import (
 from ..utils.whispercpp_model_info import WHISPERCPP_MODEL_INFO, get_model_path, is_model_downloaded
 from ..version import __version__
 from .command_processor import CommandProcessor
-from .dictionary_corrector import apply_dictionary, load_custom_dictionary
+from .dictionary_corrector import load_custom_dictionary, mask_dictionary_phrases, unmask_dictionary_phrases
 from .silero_vad import SILERO_CHUNK_SIZE, load_silero_vad
 
 
@@ -3277,29 +3277,26 @@ class SpeechRecognitionManager:
         # Process text - either with voice commands or pass through directly
         logger.debug(f"_process_audio_buffer got text='{text[:50] if text else '(empty)'}...'")
         if text:
-            # Apply user-configured custom dictionary corrections to the raw
-            # transcript before command matching, so a corrected phrase cannot
-            # be consumed as a voice command. Re-read config.json each segment
+            # Mask dictionary phrases with sentinels before command matching so
+            # a spoken command-like phrase can be remapped, a replacement that
+            # equals a reserved command stays plain text, and unrelated commands
+            # in the same transcript still run. Re-read config.json each segment
             # so Settings changes apply without a restart.
-            original_text = text
             dictionary_entries = load_custom_dictionary()
+            mapping: dict[str, str] = {}
             if dictionary_entries:
-                text = apply_dictionary(text, dictionary_entries)
+                text, mapping = mask_dictionary_phrases(text, dictionary_entries)
 
-            # Dictionary is for wording, not synthesizing voice commands. If it
-            # rewrote this transcript, inject the corrected text and skip
-            # CommandProcessor so a replacement like "delete that" cannot fire
-            # delete_last.
-            if dictionary_entries and text != original_text:
-                processed_text = text.strip()
-                actions = []
-            elif self._voice_commands_enabled:
+            if self._voice_commands_enabled:
                 # Process with voice commands (original behavior)
                 processed_text, actions = self.command_processor.process_text(text)
             else:
                 # Voice commands disabled - pass text through directly (Whisper handles punctuation)
                 processed_text = text.strip()
                 actions = []
+
+            if mapping:
+                processed_text = unmask_dictionary_phrases(processed_text, mapping)
 
             # Call text callbacks with processed text
             logger.debug(

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -39,6 +39,7 @@ from ..utils.whisper_model_info import (
 from ..utils.whispercpp_model_info import WHISPERCPP_MODEL_INFO, get_model_path, is_model_downloaded
 from ..version import __version__
 from .command_processor import CommandProcessor
+from .dictionary_corrector import apply_dictionary, load_custom_dictionary
 from .silero_vad import SILERO_CHUNK_SIZE, load_silero_vad
 
 
@@ -3283,6 +3284,14 @@ class SpeechRecognitionManager:
                 # Voice commands disabled - pass text through directly (Whisper handles punctuation)
                 processed_text = text.strip()
                 actions = []
+
+            # Apply user-configured custom dictionary corrections so
+            # misheard words are fixed in the final transcript. The
+            # dictionary is re-read from config.json on every segment so
+            # Settings changes apply without a restart.
+            dictionary_entries = load_custom_dictionary()
+            if dictionary_entries:
+                processed_text = apply_dictionary(processed_text, dictionary_entries)
 
             # Call text callbacks with processed text
             logger.debug(

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -3277,6 +3277,14 @@ class SpeechRecognitionManager:
         # Process text - either with voice commands or pass through directly
         logger.debug(f"_process_audio_buffer got text='{text[:50] if text else '(empty)'}...'")
         if text:
+            # Apply user-configured custom dictionary corrections to the raw
+            # transcript before command matching, so a corrected phrase cannot
+            # be consumed as a voice command. Re-read config.json each segment
+            # so Settings changes apply without a restart.
+            dictionary_entries = load_custom_dictionary()
+            if dictionary_entries:
+                text = apply_dictionary(text, dictionary_entries)
+
             if self._voice_commands_enabled:
                 # Process with voice commands (original behavior)
                 processed_text, actions = self.command_processor.process_text(text)
@@ -3284,14 +3292,6 @@ class SpeechRecognitionManager:
                 # Voice commands disabled - pass text through directly (Whisper handles punctuation)
                 processed_text = text.strip()
                 actions = []
-
-            # Apply user-configured custom dictionary corrections so
-            # misheard words are fixed in the final transcript. The
-            # dictionary is re-read from config.json on every segment so
-            # Settings changes apply without a restart.
-            dictionary_entries = load_custom_dictionary()
-            if dictionary_entries:
-                processed_text = apply_dictionary(processed_text, dictionary_entries)
 
             # Call text callbacks with processed text
             logger.debug(

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -3281,11 +3281,19 @@ class SpeechRecognitionManager:
             # transcript before command matching, so a corrected phrase cannot
             # be consumed as a voice command. Re-read config.json each segment
             # so Settings changes apply without a restart.
+            original_text = text
             dictionary_entries = load_custom_dictionary()
             if dictionary_entries:
                 text = apply_dictionary(text, dictionary_entries)
 
-            if self._voice_commands_enabled:
+            # Dictionary is for wording, not synthesizing voice commands. If it
+            # rewrote this transcript, inject the corrected text and skip
+            # CommandProcessor so a replacement like "delete that" cannot fire
+            # delete_last.
+            if dictionary_entries and text != original_text:
+                processed_text = text.strip()
+                actions = []
+            elif self._voice_commands_enabled:
                 # Process with voice commands (original behavior)
                 processed_text, actions = self.command_processor.process_text(text)
             else:

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -39,7 +39,11 @@ from ..utils.whisper_model_info import (
 from ..utils.whispercpp_model_info import WHISPERCPP_MODEL_INFO, get_model_path, is_model_downloaded
 from ..version import __version__
 from .command_processor import CommandProcessor
-from .dictionary_corrector import apply_dictionary, load_custom_dictionary
+from .dictionary_corrector import (
+    load_custom_dictionary,
+    mask_dictionary_phrases,
+    unmask_dictionary_phrases,
+)
 from .silero_vad import SILERO_CHUNK_SIZE, load_silero_vad
 
 
@@ -3277,29 +3281,17 @@ class SpeechRecognitionManager:
         # Process text - either with voice commands or pass through directly
         logger.debug(f"_process_audio_buffer got text='{text[:50] if text else '(empty)'}...'")
         if text:
-            # Two-phase dictionary: remap spoken phrases that collide with voice
-            # commands before CommandProcessor, then apply the rest afterward.
-            # That lets "delete that" -> "keep that" avoid dispatch, keeps a
-            # replacement like "delete that" as plain text, and still runs
-            # unrelated commands such as period in the same transcript.
+            # Mask dictionary phrases with word-like sentinels before command
+            # matching, then restore replacements afterward. That covers spoken
+            # command remaps, command-like replacements, hardcoded CommandProcessor
+            # phrases, and unrelated commands in the same transcript, without
+            # letting format commands destroy the placeholders.
             # Re-read config.json each segment so Settings changes apply without
             # a restart.
             dictionary_entries = load_custom_dictionary()
-            pre_entries: list[dict] = []
-            post_entries: list[dict] = []
+            mapping: dict[str, str] = {}
             if dictionary_entries:
-                command_phrases = {
-                    *(k.lower() for k in self.command_processor.text_commands),
-                    *(k.lower() for k in self.command_processor.action_commands),
-                    *(k.lower() for k in self.command_processor.format_commands),
-                }
-                for entry in dictionary_entries:
-                    if entry["spoken"].lower() in command_phrases:
-                        pre_entries.append(entry)
-                    else:
-                        post_entries.append(entry)
-                if pre_entries:
-                    text = apply_dictionary(text, pre_entries)
+                text, mapping = mask_dictionary_phrases(text, dictionary_entries)
 
             if self._voice_commands_enabled:
                 # Process with voice commands (original behavior)
@@ -3309,8 +3301,8 @@ class SpeechRecognitionManager:
                 processed_text = text.strip()
                 actions = []
 
-            if post_entries:
-                processed_text = apply_dictionary(processed_text, post_entries)
+            if mapping:
+                processed_text = unmask_dictionary_phrases(processed_text, mapping)
 
             # Call text callbacks with processed text
             logger.debug(

--- a/src/vocalinux/speech_recognition/recognition_manager.py
+++ b/src/vocalinux/speech_recognition/recognition_manager.py
@@ -39,7 +39,7 @@ from ..utils.whisper_model_info import (
 from ..utils.whispercpp_model_info import WHISPERCPP_MODEL_INFO, get_model_path, is_model_downloaded
 from ..version import __version__
 from .command_processor import CommandProcessor
-from .dictionary_corrector import load_custom_dictionary, mask_dictionary_phrases, unmask_dictionary_phrases
+from .dictionary_corrector import apply_dictionary, load_custom_dictionary
 from .silero_vad import SILERO_CHUNK_SIZE, load_silero_vad
 
 
@@ -3277,15 +3277,29 @@ class SpeechRecognitionManager:
         # Process text - either with voice commands or pass through directly
         logger.debug(f"_process_audio_buffer got text='{text[:50] if text else '(empty)'}...'")
         if text:
-            # Mask dictionary phrases with sentinels before command matching so
-            # a spoken command-like phrase can be remapped, a replacement that
-            # equals a reserved command stays plain text, and unrelated commands
-            # in the same transcript still run. Re-read config.json each segment
-            # so Settings changes apply without a restart.
+            # Two-phase dictionary: remap spoken phrases that collide with voice
+            # commands before CommandProcessor, then apply the rest afterward.
+            # That lets "delete that" -> "keep that" avoid dispatch, keeps a
+            # replacement like "delete that" as plain text, and still runs
+            # unrelated commands such as period in the same transcript.
+            # Re-read config.json each segment so Settings changes apply without
+            # a restart.
             dictionary_entries = load_custom_dictionary()
-            mapping: dict[str, str] = {}
+            pre_entries: list[dict] = []
+            post_entries: list[dict] = []
             if dictionary_entries:
-                text, mapping = mask_dictionary_phrases(text, dictionary_entries)
+                command_phrases = {
+                    *(k.lower() for k in self.command_processor.text_commands),
+                    *(k.lower() for k in self.command_processor.action_commands),
+                    *(k.lower() for k in self.command_processor.format_commands),
+                }
+                for entry in dictionary_entries:
+                    if entry["spoken"].lower() in command_phrases:
+                        pre_entries.append(entry)
+                    else:
+                        post_entries.append(entry)
+                if pre_entries:
+                    text = apply_dictionary(text, pre_entries)
 
             if self._voice_commands_enabled:
                 # Process with voice commands (original behavior)
@@ -3295,8 +3309,8 @@ class SpeechRecognitionManager:
                 processed_text = text.strip()
                 actions = []
 
-            if mapping:
-                processed_text = unmask_dictionary_phrases(processed_text, mapping)
+            if post_entries:
+                processed_text = apply_dictionary(processed_text, post_entries)
 
             # Call text callbacks with processed text
             logger.debug(

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -140,6 +140,10 @@ DEFAULT_CONFIG = {
         # Clipboard-paste chord: auto-detect terminals, or force Ctrl+V /
         # Ctrl+Shift+V when a nested terminal panel is not detected.
         "paste_shortcut": "auto",
+        # User-defined phrase corrections applied to the final transcript,
+        # e.g. [{"spoken": "super base", "replacement": "Supabase"}].
+        # Applied case-insensitively on whole words by the recognition manager.
+        "custom_dictionary": [],
     },
     "advanced": {
         "power_user_mode": False,

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -2597,11 +2597,20 @@ class SettingsDialog(Gtk.Dialog):
                 cleaned.append({"spoken": spoken, "replacement": replacement})
         return cleaned
 
-    def _save_custom_dictionary(self, entries: list) -> None:
-        """Persist the dictionary and refresh the list UI."""
+    def _save_custom_dictionary(self, entries: list) -> bool:
+        """Persist the dictionary and refresh the list UI.
+
+        Returns:
+            True if the config was written. On write failure the in-memory
+            value is restored so UI and memory match disk.
+        """
+        previous = self._get_custom_dictionary()
         self.config_manager.set("text_injection", "custom_dictionary", entries)
-        self.config_manager.save_config()
+        saved = bool(self.config_manager.save_config())
+        if not saved:
+            self.config_manager.set("text_injection", "custom_dictionary", previous)
         self._refresh_custom_dictionary_list()
+        return saved
 
     def _refresh_custom_dictionary_list(self) -> None:
         """Rebuild the custom dictionary list UI from config."""
@@ -2636,7 +2645,7 @@ class SettingsDialog(Gtk.Dialog):
 
         self.custom_dictionary_listbox.show_all()
 
-    def _on_custom_dictionary_add_clicked(self, widget):
+    def _on_custom_dictionary_add_clicked(self, widget: Any) -> None:
         if self._initializing or self._applying_settings:
             return
         spoken = self.custom_dictionary_spoken_entry.get_text().strip()
@@ -2647,18 +2656,20 @@ class SettingsDialog(Gtk.Dialog):
         # Re-adding an existing phrase updates its replacement (last wins)
         entries = [e for e in entries if e["spoken"].lower() != spoken.lower()]
         entries.append({"spoken": spoken, "replacement": replacement})
-        self._save_custom_dictionary(entries)
+        if not self._save_custom_dictionary(entries):
+            return
         self.custom_dictionary_spoken_entry.set_text("")
         self.custom_dictionary_replacement_entry.set_text("")
         logger.info("Saved dictionary correction: '%s' -> '%s'", spoken, replacement)
 
-    def _on_custom_dictionary_remove_clicked(self, widget, spoken: str):
+    def _on_custom_dictionary_remove_clicked(self, widget: Any, spoken: str) -> None:
         if self._initializing or self._applying_settings:
             return
         entries = [
             e for e in self._get_custom_dictionary() if e["spoken"].lower() != spoken.lower()
         ]
-        self._save_custom_dictionary(entries)
+        if not self._save_custom_dictionary(entries):
+            return
         logger.info("Removed dictionary correction for '%s'", spoken)
 
     def _build_auto_pause_section(self):

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -2573,18 +2573,11 @@ class SettingsDialog(Gtk.Dialog):
         self.custom_dictionary_empty_label.show()
         self.custom_dictionary_listbox.set_placeholder(self.custom_dictionary_empty_label)
 
-        list_scrolled = Gtk.ScrolledWindow()
-        list_scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        list_scrolled.set_min_content_height(48)
-        list_scrolled.set_max_content_height(160)
-        list_scrolled.set_margin_start(8)
-        list_scrolled.set_margin_end(8)
-        list_scrolled.set_margin_bottom(8)
-        list_scrolled.add(self.custom_dictionary_listbox)
-
+        # No inner ScrolledWindow: the dictation page already scrolls, and a
+        # nested scroller would hide entries behind its own scrollbar.
         list_row = Gtk.ListBoxRow()
         list_row.set_activatable(False)
-        list_row.add(list_scrolled)
+        list_row.add(self.custom_dictionary_listbox)
         group.add_row(list_row)
 
         return group

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -2498,6 +2498,176 @@ class SettingsDialog(Gtk.Dialog):
         self.start_minimized_switch.connect("state-set", self._on_start_minimized_toggled)
         self.missing_tray_warning_switch.connect("state-set", self._on_missing_tray_warning_toggled)
 
+    def _build_custom_dictionary_group(self) -> "PreferencesGroup":
+        """Build the Custom Dictionary settings: misheard phrase corrections."""
+        group = PreferencesGroup(
+            title="Custom Dictionary",
+            description=(
+                "Fix words the speech model mishears. Each entry replaces the "
+                "misheard phrase with your intended term in the final transcript, "
+                "e.g. 'super base' \u2192 'Supabase'. Matching is case-insensitive "
+                "on whole words. Changes apply from the next dictation onward."
+            ),
+            keywords=("dictionary", "vocabulary", "correction", "jargon", "replacement", "words"),
+        )
+
+        # Add entry: "Heard as" and "Replace with" fields + Add button
+        add_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        add_box.set_margin_top(8)
+        add_box.set_margin_bottom(4)
+        add_box.set_margin_start(16)
+        add_box.set_margin_end(16)
+
+        self.custom_dictionary_spoken_entry = Gtk.Entry()
+        self.custom_dictionary_spoken_entry.set_placeholder_text("Heard as (e.g. super base)")
+        self.custom_dictionary_spoken_entry.set_hexpand(True)
+        self.custom_dictionary_spoken_entry.set_tooltip_text(
+            "The phrase the speech model typically mishears. "
+            "Matched case-insensitively on whole words."
+        )
+        add_box.pack_start(self.custom_dictionary_spoken_entry, True, True, 0)
+
+        self.custom_dictionary_replacement_entry = Gtk.Entry()
+        self.custom_dictionary_replacement_entry.set_placeholder_text(
+            "Replace with (e.g. Supabase)"
+        )
+        self.custom_dictionary_replacement_entry.set_hexpand(True)
+        self.custom_dictionary_replacement_entry.set_tooltip_text(
+            "The text to insert instead, exactly as typed here."
+        )
+        add_box.pack_start(self.custom_dictionary_replacement_entry, True, True, 0)
+
+        self.custom_dictionary_add_btn = Gtk.Button(label="Add")
+        self.custom_dictionary_add_btn.set_tooltip_text("Add this correction to the dictionary")
+        self.custom_dictionary_add_btn.connect("clicked", self._on_custom_dictionary_add_clicked)
+        self.custom_dictionary_spoken_entry.connect(
+            "activate", self._on_custom_dictionary_add_clicked
+        )
+        self.custom_dictionary_replacement_entry.connect(
+            "activate", self._on_custom_dictionary_add_clicked
+        )
+        add_box.pack_start(self.custom_dictionary_add_btn, False, False, 0)
+
+        add_row = Gtk.ListBoxRow()
+        add_row.set_activatable(False)
+        add_row.add(add_box)
+        group.add_row(add_row)
+
+        # List of configured corrections; the empty-state text is an in-list
+        # placeholder so there is no blank hole when the list is empty.
+        self.custom_dictionary_listbox = Gtk.ListBox()
+        self.custom_dictionary_listbox.set_selection_mode(Gtk.SelectionMode.NONE)
+        self.custom_dictionary_listbox.set_activate_on_single_click(False)
+
+        self.custom_dictionary_empty_label = Gtk.Label(
+            label="No corrections yet. Add the misheard phrase and the term to use instead.",
+            xalign=0.5,
+            wrap=True,
+            justify=Gtk.Justification.CENTER,
+        )
+        self.custom_dictionary_empty_label.get_style_context().add_class("preference-row-subtitle")
+        self.custom_dictionary_empty_label.set_margin_top(12)
+        self.custom_dictionary_empty_label.set_margin_bottom(12)
+        self.custom_dictionary_empty_label.set_margin_start(16)
+        self.custom_dictionary_empty_label.set_margin_end(16)
+        self.custom_dictionary_empty_label.show()
+        self.custom_dictionary_listbox.set_placeholder(self.custom_dictionary_empty_label)
+
+        list_scrolled = Gtk.ScrolledWindow()
+        list_scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        list_scrolled.set_min_content_height(48)
+        list_scrolled.set_max_content_height(160)
+        list_scrolled.set_margin_start(8)
+        list_scrolled.set_margin_end(8)
+        list_scrolled.set_margin_bottom(8)
+        list_scrolled.add(self.custom_dictionary_listbox)
+
+        list_row = Gtk.ListBoxRow()
+        list_row.set_activatable(False)
+        list_row.add(list_scrolled)
+        group.add_row(list_row)
+
+        return group
+
+    def _get_custom_dictionary(self) -> list:
+        """Return a clean list of configured dictionary corrections."""
+        entries = self.config_manager.get("text_injection", "custom_dictionary", []) or []
+        if not isinstance(entries, list):
+            return []
+        cleaned = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            spoken = str(entry.get("spoken", "")).strip()
+            replacement = str(entry.get("replacement", "")).strip()
+            if spoken and replacement:
+                cleaned.append({"spoken": spoken, "replacement": replacement})
+        return cleaned
+
+    def _save_custom_dictionary(self, entries: list) -> None:
+        """Persist the dictionary and refresh the list UI."""
+        self.config_manager.set("text_injection", "custom_dictionary", entries)
+        self.config_manager.save_config()
+        self._refresh_custom_dictionary_list()
+
+    def _refresh_custom_dictionary_list(self) -> None:
+        """Rebuild the custom dictionary list UI from config."""
+        if not hasattr(self, "custom_dictionary_listbox"):
+            return
+
+        for child in list(self.custom_dictionary_listbox.get_children()):
+            self.custom_dictionary_listbox.remove(child)
+
+        for entry in self._get_custom_dictionary():
+            spoken = entry["spoken"]
+            replacement = entry["replacement"]
+            row = Gtk.ListBoxRow()
+            row.set_activatable(False)
+            hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+            hbox.set_margin_top(6)
+            hbox.set_margin_bottom(6)
+            hbox.set_margin_start(16)
+            hbox.set_margin_end(16)
+
+            label = Gtk.Label(label=f"{spoken} \u2192 {replacement}", xalign=0)
+            label.set_hexpand(True)
+            hbox.pack_start(label, True, True, 0)
+
+            remove_btn = Gtk.Button(label="Remove")
+            remove_btn.set_tooltip_text(f"Remove the correction for '{spoken}'")
+            remove_btn.connect("clicked", self._on_custom_dictionary_remove_clicked, spoken)
+            hbox.pack_start(remove_btn, False, False, 0)
+
+            row.add(hbox)
+            self.custom_dictionary_listbox.add(row)
+
+        self.custom_dictionary_listbox.show_all()
+
+    def _on_custom_dictionary_add_clicked(self, widget):
+        if self._initializing or self._applying_settings:
+            return
+        spoken = self.custom_dictionary_spoken_entry.get_text().strip()
+        replacement = self.custom_dictionary_replacement_entry.get_text().strip()
+        if not spoken or not replacement:
+            return
+        entries = self._get_custom_dictionary()
+        # Re-adding an existing phrase updates its replacement (last wins)
+        entries = [e for e in entries if e["spoken"].lower() != spoken.lower()]
+        entries.append({"spoken": spoken, "replacement": replacement})
+        self._save_custom_dictionary(entries)
+        self.custom_dictionary_spoken_entry.set_text("")
+        self.custom_dictionary_replacement_entry.set_text("")
+        logger.info("Saved dictionary correction: '%s' -> '%s'", spoken, replacement)
+
+    def _on_custom_dictionary_remove_clicked(self, widget, spoken: str):
+        if self._initializing or self._applying_settings:
+            return
+        entries = [
+            e for e in self._get_custom_dictionary() if e["spoken"].lower() != spoken.lower()
+        ]
+        self._save_custom_dictionary(entries)
+        logger.info("Removed dictionary correction for '%s'", spoken)
+
     def _build_auto_pause_section(self):
         """Build Auto-Pause settings: enable toggle + process name list."""
         group = PreferencesGroup(
@@ -3468,6 +3638,10 @@ class SettingsDialog(Gtk.Dialog):
             "state-set", self._on_append_trailing_space_toggled
         )
         self.paste_shortcut_combo.connect("changed", self._on_paste_shortcut_changed)
+
+        # Custom dictionary group: user-configured transcript corrections
+        dictionary_group = self._build_custom_dictionary_group()
+        self.recognition_settings_tab.pack_start(dictionary_group, False, False, 0)
 
         if not silero_active:
             vad_info_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
@@ -4978,6 +5152,7 @@ class SettingsDialog(Gtk.Dialog):
         self.auto_pause_switch.set_active(auto_pause_enabled)
         self._update_auto_pause_sensitivity(auto_pause_enabled)
         self._refresh_auto_pause_list()
+        self._refresh_custom_dictionary_list()
 
         keepalive_settings = self.config_manager.get_settings().get("model_keepalive", {})
         keepalive_enabled = bool(keepalive_settings.get("enabled", False))

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -83,6 +83,18 @@ class TestConfigManager(unittest.TestCase):
         )
         self.assertTrue(os.path.exists(self.temp_config_dir))
 
+    def test_custom_dictionary_default_and_roundtrip(self):
+        """custom_dictionary defaults to [] and survives a save/reload cycle."""
+        config_manager = ConfigManager()
+        self.assertEqual(config_manager.get("text_injection", "custom_dictionary", None), [])
+
+        entries = [{"spoken": "super base", "replacement": "Supabase"}]
+        config_manager.set("text_injection", "custom_dictionary", entries)
+        config_manager.save_config()
+
+        reloaded = ConfigManager()
+        self.assertEqual(reloaded.get("text_injection", "custom_dictionary", []), entries)
+
     def test_ensure_config_dir(self):
         """Test that _ensure_config_dir creates the directory."""
         # Delete the config directory to test creation

--- a/tests/test_dictionary_corrector.py
+++ b/tests/test_dictionary_corrector.py
@@ -1,0 +1,193 @@
+"""
+Tests for the custom dictionary transcript corrector.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from vocalinux.speech_recognition.dictionary_corrector import (
+    apply_dictionary,
+    load_custom_dictionary,
+)
+
+
+def _entry(spoken: str, replacement: str) -> dict:
+    """Build a single dictionary entry."""
+    return {"spoken": spoken, "replacement": replacement}
+
+
+class TestApplyDictionary(unittest.TestCase):
+    """Test cases for apply_dictionary."""
+
+    def test_basic_phrase_replacement(self):
+        """A multi-word misheard phrase is replaced with the intended term."""
+        entries = [_entry("super base", "Supabase")]
+        self.assertEqual(
+            apply_dictionary("I use super base daily", entries), "I use Supabase daily"
+        )
+
+    def test_case_insensitive_match(self):
+        """Matching is case-insensitive; replacement is inserted as typed."""
+        entries = [_entry("super base", "Supabase")]
+        self.assertEqual(
+            apply_dictionary("I use SUPER BASE daily", entries), "I use Supabase daily"
+        )
+        self.assertEqual(
+            apply_dictionary("I use Super Base daily", entries), "I use Supabase daily"
+        )
+
+    def test_no_match_inside_larger_words(self):
+        """Word boundaries prevent matching a phrase inside other words."""
+        entries = [_entry("base", "basis")]
+        self.assertEqual(apply_dictionary("The database is down", entries), "The database is down")
+
+    def test_no_match_without_inner_space(self):
+        """A multi-word phrase requires the exact word sequence."""
+        entries = [_entry("super base", "Supabase")]
+        self.assertEqual(
+            apply_dictionary("I use superbase daily", entries), "I use superbase daily"
+        )
+
+    def test_match_adjacent_to_punctuation(self):
+        """Phrases are matched when touching punctuation."""
+        entries = [_entry("super base", "Supabase")]
+        self.assertEqual(apply_dictionary("(super base), really.", entries), "(Supabase), really.")
+
+    def test_all_occurrences_replaced(self):
+        """Every occurrence in the segment is corrected."""
+        entries = [_entry("super base", "Supabase")]
+        self.assertEqual(
+            apply_dictionary("super base and super base again", entries),
+            "Supabase and Supabase again",
+        )
+
+    def test_longest_phrase_wins(self):
+        """Longer phrases take priority over shorter overlapping ones."""
+        entries = [_entry("super", "great"), _entry("super base", "Supabase")]
+        self.assertEqual(
+            apply_dictionary("super base and super work", entries), "Supabase and great work"
+        )
+
+    def test_regex_metacharacters_are_escaped(self):
+        """User phrases containing regex metacharacters match literally."""
+        entries = [_entry("C++", "C plus plus")]
+        self.assertEqual(apply_dictionary("I write C++ code", entries), "I write C plus plus code")
+        # The trailing (?!\w) guard still applies after non-word characters
+        self.assertEqual(apply_dictionary("I write C++code here", entries), "I write C++code here")
+
+    def test_replacement_keeps_configured_case(self):
+        """The replacement is inserted exactly as configured, even lowercase."""
+        entries = [_entry("Supabase", "supabase")]
+        self.assertEqual(apply_dictionary("SUPABASE rocks", entries), "supabase rocks")
+
+    def test_empty_text_unchanged(self):
+        """Empty text is passed through."""
+        self.assertEqual(apply_dictionary("", [_entry("a", "b")]), "")
+
+    def test_empty_entries_unchanged(self):
+        """No entries means no changes."""
+        self.assertEqual(apply_dictionary("super base", []), "super base")
+
+    def test_malformed_entries_ignored(self):
+        """Entries with missing or empty fields are skipped."""
+        entries = [
+            {"spoken": "super base"},  # missing replacement
+            {"replacement": "Supabase"},  # missing spoken
+            _entry("", "Supabase"),  # empty spoken
+            _entry("super base", ""),  # empty replacement
+            "not a dict",
+            None,
+            _entry("next door", "Nextdoor"),  # valid
+        ]
+        self.assertEqual(
+            apply_dictionary("super base near next door", entries), "super base near Nextdoor"
+        )
+
+    def test_entries_with_only_invalid_content_unchanged(self):
+        """Text is unchanged when every entry is malformed."""
+        entries = [{"spoken": "x"}, "garbage"]
+        self.assertEqual(apply_dictionary("unchanged text", entries), "unchanged text")
+
+
+class TestLoadCustomDictionary(unittest.TestCase):
+    """Test cases for load_custom_dictionary reading config.json from disk."""
+
+    def setUp(self):
+        """Point the corrector's config_dir at a temp directory."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.config_dir_patcher = patch(
+            "vocalinux.speech_recognition.dictionary_corrector.config_dir",
+            return_value=self.temp_dir.name,
+        )
+        self.config_dir_patcher.start()
+
+    def tearDown(self):
+        self.config_dir_patcher.stop()
+        self.temp_dir.cleanup()
+
+    def _write_config(self, payload) -> None:
+        with open(os.path.join(self.temp_dir.name, "config.json"), "w") as f:
+            if isinstance(payload, str):
+                f.write(payload)
+            else:
+                json.dump(payload, f)
+
+    def test_no_config_file_returns_empty(self):
+        self.assertEqual(load_custom_dictionary(), [])
+
+    def test_loads_valid_entries(self):
+        self._write_config(
+            {
+                "text_injection": {
+                    "custom_dictionary": [
+                        {"spoken": "super base", "replacement": "Supabase"},
+                        {"spoken": "next door", "replacement": "Nextdoor"},
+                    ]
+                }
+            }
+        )
+        self.assertEqual(
+            load_custom_dictionary(),
+            [
+                {"spoken": "super base", "replacement": "Supabase"},
+                {"spoken": "next door", "replacement": "Nextdoor"},
+            ],
+        )
+
+    def test_missing_key_returns_empty(self):
+        self._write_config({"text_injection": {}})
+        self.assertEqual(load_custom_dictionary(), [])
+
+    def test_malformed_entries_dropped(self):
+        self._write_config(
+            {
+                "text_injection": {
+                    "custom_dictionary": [
+                        {"spoken": "super base", "replacement": "Supabase"},
+                        {"spoken": ""},
+                        {"replacement": "orphan"},
+                        42,
+                        {"spoken": "  ", "replacement": "  "},
+                    ]
+                }
+            }
+        )
+        self.assertEqual(
+            load_custom_dictionary(),
+            [{"spoken": "super base", "replacement": "Supabase"}],
+        )
+
+    def test_non_list_config_returns_empty(self):
+        self._write_config({"text_injection": {"custom_dictionary": "nope"}})
+        self.assertEqual(load_custom_dictionary(), [])
+
+    def test_invalid_json_returns_empty(self):
+        self._write_config("{not valid json")
+        self.assertEqual(load_custom_dictionary(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dictionary_corrector.py
+++ b/tests/test_dictionary_corrector.py
@@ -11,8 +11,6 @@ from unittest.mock import patch
 from vocalinux.speech_recognition.dictionary_corrector import (
     apply_dictionary,
     load_custom_dictionary,
-    mask_dictionary_phrases,
-    unmask_dictionary_phrases,
 )
 
 
@@ -198,19 +196,11 @@ class TestLoadCustomDictionary(unittest.TestCase):
         self._write_config({"text_injection": "nope"})
         self.assertEqual(load_custom_dictionary(), [])
 
-
-
-class TestMaskDictionaryPhrases(unittest.TestCase):
-    """Sentinel masking keeps replacements out of CommandProcessor."""
-
-    def test_mask_then_unmask_round_trip(self):
-        entries = [_entry("super base", "Supabase")]
-        masked, mapping = mask_dictionary_phrases("I use super base daily", entries)
-        self.assertNotIn("super base", masked.lower())
-        self.assertEqual(unmask_dictionary_phrases(masked, mapping), "I use Supabase daily")
-
-    def test_mask_empty_is_noop(self):
-        self.assertEqual(mask_dictionary_phrases("hello", []), ("hello", {}))
+    def test_invalid_encoding_returns_empty(self):
+        config_path = os.path.join(self.temp_dir.name, "config.json")
+        with open(config_path, "wb") as f:
+            f.write(b"{\xff\xfe invalid")
+        self.assertEqual(load_custom_dictionary(), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_dictionary_corrector.py
+++ b/tests/test_dictionary_corrector.py
@@ -188,6 +188,14 @@ class TestLoadCustomDictionary(unittest.TestCase):
         self._write_config("{not valid json")
         self.assertEqual(load_custom_dictionary(), [])
 
+    def test_non_dict_json_root_returns_empty(self):
+        self._write_config("[]")
+        self.assertEqual(load_custom_dictionary(), [])
+
+    def test_non_dict_section_returns_empty(self):
+        self._write_config({"text_injection": "nope"})
+        self.assertEqual(load_custom_dictionary(), [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_dictionary_corrector.py
+++ b/tests/test_dictionary_corrector.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 from vocalinux.speech_recognition.dictionary_corrector import (
     apply_dictionary,
     load_custom_dictionary,
+    mask_dictionary_phrases,
+    unmask_dictionary_phrases,
 )
 
 
@@ -201,6 +203,21 @@ class TestLoadCustomDictionary(unittest.TestCase):
         with open(config_path, "wb") as f:
             f.write(b"{\xff\xfe invalid")
         self.assertEqual(load_custom_dictionary(), [])
+
+
+class TestMaskDictionaryPhrases(unittest.TestCase):
+    """Word-like sentinels survive CommandProcessor format casing."""
+
+    def test_mask_then_unmask_round_trip(self):
+        entries = [_entry("super base", "Supabase")]
+        masked, mapping = mask_dictionary_phrases("I use super base daily", entries)
+        self.assertIn("zzdict", masked)
+        self.assertEqual(unmask_dictionary_phrases(masked, mapping), "I use Supabase daily")
+
+    def test_unmask_ignores_format_casing(self):
+        entries = [_entry("super base", "Supabase")]
+        masked, mapping = mask_dictionary_phrases("super base", entries)
+        self.assertEqual(unmask_dictionary_phrases(masked.upper(), mapping), "Supabase")
 
 
 if __name__ == "__main__":

--- a/tests/test_dictionary_corrector.py
+++ b/tests/test_dictionary_corrector.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 from vocalinux.speech_recognition.dictionary_corrector import (
     apply_dictionary,
     load_custom_dictionary,
+    mask_dictionary_phrases,
+    unmask_dictionary_phrases,
 )
 
 
@@ -195,6 +197,20 @@ class TestLoadCustomDictionary(unittest.TestCase):
     def test_non_dict_section_returns_empty(self):
         self._write_config({"text_injection": "nope"})
         self.assertEqual(load_custom_dictionary(), [])
+
+
+
+class TestMaskDictionaryPhrases(unittest.TestCase):
+    """Sentinel masking keeps replacements out of CommandProcessor."""
+
+    def test_mask_then_unmask_round_trip(self):
+        entries = [_entry("super base", "Supabase")]
+        masked, mapping = mask_dictionary_phrases("I use super base daily", entries)
+        self.assertNotIn("super base", masked.lower())
+        self.assertEqual(unmask_dictionary_phrases(masked, mapping), "I use Supabase daily")
+
+    def test_mask_empty_is_noop(self):
+        self.assertEqual(mask_dictionary_phrases("hello", []), ("hello", {}))
 
 
 if __name__ == "__main__":

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1366,5 +1366,167 @@ class TestSettingsControlColumn(unittest.TestCase):
         self.assertNotIn("Tip: <b>", self.source)
 
 
+class _GtkShimMeta(type):
+    """Metaclass that fabricates any missing GTK symbol as a plain class.
+
+    With the usual MagicMock ``gi`` stub, ``class SettingsDialog(Gtk.Dialog)``
+    invokes the mock as a metaclass and the whole class silently becomes a
+    MagicMock — its methods cannot be called for real. A shim base class with
+    this metaclass keeps ``SettingsDialog`` a genuine class so its helper
+    methods can be exercised directly.
+    """
+
+    def __getattr__(cls, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return type(name, (), {"__init__": lambda self, *a, **k: None})
+
+
+class TestCustomDictionaryUI(unittest.TestCase):
+    """Custom dictionary group lives on the dictation page and edits config."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.source = TestSettingsSearch._settings_source()
+
+        # Re-import settings_dialog with a Gtk shim so SettingsDialog is a
+        # real class whose helper methods we can call.
+        cls._saved_modules = {
+            name: sys.modules.get(name)
+            for name in ("gi.repository", "vocalinux.ui.settings_dialog")
+        }
+        shim_gtk = _GtkShimMeta("GtkShim", (), {})
+        repo_mock = MagicMock()
+        repo_mock.Gtk = shim_gtk
+        sys.modules["gi.repository"] = repo_mock
+        sys.modules.pop("vocalinux.ui.settings_dialog", None)
+        from vocalinux.ui.settings_dialog import SettingsDialog as _RealSettingsDialog
+
+        cls.SettingsDialog = _RealSettingsDialog
+
+    @classmethod
+    def tearDownClass(cls):
+        sys.modules.pop("vocalinux.ui.settings_dialog", None)
+        for name, module in cls._saved_modules.items():
+            if module is not None:
+                sys.modules[name] = module
+            else:
+                sys.modules.pop(name, None)
+
+    def test_dictionary_group_is_on_dictation_page(self):
+        """The group is built and packed into the recognition (dictation) tab."""
+        self.assertIn("def _build_custom_dictionary_group(", self.source)
+        self.assertIn("self.recognition_settings_tab.pack_start(dictionary_group", self.source)
+
+    def test_dictionary_group_has_add_fields_and_list(self):
+        """Two entry fields, an Add button, and a removal list exist."""
+        for snippet in (
+            "self.custom_dictionary_spoken_entry",
+            "self.custom_dictionary_replacement_entry",
+            "self.custom_dictionary_add_btn",
+            "self.custom_dictionary_listbox",
+            'set_placeholder_text("Heard as (e.g. super base)")',
+            "Remove",
+        ):
+            self.assertIn(snippet, self.source, snippet)
+
+    def test_dictionary_persists_to_text_injection_section(self):
+        """Entries are saved under text_injection.custom_dictionary."""
+        self.assertIn(
+            'self.config_manager.set("text_injection", "custom_dictionary", entries)',
+            self.source,
+        )
+
+    def test_dictionary_list_refreshed_on_load(self):
+        """The list is rebuilt from config when the dialog loads settings."""
+        self.assertIn("self._refresh_custom_dictionary_list()", self.source)
+
+    def _make_dialog_stub(self):
+        """Build a stub carrying the real dictionary helper methods."""
+        from types import SimpleNamespace
+
+        stub = SimpleNamespace(
+            config_manager=Mock(),
+            _initializing=False,
+            _applying_settings=False,
+            # The stub intentionally lacks custom_dictionary_listbox, which
+            # _refresh_custom_dictionary_list guards on, so refresh is a no-op
+            custom_dictionary_spoken_entry=Mock(),
+            custom_dictionary_replacement_entry=Mock(),
+        )
+        stub.custom_dictionary_spoken_entry.get_text = Mock(return_value="Super Base")
+        stub.custom_dictionary_replacement_entry.get_text = Mock(return_value="Supabase")
+        # Bind unbound methods so `self` is the stub
+        dialog_cls = self.SettingsDialog
+        stub._get_custom_dictionary = dialog_cls._get_custom_dictionary.__get__(stub)
+        stub._save_custom_dictionary = dialog_cls._save_custom_dictionary.__get__(stub)
+        stub._refresh_custom_dictionary_list = dialog_cls._refresh_custom_dictionary_list.__get__(
+            stub
+        )
+        return stub
+
+    def test_get_custom_dictionary_cleans_malformed_entries(self):
+        stub = self._make_dialog_stub()
+        stub.config_manager.get = Mock(
+            return_value=[
+                {"spoken": "super base", "replacement": "Supabase"},
+                {"spoken": ""},
+                {"replacement": "orphan"},
+                "garbage",
+                {"spoken": "  next door  ", "replacement": " Nextdoor "},
+            ]
+        )
+
+        cleaned = self.SettingsDialog._get_custom_dictionary(stub)
+        self.assertEqual(
+            cleaned,
+            [
+                {"spoken": "super base", "replacement": "Supabase"},
+                {"spoken": "next door", "replacement": "Nextdoor"},
+            ],
+        )
+
+    def test_add_correction_updates_existing_spoken_phrase(self):
+        """Re-adding the same spoken phrase replaces its replacement (last wins)."""
+        stub = self._make_dialog_stub()
+        stub.config_manager.get = Mock(
+            return_value=[{"spoken": "super base", "replacement": "Superb Ass"}]
+        )
+
+        self.SettingsDialog._on_custom_dictionary_add_clicked(stub, Mock())
+
+        stub.config_manager.set.assert_called_once_with(
+            "text_injection",
+            "custom_dictionary",
+            [{"spoken": "Super Base", "replacement": "Supabase"}],
+        )
+        stub.config_manager.save_config.assert_called_once()
+
+    def test_add_correction_ignores_empty_fields(self):
+        stub = self._make_dialog_stub()
+        stub.custom_dictionary_replacement_entry.get_text = Mock(return_value="")
+
+        self.SettingsDialog._on_custom_dictionary_add_clicked(stub, Mock())
+
+        stub.config_manager.set.assert_not_called()
+
+    def test_remove_correction_filters_case_insensitively(self):
+        stub = self._make_dialog_stub()
+        stub.config_manager.get = Mock(
+            return_value=[
+                {"spoken": "super base", "replacement": "Supabase"},
+                {"spoken": "next door", "replacement": "Nextdoor"},
+            ]
+        )
+
+        self.SettingsDialog._on_custom_dictionary_remove_clicked(stub, Mock(), "SUPER BASE")
+
+        stub.config_manager.set.assert_called_once_with(
+            "text_injection",
+            "custom_dictionary",
+            [{"spoken": "next door", "replacement": "Nextdoor"}],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1465,6 +1465,7 @@ class TestCustomDictionaryUI(unittest.TestCase):
         )
         stub.custom_dictionary_spoken_entry.get_text = Mock(return_value="Super Base")
         stub.custom_dictionary_replacement_entry.get_text = Mock(return_value="Supabase")
+        stub.config_manager.save_config = Mock(return_value=True)
         # Bind unbound methods so `self` is the stub
         dialog_cls = self.SettingsDialog
         stub._get_custom_dictionary = dialog_cls._get_custom_dictionary.__get__(stub)
@@ -1510,6 +1511,30 @@ class TestCustomDictionaryUI(unittest.TestCase):
             [{"spoken": "Super Base", "replacement": "Supabase"}],
         )
         stub.config_manager.save_config.assert_called_once()
+        stub.custom_dictionary_spoken_entry.set_text.assert_called_once_with("")
+        stub.custom_dictionary_replacement_entry.set_text.assert_called_once_with("")
+
+    def test_add_correction_does_not_claim_success_when_save_fails(self):
+        """A failed write leaves the add fields intact and restores memory to disk."""
+        stub = self._make_dialog_stub()
+        previous = [{"spoken": "super base", "replacement": "Superb Ass"}]
+        stub.config_manager.get = Mock(return_value=previous)
+        stub.config_manager.save_config.return_value = False
+
+        self.SettingsDialog._on_custom_dictionary_add_clicked(stub, Mock())
+
+        stub.config_manager.set.assert_has_calls(
+            [
+                call(
+                    "text_injection",
+                    "custom_dictionary",
+                    [{"spoken": "Super Base", "replacement": "Supabase"}],
+                ),
+                call("text_injection", "custom_dictionary", previous),
+            ]
+        )
+        stub.custom_dictionary_spoken_entry.set_text.assert_not_called()
+        stub.custom_dictionary_replacement_entry.set_text.assert_not_called()
 
     def test_add_correction_ignores_empty_fields(self):
         stub = self._make_dialog_stub()

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -1430,6 +1430,15 @@ class TestCustomDictionaryUI(unittest.TestCase):
         ):
             self.assertIn(snippet, self.source, snippet)
 
+    def test_dictionary_list_has_no_inner_scrolled_window(self):
+        """The list grows freely: the dictation page already scrolls, so a
+        nested ScrolledWindow would hide entries behind its own scrollbar."""
+        start = self.source.index("def _build_custom_dictionary_group(")
+        end = self.source.index("def _get_custom_dictionary(")
+        group_source = self.source[start:end]
+        self.assertNotIn("Gtk.ScrolledWindow()", group_source)
+        self.assertIn("list_row.add(self.custom_dictionary_listbox)", group_source)
+
     def test_dictionary_persists_to_text_injection_section(self):
         """Entries are saved under text_injection.custom_dictionary."""
         self.assertIn(

--- a/tests/test_speech_recognition.py
+++ b/tests/test_speech_recognition.py
@@ -480,6 +480,81 @@ class TestSpeechRecognition(unittest.TestCase):
         text_callback.assert_called_once_with("processed text")
         action_callback.assert_called_once_with("action1")
 
+    def test_process_final_buffer_applies_custom_dictionary(self):
+        """Custom dictionary corrections are applied before text callbacks."""
+        manager = SpeechRecognitionManager(engine="vosk")
+
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = MOCK_VOSK_RESULT
+        mock_recognizer.AcceptWaveform.return_value = True
+        manager.recognizer = mock_recognizer
+
+        self.mock_cmd.process_text.return_value = ("super base is great", [])
+
+        text_callback = MagicMock()
+        manager.register_text_callback(text_callback)
+
+        manager.audio_buffer = [b"audio_data1"]
+
+        dictionary = [{"spoken": "super base", "replacement": "Supabase"}]
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.load_custom_dictionary",
+            return_value=dictionary,
+        ):
+            manager._process_final_buffer()
+
+        text_callback.assert_called_once_with("Supabase is great")
+
+    def test_process_final_buffer_applies_custom_dictionary_without_commands(self):
+        """Corrections apply even when voice commands are disabled."""
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager._voice_commands_enabled = False
+
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = MOCK_VOSK_RESULT
+        mock_recognizer.AcceptWaveform.return_value = True
+        manager.recognizer = mock_recognizer
+
+        text_callback = MagicMock()
+        manager.register_text_callback(text_callback)
+
+        manager.audio_buffer = [b"audio_data1"]
+
+        dictionary = [{"spoken": "test transcription", "replacement": "corrected output"}]
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.load_custom_dictionary",
+            return_value=dictionary,
+        ):
+            manager._process_final_buffer()
+
+        # Voice commands skipped, dictionary still applied
+        self.mock_cmd.process_text.assert_not_called()
+        text_callback.assert_called_once_with("corrected output")
+
+    def test_process_final_buffer_without_dictionary_passthrough(self):
+        """No dictionary entries means the processed text is unchanged."""
+        manager = SpeechRecognitionManager(engine="vosk")
+
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = MOCK_VOSK_RESULT
+        mock_recognizer.AcceptWaveform.return_value = True
+        manager.recognizer = mock_recognizer
+
+        self.mock_cmd.process_text.return_value = ("processed text", [])
+
+        text_callback = MagicMock()
+        manager.register_text_callback(text_callback)
+
+        manager.audio_buffer = [b"audio_data1"]
+
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.load_custom_dictionary",
+            return_value=[],
+        ):
+            manager._process_final_buffer()
+
+        text_callback.assert_called_once_with("processed text")
+
     def test_process_final_buffer_whisper(self):
         """Test processing the final audio buffer with Whisper."""
         # Skip the problematic file operations by creating a mock implementation

--- a/tests/test_speech_recognition.py
+++ b/tests/test_speech_recognition.py
@@ -485,11 +485,11 @@ class TestSpeechRecognition(unittest.TestCase):
         manager = SpeechRecognitionManager(engine="vosk")
 
         mock_recognizer = MagicMock()
-        mock_recognizer.FinalResult.return_value = MOCK_VOSK_RESULT
+        mock_recognizer.FinalResult.return_value = '{"text": "super base is great"}'
         mock_recognizer.AcceptWaveform.return_value = True
         manager.recognizer = mock_recognizer
 
-        self.mock_cmd.process_text.return_value = ("super base is great", [])
+        self.mock_cmd.process_text.return_value = ("Supabase is great", [])
 
         text_callback = MagicMock()
         manager.register_text_callback(text_callback)
@@ -503,7 +503,37 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
+        self.mock_cmd.process_text.assert_called_once_with("Supabase is great")
         text_callback.assert_called_once_with("Supabase is great")
+
+    def test_process_final_buffer_applies_dictionary_before_commands(self):
+        """A phrase that would be a voice command is corrected before commands see it."""
+        manager = SpeechRecognitionManager(engine="vosk")
+
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = '{"text": "delete that"}'
+        mock_recognizer.AcceptWaveform.return_value = True
+        manager.recognizer = mock_recognizer
+
+        self.mock_cmd.process_text.return_value = ("keep that", [])
+
+        text_callback = MagicMock()
+        action_callback = MagicMock()
+        manager.register_text_callback(text_callback)
+        manager.register_action_callback(action_callback)
+
+        manager.audio_buffer = [b"audio_data1"]
+
+        dictionary = [{"spoken": "delete that", "replacement": "keep that"}]
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.load_custom_dictionary",
+            return_value=dictionary,
+        ):
+            manager._process_final_buffer()
+
+        self.mock_cmd.process_text.assert_called_once_with("keep that")
+        text_callback.assert_called_once_with("keep that")
+        action_callback.assert_not_called()
 
     def test_process_final_buffer_applies_custom_dictionary_without_commands(self):
         """Corrections apply even when voice commands are disabled."""

--- a/tests/test_speech_recognition.py
+++ b/tests/test_speech_recognition.py
@@ -489,8 +489,6 @@ class TestSpeechRecognition(unittest.TestCase):
         mock_recognizer.AcceptWaveform.return_value = True
         manager.recognizer = mock_recognizer
 
-        self.mock_cmd.process_text.return_value = ("Supabase is great", [])
-
         text_callback = MagicMock()
         manager.register_text_callback(text_callback)
 
@@ -503,19 +501,18 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
-        self.mock_cmd.process_text.assert_called_once_with("Supabase is great")
+        # Dictionary rewrote the transcript: inject corrected text, skip commands.
+        self.mock_cmd.process_text.assert_not_called()
         text_callback.assert_called_once_with("Supabase is great")
 
     def test_process_final_buffer_applies_dictionary_before_commands(self):
-        """A phrase that would be a voice command is corrected before commands see it."""
+        """A phrase that would be a voice command is corrected and not dispatched."""
         manager = SpeechRecognitionManager(engine="vosk")
 
         mock_recognizer = MagicMock()
         mock_recognizer.FinalResult.return_value = '{"text": "delete that"}'
         mock_recognizer.AcceptWaveform.return_value = True
         manager.recognizer = mock_recognizer
-
-        self.mock_cmd.process_text.return_value = ("keep that", [])
 
         text_callback = MagicMock()
         action_callback = MagicMock()
@@ -531,8 +528,35 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
-        self.mock_cmd.process_text.assert_called_once_with("keep that")
+        self.mock_cmd.process_text.assert_not_called()
         text_callback.assert_called_once_with("keep that")
+        action_callback.assert_not_called()
+
+    def test_process_final_buffer_dictionary_replacement_does_not_become_command(self):
+        """A replacement that equals a reserved command is injected as plain text."""
+        manager = SpeechRecognitionManager(engine="vosk")
+
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = '{"text": "wipe last"}'
+        mock_recognizer.AcceptWaveform.return_value = True
+        manager.recognizer = mock_recognizer
+
+        text_callback = MagicMock()
+        action_callback = MagicMock()
+        manager.register_text_callback(text_callback)
+        manager.register_action_callback(action_callback)
+
+        manager.audio_buffer = [b"audio_data1"]
+
+        dictionary = [{"spoken": "wipe last", "replacement": "delete that"}]
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.load_custom_dictionary",
+            return_value=dictionary,
+        ):
+            manager._process_final_buffer()
+
+        self.mock_cmd.process_text.assert_not_called()
+        text_callback.assert_called_once_with("delete that")
         action_callback.assert_not_called()
 
     def test_process_final_buffer_applies_custom_dictionary_without_commands(self):

--- a/tests/test_speech_recognition.py
+++ b/tests/test_speech_recognition.py
@@ -483,14 +483,16 @@ class TestSpeechRecognition(unittest.TestCase):
     def test_process_final_buffer_applies_custom_dictionary(self):
         """Custom dictionary corrections are applied before text callbacks."""
         manager = SpeechRecognitionManager(engine="vosk")
+        # Non-command spoken phrases are applied after CommandProcessor.
+        self.mock_cmd.text_commands = {}
+        self.mock_cmd.action_commands = {}
+        self.mock_cmd.format_commands = {}
+        self.mock_cmd.process_text.side_effect = lambda t: (t, [])
 
         mock_recognizer = MagicMock()
         mock_recognizer.FinalResult.return_value = '{"text": "super base is great"}'
         mock_recognizer.AcceptWaveform.return_value = True
         manager.recognizer = mock_recognizer
-
-        # Pass masked text through so unmask can restore the replacement.
-        self.mock_cmd.process_text.side_effect = lambda t: (t, [])
 
         text_callback = MagicMock()
         manager.register_text_callback(text_callback)
@@ -504,22 +506,21 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
-        self.mock_cmd.process_text.assert_called_once()
-        masked_arg = self.mock_cmd.process_text.call_args.args[0]
-        self.assertNotIn("super base", masked_arg.lower())
-        self.assertNotIn("Supabase", masked_arg)
+        self.mock_cmd.process_text.assert_called_once_with("super base is great")
         text_callback.assert_called_once_with("Supabase is great")
 
     def test_process_final_buffer_applies_dictionary_before_commands(self):
-        """A spoken command phrase is masked so CommandProcessor never sees it."""
+        """Spoken command phrases are remapped before CommandProcessor runs."""
         manager = SpeechRecognitionManager(engine="vosk")
+        self.mock_cmd.text_commands = {}
+        self.mock_cmd.action_commands = {"delete that": "delete_last"}
+        self.mock_cmd.format_commands = {}
+        self.mock_cmd.process_text.side_effect = lambda t: (t, [])
 
         mock_recognizer = MagicMock()
         mock_recognizer.FinalResult.return_value = '{"text": "delete that"}'
         mock_recognizer.AcceptWaveform.return_value = True
         manager.recognizer = mock_recognizer
-
-        self.mock_cmd.process_text.side_effect = lambda t: (t, [])
 
         text_callback = MagicMock()
         action_callback = MagicMock()
@@ -535,21 +536,22 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
-        masked_arg = self.mock_cmd.process_text.call_args.args[0]
-        self.assertNotEqual(masked_arg.lower(), "delete that")
+        self.mock_cmd.process_text.assert_called_once_with("keep that")
         text_callback.assert_called_once_with("keep that")
         action_callback.assert_not_called()
 
     def test_process_final_buffer_dictionary_replacement_does_not_become_command(self):
         """A replacement that equals a reserved command is injected as plain text."""
         manager = SpeechRecognitionManager(engine="vosk")
+        self.mock_cmd.text_commands = {}
+        self.mock_cmd.action_commands = {"delete that": "delete_last"}
+        self.mock_cmd.format_commands = {}
+        self.mock_cmd.process_text.side_effect = lambda t: (t, [])
 
         mock_recognizer = MagicMock()
         mock_recognizer.FinalResult.return_value = '{"text": "wipe last"}'
         mock_recognizer.AcceptWaveform.return_value = True
         manager.recognizer = mock_recognizer
-
-        self.mock_cmd.process_text.side_effect = lambda t: (t, [])
 
         text_callback = MagicMock()
         action_callback = MagicMock()
@@ -565,8 +567,7 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
-        masked_arg = self.mock_cmd.process_text.call_args.args[0]
-        self.assertNotIn("delete that", masked_arg.lower())
+        self.mock_cmd.process_text.assert_called_once_with("wipe last")
         text_callback.assert_called_once_with("delete that")
         action_callback.assert_not_called()
 
@@ -598,6 +599,35 @@ class TestSpeechRecognition(unittest.TestCase):
 
         text_callback.assert_called_once_with("Supabase is great.")
         action_callback.assert_not_called()
+
+    def test_process_final_buffer_dictionary_survives_format_commands(self):
+        """Format commands still apply when a nearby phrase is dictionary-corrected."""
+        from vocalinux.speech_recognition.command_processor import CommandProcessor
+
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.command_processor = CommandProcessor()
+
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = '{"text": "capitalize super base"}'
+        mock_recognizer.AcceptWaveform.return_value = True
+        manager.recognizer = mock_recognizer
+
+        text_callback = MagicMock()
+        manager.register_text_callback(text_callback)
+        manager.audio_buffer = [b"audio_data1"]
+
+        dictionary = [{"spoken": "super base", "replacement": "Supabase"}]
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.load_custom_dictionary",
+            return_value=dictionary,
+        ):
+            manager._process_final_buffer()
+
+        # capitalize applies to "super", then post-dict cannot match "Super base";
+        # with two-phase, commands run on raw first: capitalize super base -> "Super base"
+        # then dictionary may not match "Super base" if case-sensitive on spoken...
+        # apply_dictionary is case-insensitive on spoken, so "Super base" -> Supabase.
+        text_callback.assert_called_once_with("Supabase")
 
     def test_process_final_buffer_applies_custom_dictionary_without_commands(self):
         """Corrections apply even when voice commands are disabled."""

--- a/tests/test_speech_recognition.py
+++ b/tests/test_speech_recognition.py
@@ -489,6 +489,9 @@ class TestSpeechRecognition(unittest.TestCase):
         mock_recognizer.AcceptWaveform.return_value = True
         manager.recognizer = mock_recognizer
 
+        # Pass masked text through so unmask can restore the replacement.
+        self.mock_cmd.process_text.side_effect = lambda t: (t, [])
+
         text_callback = MagicMock()
         manager.register_text_callback(text_callback)
 
@@ -501,18 +504,22 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
-        # Dictionary rewrote the transcript: inject corrected text, skip commands.
-        self.mock_cmd.process_text.assert_not_called()
+        self.mock_cmd.process_text.assert_called_once()
+        masked_arg = self.mock_cmd.process_text.call_args.args[0]
+        self.assertNotIn("super base", masked_arg.lower())
+        self.assertNotIn("Supabase", masked_arg)
         text_callback.assert_called_once_with("Supabase is great")
 
     def test_process_final_buffer_applies_dictionary_before_commands(self):
-        """A phrase that would be a voice command is corrected and not dispatched."""
+        """A spoken command phrase is masked so CommandProcessor never sees it."""
         manager = SpeechRecognitionManager(engine="vosk")
 
         mock_recognizer = MagicMock()
         mock_recognizer.FinalResult.return_value = '{"text": "delete that"}'
         mock_recognizer.AcceptWaveform.return_value = True
         manager.recognizer = mock_recognizer
+
+        self.mock_cmd.process_text.side_effect = lambda t: (t, [])
 
         text_callback = MagicMock()
         action_callback = MagicMock()
@@ -528,7 +535,8 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
-        self.mock_cmd.process_text.assert_not_called()
+        masked_arg = self.mock_cmd.process_text.call_args.args[0]
+        self.assertNotEqual(masked_arg.lower(), "delete that")
         text_callback.assert_called_once_with("keep that")
         action_callback.assert_not_called()
 
@@ -540,6 +548,8 @@ class TestSpeechRecognition(unittest.TestCase):
         mock_recognizer.FinalResult.return_value = '{"text": "wipe last"}'
         mock_recognizer.AcceptWaveform.return_value = True
         manager.recognizer = mock_recognizer
+
+        self.mock_cmd.process_text.side_effect = lambda t: (t, [])
 
         text_callback = MagicMock()
         action_callback = MagicMock()
@@ -555,8 +565,38 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
-        self.mock_cmd.process_text.assert_not_called()
+        masked_arg = self.mock_cmd.process_text.call_args.args[0]
+        self.assertNotIn("delete that", masked_arg.lower())
         text_callback.assert_called_once_with("delete that")
+        action_callback.assert_not_called()
+
+    def test_process_final_buffer_dictionary_keeps_unrelated_commands(self):
+        """A correction in the same utterance still lets unrelated commands run."""
+        from vocalinux.speech_recognition.command_processor import CommandProcessor
+
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.command_processor = CommandProcessor()
+
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = '{"text": "super base is great period"}'
+        mock_recognizer.AcceptWaveform.return_value = True
+        manager.recognizer = mock_recognizer
+
+        text_callback = MagicMock()
+        action_callback = MagicMock()
+        manager.register_text_callback(text_callback)
+        manager.register_action_callback(action_callback)
+
+        manager.audio_buffer = [b"audio_data1"]
+
+        dictionary = [{"spoken": "super base", "replacement": "Supabase"}]
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.load_custom_dictionary",
+            return_value=dictionary,
+        ):
+            manager._process_final_buffer()
+
+        text_callback.assert_called_once_with("Supabase is great.")
         action_callback.assert_not_called()
 
     def test_process_final_buffer_applies_custom_dictionary_without_commands(self):

--- a/tests/test_speech_recognition.py
+++ b/tests/test_speech_recognition.py
@@ -483,10 +483,6 @@ class TestSpeechRecognition(unittest.TestCase):
     def test_process_final_buffer_applies_custom_dictionary(self):
         """Custom dictionary corrections are applied before text callbacks."""
         manager = SpeechRecognitionManager(engine="vosk")
-        # Non-command spoken phrases are applied after CommandProcessor.
-        self.mock_cmd.text_commands = {}
-        self.mock_cmd.action_commands = {}
-        self.mock_cmd.format_commands = {}
         self.mock_cmd.process_text.side_effect = lambda t: (t, [])
 
         mock_recognizer = MagicMock()
@@ -496,7 +492,6 @@ class TestSpeechRecognition(unittest.TestCase):
 
         text_callback = MagicMock()
         manager.register_text_callback(text_callback)
-
         manager.audio_buffer = [b"audio_data1"]
 
         dictionary = [{"spoken": "super base", "replacement": "Supabase"}]
@@ -506,15 +501,14 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
-        self.mock_cmd.process_text.assert_called_once_with("super base is great")
+        masked_arg = self.mock_cmd.process_text.call_args.args[0]
+        self.assertIn("zzdict", masked_arg)
+        self.assertNotIn("super base", masked_arg.lower())
         text_callback.assert_called_once_with("Supabase is great")
 
     def test_process_final_buffer_applies_dictionary_before_commands(self):
-        """Spoken command phrases are remapped before CommandProcessor runs."""
+        """Spoken command phrases are masked so CommandProcessor never sees them."""
         manager = SpeechRecognitionManager(engine="vosk")
-        self.mock_cmd.text_commands = {}
-        self.mock_cmd.action_commands = {"delete that": "delete_last"}
-        self.mock_cmd.format_commands = {}
         self.mock_cmd.process_text.side_effect = lambda t: (t, [])
 
         mock_recognizer = MagicMock()
@@ -526,7 +520,6 @@ class TestSpeechRecognition(unittest.TestCase):
         action_callback = MagicMock()
         manager.register_text_callback(text_callback)
         manager.register_action_callback(action_callback)
-
         manager.audio_buffer = [b"audio_data1"]
 
         dictionary = [{"spoken": "delete that", "replacement": "keep that"}]
@@ -536,16 +529,14 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
-        self.mock_cmd.process_text.assert_called_once_with("keep that")
+        masked_arg = self.mock_cmd.process_text.call_args.args[0]
+        self.assertNotEqual(masked_arg.lower(), "delete that")
         text_callback.assert_called_once_with("keep that")
         action_callback.assert_not_called()
 
     def test_process_final_buffer_dictionary_replacement_does_not_become_command(self):
         """A replacement that equals a reserved command is injected as plain text."""
         manager = SpeechRecognitionManager(engine="vosk")
-        self.mock_cmd.text_commands = {}
-        self.mock_cmd.action_commands = {"delete that": "delete_last"}
-        self.mock_cmd.format_commands = {}
         self.mock_cmd.process_text.side_effect = lambda t: (t, [])
 
         mock_recognizer = MagicMock()
@@ -557,7 +548,6 @@ class TestSpeechRecognition(unittest.TestCase):
         action_callback = MagicMock()
         manager.register_text_callback(text_callback)
         manager.register_action_callback(action_callback)
-
         manager.audio_buffer = [b"audio_data1"]
 
         dictionary = [{"spoken": "wipe last", "replacement": "delete that"}]
@@ -567,7 +557,8 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
-        self.mock_cmd.process_text.assert_called_once_with("wipe last")
+        masked_arg = self.mock_cmd.process_text.call_args.args[0]
+        self.assertNotIn("delete that", masked_arg.lower())
         text_callback.assert_called_once_with("delete that")
         action_callback.assert_not_called()
 
@@ -587,7 +578,6 @@ class TestSpeechRecognition(unittest.TestCase):
         action_callback = MagicMock()
         manager.register_text_callback(text_callback)
         manager.register_action_callback(action_callback)
-
         manager.audio_buffer = [b"audio_data1"]
 
         dictionary = [{"spoken": "super base", "replacement": "Supabase"}]
@@ -601,7 +591,7 @@ class TestSpeechRecognition(unittest.TestCase):
         action_callback.assert_not_called()
 
     def test_process_final_buffer_dictionary_survives_format_commands(self):
-        """Format commands still apply when a nearby phrase is dictionary-corrected."""
+        """Format commands do not destroy dictionary placeholders."""
         from vocalinux.speech_recognition.command_processor import CommandProcessor
 
         manager = SpeechRecognitionManager(engine="vosk")
@@ -623,11 +613,63 @@ class TestSpeechRecognition(unittest.TestCase):
         ):
             manager._process_final_buffer()
 
-        # capitalize applies to "super", then post-dict cannot match "Super base";
-        # with two-phase, commands run on raw first: capitalize super base -> "Super base"
-        # then dictionary may not match "Super base" if case-sensitive on spoken...
-        # apply_dictionary is case-insensitive on spoken, so "Super base" -> Supabase.
         text_callback.assert_called_once_with("Supabase")
+
+    def test_process_final_buffer_hardcoded_command_phrase_is_masked(self):
+        """Hardcoded CommandProcessor phrases are masked before exact-match dispatch."""
+        from vocalinux.speech_recognition.command_processor import CommandProcessor
+
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.command_processor = CommandProcessor()
+
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = '{"text": "select all text"}'
+        mock_recognizer.AcceptWaveform.return_value = True
+        manager.recognizer = mock_recognizer
+
+        text_callback = MagicMock()
+        action_callback = MagicMock()
+        manager.register_text_callback(text_callback)
+        manager.register_action_callback(action_callback)
+        manager.audio_buffer = [b"audio_data1"]
+
+        dictionary = [{"spoken": "select all text", "replacement": "highlight everything"}]
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.load_custom_dictionary",
+            return_value=dictionary,
+        ):
+            manager._process_final_buffer()
+
+        text_callback.assert_called_once_with("highlight everything")
+        action_callback.assert_not_called()
+
+    def test_process_final_buffer_pre_replacement_command_stays_literal(self):
+        """Mapping one reserved phrase to another injects the replacement as text."""
+        from vocalinux.speech_recognition.command_processor import CommandProcessor
+
+        manager = SpeechRecognitionManager(engine="vosk")
+        manager.command_processor = CommandProcessor()
+
+        mock_recognizer = MagicMock()
+        mock_recognizer.FinalResult.return_value = '{"text": "delete that"}'
+        mock_recognizer.AcceptWaveform.return_value = True
+        manager.recognizer = mock_recognizer
+
+        text_callback = MagicMock()
+        action_callback = MagicMock()
+        manager.register_text_callback(text_callback)
+        manager.register_action_callback(action_callback)
+        manager.audio_buffer = [b"audio_data1"]
+
+        dictionary = [{"spoken": "delete that", "replacement": "undo"}]
+        with patch(
+            "vocalinux.speech_recognition.recognition_manager.load_custom_dictionary",
+            return_value=dictionary,
+        ):
+            manager._process_final_buffer()
+
+        text_callback.assert_called_once_with("undo")
+        action_callback.assert_not_called()
 
     def test_process_final_buffer_applies_custom_dictionary_without_commands(self):
         """Corrections apply even when voice commands are disabled."""


### PR DESCRIPTION
## Description

When the model incorrectly transcripts a word, there's currently no mechanism to fix the word for the next use. This PR implements a simple dictionary where the incorrect words can be replaced during post processing.  It also adds a dictionary section to the dictation tab of the GUI.

## Related Issue

Partly fixes  #408, #475 

## Type of Change

- [*] ✨ New feature (non-breaking change which adds functionality)


## Checklist

- [*] My code follows the code style of this project (black, isort)
- [*] I have updated the documentation accordingly
- [*] I have added tests to cover my changes
- [*] All new and existing tests pass locally
- [*] Pre-commit hooks pass

## Screenshots (if applicable)

<img width="2020" height="1596" alt="image" src="https://github.com/user-attachments/assets/5c8cfa6b-2610-448f-a4fd-969bf04f3099" />


## Additional Notes

It just adds the dictionary to the `config.json` , words can be added in the UI and the text is replaced during post-processing.

```
"text_injection": {
    "custom_dictionary": [
        {"spoken": "super base", "replacement": "Supabase"},
        {"spoken": "next door", "replacement": "Nextdoor"}
    ]
}
```

Discussion : https://github.com/VocaHQ/vocalinux/discussions/483