### PR TITLE
chore(ci): test the distros the docs promise, and fix the docs that drifted

### DIFF
--- a/.github/workflows/distro-test-matrix.yml
+++ b/.github/workflows/distro-test-matrix.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main, master ]
     paths:
-      - 'install.sh'
+      - '**/*.sh'
       - 'scripts/**'
       - 'pyproject.toml'
       - 'src/vocalinux/version.py'
@@ -12,7 +12,7 @@ on:
   pull_request:
     branches: [ main, master ]
     paths:
-      - 'install.sh'
+      - '**/*.sh'
       - 'scripts/**'
       - 'pyproject.toml'
       - 'src/vocalinux/version.py'
@@ -20,6 +20,21 @@ on:
   workflow_dispatch:
 
 jobs:
+  # The repo's only `bash -n install.sh` used to live inside the matrix below,
+  # under continue-on-error, so a syntax error in a 4698-line installer could
+  # not fail a build anywhere. This job is the one thing here allowed to fail.
+  # It is not phase 2.4 — nothing here runs the installer yet — it just stops
+  # the cheapest check we have from being advisory.
+  syntax:
+    name: Shell syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: bash -n every shell script we ship
+        run: |
+          set -euo pipefail
+          git ls-files -z '*.sh' | xargs -0 -n1 -t bash -n
+
   test:
     name: Test on ${{ matrix.container }}
     runs-on: ubuntu-latest
@@ -27,11 +42,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # README.md advertises Arch and Tumbleweed as tested and neither was
+        # here; fedora:39 has been EOL since 2024 while the AppImage boot
+        # matrix moved to 42. This list is what the docs promise.
         container:
           - ubuntu:24.04
           - ubuntu:26.04
           - debian:12
-          - fedora:39
+          - fedora:42
+          - archlinux:latest
+          - opensuse/tumbleweed
     container:
       image: ${{ matrix.container }}
 
@@ -54,6 +74,13 @@ jobs:
               echo "⚠ dnf install failed, trying with --nogpgcheck..."
               dnf install -y --nogpgcheck bash curl python3 git
             }
+          elif command -v pacman >/dev/null 2>&1; then
+            # -Syu, never -Sy: archlinux:latest lags the mirrors and a partial
+            # upgrade would be our breakage, not the installer's.
+            pacman -Syu --noconfirm bash curl python git
+          elif command -v zypper >/dev/null 2>&1; then
+            zypper --non-interactive --gpg-auto-import-keys refresh
+            zypper --non-interactive install bash curl python3 git
           fi
 
       # ============================================================================
@@ -139,6 +166,10 @@ jobs:
             apt-get install -y pkg-config libgirepository1.0-dev 2>/dev/null || true
           elif command -v dnf >/dev/null 2>&1; then
             dnf install -y pkg-config gobject-introspection-devel 2>/dev/null || true
+          elif command -v pacman >/dev/null 2>&1; then
+            pacman -S --needed --noconfirm pkgconf gobject-introspection 2>/dev/null || true
+          elif command -v zypper >/dev/null 2>&1; then
+            zypper --non-interactive install pkgconf-pkg-config gobject-introspection-devel 2>/dev/null || true
           fi
 
           # Test typelib path detection
@@ -227,6 +258,10 @@ jobs:
             apt-get install -y python3-venv python3-pip python3-dev 2>/dev/null || true
           elif command -v dnf >/dev/null 2>&1; then
             dnf install -y python3-virtualenv python3-pip python3-devel 2>/dev/null || true
+          elif command -v pacman >/dev/null 2>&1; then
+            pacman -S --needed --noconfirm python python-pip 2>/dev/null || true
+          elif command -v zypper >/dev/null 2>&1; then
+            zypper --non-interactive install python3-pip python3-devel 2>/dev/null || true
           fi
 
           # Create a temporary venv to test the flow
@@ -271,13 +306,15 @@ jobs:
           echo "  ✓ ubuntu:24.04 - Full support expected"
           echo "  ✓ ubuntu:26.04 - Full support expected"
           echo "  ✓ debian:12 - Full support expected"
-          echo "  ⚠ fedora:39 - Good support, minor differences expected"
+          echo "  ⚠ fedora:42 - Good support, minor differences expected"
+          echo "  ⚠ archlinux:latest - Rolling; also the AUR package's distro"
+          echo "  ⚠ opensuse/tumbleweed - Rolling, least exercised"
           echo ""
           echo "Key tests performed:"
           echo "  1. /etc/os-release availability"
           echo "  2. Distro detection function"
           echo "  3. Typelib path detection"
-          echo "  4. install.sh syntax validation"
+          echo "  4. install.sh syntax validation (also gated in the syntax job)"
           echo "  5. Dependency checker"
           echo "  6. Installer --help command"
           echo "  7. Virtual environment creation"

--- a/README.md
+++ b/README.md
@@ -216,8 +216,11 @@ flatpak run com.vocalinux.Vocalinux
 
 The Flatpak ships the whisper.cpp engine with Vulkan GPU support and runs through
 XWayland on Wayland sessions. See [`packaging/flatpak/README.md`](packaging/flatpak/README.md)
-for build details, permissions, and Flathub submission notes. Flathub publishing
-is in progress.
+for build details, permissions, and Flathub submission notes. It is **not on
+Flathub**: the submission ([flathub/flathub#9368](https://github.com/flathub/flathub/pull/9368))
+was closed on 2026-07-23 on policy grounds. The manifest is complete and builds
+in CI on both arches, so build it yourself as above; where it gets published is
+tracked in [#167](https://github.com/VocaHQ/vocalinux/issues/167).
 
 ### Alternative: Install from Source
 
@@ -266,7 +269,7 @@ Or launch it from your application menu!
 
 ## 📋 Requirements
 
-- **OS**: Linux (tested on Ubuntu 24.04+, Debian 12+, Fedora 39+, Arch Linux, openSUSE Tumbleweed)
+- **OS**: Linux (tested on Ubuntu 24.04+, Debian 12+, Fedora 42+, Arch Linux, openSUSE Tumbleweed)
 - **Python**: 3.11 or newer
 - **Display**: X11 or Wayland
 - **Hardware**: Microphone for voice input
@@ -450,7 +453,7 @@ This script generates all three sounds using the same smooth glide algorithm. Yo
 - [x] ~~Vulkan GPU support~~ ✅
 - [x] In-app update mechanism ✅
 - [x] ~~Wayland support via IBus~~ ✅
-- [x] ~~Flatpak packaging~~ ✅ (Flathub submission in progress)
+- [x] ~~Flatpak packaging~~ ✅ (manifest ships; not on Flathub — see #167)
 - [ ] Application-specific commands
 - [ ] Debian/Ubuntu package (.deb)
 - [ ] Voice command customization

--- a/docs/DISTRO_COMPATIBILITY.md
+++ b/docs/DISTRO_COMPATIBILITY.md
@@ -9,10 +9,10 @@ The cross-distribution compatibility improvements have been implemented in phase
 | Phase 1 | ✅ Complete | Dynamic GI_TYPELIB_PATH detection using pkg-config, multi-arch support, ALSA library fallbacks |
 | Phase 2 | ✅ Complete | Enhanced distro detection (Gentoo, Alpine, Void, Solus, Mageia) |
 | Phase 3 | ✅ Complete | System dependency checker, improved error messages |
-| Phase 4 | ✅ Complete | CI test matrix, pkg-config as core dependency |
+| Phase 4 | 🟡 Partial | pkg-config as a core dependency ✅. The CI distro matrix covers six containers, but it checks detection logic, shell syntax and `--help` — it never runs the installer, and the container jobs are `continue-on-error`. Real install runs are tracked as phase 2.4 of [#701](https://github.com/VocaHQ/vocalinux/issues/701) |
 | **Phase 5** | ✅ **Complete** | **Fixed remaining hardcoded GI_TYPELIB_PATH values in install.sh and CI workflow** |
 | **Phase 6** | ✅ **Complete** | **Added wrapper script verification tests, updated documentation** |
-| **Phase 7** | ✅ **Complete** | **Flatpak packaging (whisper.cpp engine) for universal distribution support — see [`packaging/flatpak/`](../packaging/flatpak/README.md). Flathub submission in progress.** |
+| **Phase 7** | ✅ **Complete** | **Flatpak packaging (whisper.cpp engine) for universal distribution support — see [`packaging/flatpak/`](../packaging/flatpak/README.md). Not on Flathub: submission [flathub#9368](https://github.com/flathub/flathub/pull/9368) closed 2026-07-23 on policy grounds; channel tracked in [#167](https://github.com/VocaHQ/vocalinux/issues/167).** |
 | Phase 8 | 📋 Planned | Snap packaging for Ubuntu Software Store |
 
 ## Technical Implementation
@@ -53,7 +53,7 @@ interpreter rather than the release label.
 |--------------|---------|--------|-------|
 | Ubuntu | 24.04+ | ✅ Full Support | 22.04 ships Python 3.10, below the 3.11 floor |
 | Debian | 12+, Testing | ✅ Full Support | Primary target; use Ayatana AppIndicator |
-| Fedora | 39+ | ✅ Good Support | Uses lib64 paths, fully supported |
+| Fedora | 42+ | ✅ Good Support | Uses lib64 paths; 42 is the oldest Fedora upstream still supports, and the one in the CI matrix |
 | Arch Linux | Rolling | ✅ Good Support | Community tested, rolling release compatible |
 | openSUSE | Tumbleweed | ✅ Good Support | Good support with zypper package manager |
 | Linux Mint | On Ubuntu 24.04+ | ✅ Good Support | Mint 22 qualifies; Mint 21 is on Ubuntu 22.04, below the floor |

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -140,7 +140,7 @@ On Ubuntu 24.04+ or Pop!_OS, install `libgirepository-2.0-dev` if
 
 | Requirement | Details |
 |-------------|---------|
-| **Operating System** | Debian 12+, Ubuntu 24.04+, Fedora 39+, Arch Linux |
+| **Operating System** | Debian 12+, Ubuntu 24.04+, Fedora 42+, Arch Linux, openSUSE Tumbleweed |
 | **Python** | 3.11 or newer |
 | **Display Server** | X11 or Wayland |
 | **Hardware** | Microphone for speech input |

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -72,6 +72,13 @@ pipx run flatpak-pip-generator \
 
 ## Flathub Submission Notes
 
+Read this first: the submission,
+[flathub/flathub#9368](https://github.com/flathub/flathub/pull/9368), was
+**closed on 2026-07-23** on policy grounds — the generative-AI policy, plus a
+"tray-only application" reading. Nothing below was the reason it failed, and
+re-submitting without addressing that is a repeat. See
+[#167](https://github.com/VocaHQ/vocalinux/issues/167) for the channel decision.
+
 1. Change the `vocalinux` module source from `type: dir` to a tagged release:
 
    ```yaml


### PR DESCRIPTION
## Description

Two things that had drifted apart: what CI tests, and what the docs say we test.

`README.md` advertises Arch Linux and openSUSE Tumbleweed as tested. The distro matrix ran neither. It ran `fedora:39`, EOL since November 2024, while the AppImage boot matrix had long since moved to 42. I have actually tested this by hand and can confirm, but this work needs to be finished. So the list is now what the docs promise: `ubuntu:24.04`, `ubuntu:26.04`, `debian:12`, `fedora:42`, `archlinux:latest`, `opensuse/tumbleweed`. `detect_distro()`'s re-implemented logic already handled `arch` and `suse` — no container ever reached those branches. `pacman` and `zypper` arms were added to the three steps that only knew apt and dnf; the pacman one uses `-Syu`, never `-Sy`, for the same reason the AUR gate does.

Verified on a `workflow_dispatch` run of this branch rather than by inspection — all six containers green, no failed steps, and the two new ones took the branches they were supposed to:

```
Arch Linux 20260830.0.582275   → arch family  → typelib /usr/lib/girepository-1.0
openSUSE Tumbleweed 20260901   → suse family  → typelib /usr/lib64/girepository-1.0
```

Two resolution paths that had never once executed in CI, under a README that claimed both.

**A syntax gate that can actually fail.** `bash -n install.sh` at `:197` was the only syntax check over a 4698-line installer anywhere in the repo — not in pre-commit, not in `unified-pipeline.yml` — and it sat under `continue-on-error: true`, so a syntax error could not fail a build. The new `syntax` job runs `bash -n` over every `*.sh` in `git ls-files` (7 today) on the runner, without `continue-on-error`. `paths:` grew `'**/*.sh'` so scripts under `packaging/` reach it.

**`continue-on-error` stays on the container matrix.** It still does not run the installer — the eight "tests" are a `grep`, detection logic re-implemented in the workflow, `bash -n`, `--help`, and a step named "dry-run venv setup" that calls `python3 -m venv` without touching `install.sh`. Making a gate blocking before it tests anything is worse than leaving it advisory. That is #701 phase 2.4, and this PR does not pretend to be it.

## Docs

- **Flathub.** [flathub/flathub#9368](https://github.com/flathub/flathub/pull/9368) was closed on 2026-07-23, unmerged, on policy grounds. Three places still advertised "submission in progress" (`README.md:219-220`, `README.md:453`, `docs/DISTRO_COMPATIBILITY.md:15`); all now say what is true — not on Flathub, manifest complete and CI-building, channel tracked in #167. `packaging/flatpak/README.md` gained a note at the top of its submission checklist, because nothing in that checklist explained why the submission failed and someone would have walked it blind.
- **Fedora floor.** `README.md:269` ("tested on") and `docs/INSTALL.md:143` said Fedora 39+; CI no longer tests 39, so both say 42+. This narrows an advertised claim — if 39 should keep being promised, the fix is to put `fedora:39` back in the matrix beside 42 rather than leave the two disagreeing.
- **Phase 4 row** in `docs/DISTRO_COMPATIBILITY.md` claimed a complete "CI test matrix". Now marked partial, with what the matrix actually checks.

## Related Issue

Feeds #701's acceptance criterion *"Docs match reality: no removed flags, no wrong hotkeys, no 'submission in progress' for a closed PR"*, and clears ground for phase 2.4.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📖 Documentation update
- [ ] 🧹 Code refactoring
- [x] ✅ Test update

## Checklist

- [x] My code follows the code style of this project (black, isort)
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes — no new tests; the change is CI coverage and doc accuracy, and the existing guards that read `docs/DISTRO_COMPATIBILITY.md` (`tests/test_installer_python_selection.py`, `tests/test_cross_distro_compatibility.py`, 36 tests) still pass
- [x] All new and existing tests pass locally
- [x] Pre-commit hooks pass

## Additional Notes

- Useful for scoping phase 2.4: Arch and Tumbleweed each boot, install dependencies and create a venv in about 15 seconds. Six containers as the base for real installer runs is not expensive, and `--auto --skip-models` fits.
- Once #772 merges, `packaging/aur/build-test.sh` falls under the new syntax gate automatically.
