### PR TITLE
chore(ci): add a throwaway probe for the PyPI trusted publisher

### DIFF
--- a/.github/workflows/pypi-publisher-probe.yml
+++ b/.github/workflows/pypi-publisher-probe.yml
@@ -1,0 +1,77 @@
+name: PyPI publisher probe
+
+# Throwaway. Delete this file once it has answered its one question.
+#
+# `release.yml` publishes to PyPI with trusted publishing and no password
+# fallback (#759), and it triggers only on `v*` tags. So without this, a tag is
+# what discovers a missing or mistyped Trusted Publisher — halfway through a
+# release, after the GitHub release already exists.
+#
+# This asks PyPI the same question the release asks, and publishes nothing: it
+# requests the OIDC token GitHub would hand `publish-pypi`, offers it to PyPI's
+# mint-token endpoint, and reports whether PyPI accepted it. Owner rights on the
+# PyPI project are not needed to run it — only to fix a failure.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: Can PyPI mint a token for us?
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    # Load-bearing, not decoration. `publish-pypi` declares this environment and
+    # the Trusted Publisher entry pins it, so the claim carries it. Probing from
+    # outside the environment would fail a correctly configured publisher and
+    # send someone chasing a problem that is not there.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/vocalinux/
+    steps:
+      - name: Exchange an OIDC token with PyPI
+        run: |
+          set -euo pipefail
+          # The minted token is a real upload credential for the project. It
+          # never leaves the runner and never reaches the log.
+          trap 'rm -f /tmp/mint.json' EXIT
+
+          audience="$(curl -sS --fail https://pypi.org/_/oidc/audience | jq -r .audience)"
+          echo "PyPI expects audience: $audience"
+
+          # GitHub mints the OIDC token through a per-job endpoint; the URL
+          # already carries a query string, hence '&audience='.
+          oidc="$(curl -sS --fail \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${audience}" | jq -r .value)"
+
+          code="$(curl -sS -o /tmp/mint.json -w '%{http_code}' \
+            -X POST https://pypi.org/_/oidc/mint-token \
+            -H 'Content-Type: application/json' \
+            -d "{\"token\": \"${oidc}\"}")"
+          echo "POST /_/oidc/mint-token -> HTTP $code"
+
+          if [ "$code" = "200" ] && jq -e 'has("token")' /tmp/mint.json >/dev/null; then
+            echo
+            echo "PASS: PyPI minted an upload token."
+            echo "      The Trusted Publisher matches VocaHQ / vocalinux /"
+            echo "      release.yml / environment 'pypi'. The next v* tag will publish."
+            exit 0
+          fi
+
+          echo
+          echo "FAIL: PyPI refused to mint a token. Response (token field removed):"
+          jq 'del(.token)' /tmp/mint.json 2>/dev/null || cat /tmp/mint.json
+          echo
+          echo "Then publish-pypi will fail on the next tag, and there is no API-token"
+          echo "fallback left in release.yml. Someone with Owner rights on the PyPI"
+          echo "project needs pypi.org -> vocalinux -> Manage -> Publishing, with all"
+          echo "four fields matching exactly:"
+          echo "  Owner:            VocaHQ"
+          echo "  Repository name:  vocalinux"
+          echo "  Workflow name:    release.yml"
+          echo "  Environment name: pypi"
+          exit 1


### PR DESCRIPTION
## Description

**This is a throwaway. Merge it, run it once, read the answer, delete it.**

#759 removed `secrets.PYPI_API_TOKEN` from `release.yml`. `publish-pypi` now mints an OIDC token and has no password fallback, so the upload fails outright unless PyPI carries a Trusted Publisher matching this repository. Nothing has exercised that yet, v0.16.1 was tagged before #759 merged.

`release.yml` triggers only on `push: tags: v*`. So as things stand, **the tag is what discovers a missing or mistyped publisher**, after `build-and-release` has already created the GitHub release, and with no token left to fall back to.

This workflow asks PyPI the same question the release asks, and publishes nothing: it requests the OIDC token GitHub would hand `publish-pypi`, offers it to `https://pypi.org/_/oidc/mint-token`, and reports whether PyPI accepted it. On failure it prints the response with the token field removed, plus the four values that have to match. Owner rights on the PyPI project are not needed to *run* it — only to fix a failure.

Two details that matter:

- It declares `environment: pypi`, the same as `publish-pypi`. The Trusted Publisher entry pins the environment, so probing from outside it would fail a correctly configured publisher and send someone chasing a problem that isn't there.
- The minted token is a real upload credential for the project. It is written to `/tmp`, removed on exit, and never printed, the failure path pipes the response through `jq 'del(.token)'`.

It uses no actions, so there is nothing for `tests/test_workflow_action_pins.py` to pin.

## How to use it

1. Merge (a `workflow_dispatch` workflow has to be on the default branch before it can be dispatched).
2. Actions -> **PyPI publisher probe** -> Run workflow.
3. `PASS` means the next `v*` tag will publish. `FAIL` means someone with Owner rights needs pypi.org -> `vocalinux` -> Manage -> Publishing, with Owner `VocaHQ`, Repository `vocalinux`, Workflow `release.yml`, Environment `pypi`.
4. Delete the file.

## Related Issue

Precondition for #701's "run the release path once and check it".

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧹 Code refactoring
- [x] ✅ Test update

## Checklist

- [x] My code follows the code style of this project (black, isort)
- [x] I have updated the documentation accordingly — the workflow documents itself; it is deleted after one run
- [x] I have added tests to cover my changes — n/a, this *is* a check; the existing workflow guards still pass
- [x] All new and existing tests pass locally
- [x] Pre-commit hooks pass (YAML validated; the step script passes `bash -n`)

## Additional Notes

Adjacent, and worth doing once this reports PASS: `PYPI_API_TOKEN` still exists as a repo secret and as a live token on PyPI, with no workflow referencing it. It should be revoked on PyPI and deleted here — in that order, so we are never without both paths.
