### PR TITLE
chore(release): prepare v0.16.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ It's a free, AGPL-3.0-licensed desktop app that lets you dictate text into *any*
 
 Models are downloaded once. After that, speech-to-text stays on your machine. No Voca account is required. Just speak and type.
 
-## 📚 What's New in v0.16.1
+## 📚 What's New in v0.16.2
 
-> **0.16.1** is a stability patch on the 0.16 series. Startup uses the engine's own model instead of a leftover generic key, leftover transcription no longer leaves the tray stuck, terminals get Ctrl+Shift+V paste, and the AppImage is built against a glibc Debian 12 can run. The installer now requires Python 3.11 and verifies model downloads.
+> **0.16.2** is a stability patch on the 0.16 series. Dictation types again on KDE when a leftover IBus daemon is not the session IM, Wayland and IBus keyboard shortcuts actually fire through wtype/ydotool, "delete that" sends real BackSpace, and the installer pulls glslc on Fedora/Arch. Release builds pin builders and ship checksums; AUR PKGBUILD and distro docs get CI gates.
 
 ### 0.16 series highlights
 
@@ -60,17 +60,17 @@ Models are downloaded once. After that, speech-to-text stays on your machine. No
 | **Tone picker** | Settings → Audio: Lift, Flick, Ember, Step, Voca, Soft, Chirp, Scale, Drop, Glass, Off, plus Preview. New installs default to Voca. Catalog uses family preview WAVs (#707, #708) |
 | **Installer** | Justfile, uv lockfiles, distro python3-gi required (no pip sdist of PyGObject). Epic #701 still open (#700, #705, #706) |
 
-### Bug fixes in v0.16.1
+### Bug fixes in v0.16.2
 
-- **Speech models**: start on the engine's own model size; write the model to config only after it loaded; leftover-download list shows every row (#684, #685, #686, fixes #681, #683)
-- **Config**: one ConfigManager for the process, so Settings writes are not overwritten by a stale cache (#691, fixes #689)
-- **Tray**: stay idle after leftover transcription on toggle stop; the missing-model notification can download the recommended model (#741, #687)
-- **Injection / IBus**: Ctrl+Shift+V paste in terminals; keep the GNOME XWayland layout after scoped inject (#734, #742)
-- **Installer / AppImage**: Python 3.11 floor, verified model downloads, no invented GPUs; AppImage glibc that boots on Debian 12 through current Fedora (#713, #736, #743, #744)
-- **AUR**: build against Arch extra setuptools 84; skip `context_params` on AUR pywhispercpp 1.4 so the app starts
-- **Settings**: even dropdowns and a quieter About page with family platform marks (#754)
+- **KDE inject**: skip leftover IBus when it is not the session IM so dictation types into Kate, browsers, and terminals (#753, fixes #752)
+- **Wayland / IBus shortcuts**: wtype and ydotool deliver real chords; IBus sessions route shortcuts to a virtual-keyboard tool (#715, #716)
+- **Delete that**: send real BackSpace key events instead of U+0008 text (#714)
+- **Installer**: Fedora and Arch need glslc/shaderc, not glslang (#763, #604)
+- **Nightly / release**: stamp version before build; release integrity checksums and pinned builders (#762, #759)
+- **CI / docs**: AUR PKGBUILD gate on every PR; distro CI matches the docs (#772, #773)
+- **Site**: VocaGateway family card is Beta; README logo, badges, privacy copy (#765, #764)
 
-See [docs/UPDATE.md](docs/UPDATE.md) and the [full changelog](https://github.com/VocaHQ/vocalinux/releases/tag/v0.16.1).
+See [docs/UPDATE.md](docs/UPDATE.md) and the [full changelog](https://github.com/VocaHQ/vocalinux/releases/tag/v0.16.2).
 
 ---
 
@@ -464,7 +464,7 @@ Vocalinux is part of [VocaHQ](https://vocahq.com). On-device speech-to-text firs
 
 | Platform | Project | Website | GitHub | Status |
 |----------|---------|---------|--------|--------|
-| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [VocaHQ/vocalinux](https://github.com/VocaHQ/vocalinux) | ✅ Available now (`v0.16.1`) |
+| 🐧 Linux | **VocaLinux** | [vocalinux.com](https://vocalinux.com) | [VocaHQ/vocalinux](https://github.com/VocaHQ/vocalinux) | ✅ Available now (`v0.16.2`) |
 | 🍎 macOS | **VocaMac** | [vocamac.com](https://vocamac.com) | [VocaHQ/vocamac](https://github.com/VocaHQ/vocamac) | 🚀 Beta (`v0.9.0`) |
 | 🪟 Windows | **VocaWin** | [vocawin.com](https://vocawin.com) | [VocaHQ/vocawin](https://github.com/VocaHQ/vocawin) | 🚀 Unsigned beta (`v0.1.0-beta.1`) |
 | 📱 Phone | **VocaPhone** | [vocaphone.vocahq.com](https://vocaphone.vocahq.com) | [VocaHQ/vocaphone](https://github.com/VocaHQ/vocaphone) | 🚀 Android beta / iOS [TestFlight](https://testflight.apple.com/join/wd85wQ3W) |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -450,6 +450,7 @@ git push origin v0.5.1-beta
 | 0.14.2 | 2026-07-17 | Stable | IBus engine launch + FocusIn gate; settings tabs scroll to fit monitor |
 | 0.15.0 | 2026-07-28 | Stable | Searchable settings + sidebar dictation footer, AppImage, expanded languages, dictation polish, auto-pause/keepalive, Vulkan device selection, ibus-wayland, Bluetooth mic + shortcut UI fixes |
 | 0.16.0 | 2026-08-23 | Stable | Update checker + tray notify, Right Alt PTT default (new installs), searchable language list, delete unused models, Voca tone picker (family preview WAVs), About page, AGPL-3.0, family mic icons, installer/just/uv pinning, Test Dictation missing-model message, IBus/audio/clipboard/GPU/AppImage reliability, vocalinux.com family workbench restyle |
+| 0.16.2 | 2026-09-05 | Stable | Patch: KDE leftover IBus skip, Wayland/IBus shortcuts via wtype/ydotool, BackSpace delete that, installer glslc on Fedora/Arch, nightly version stamp, release integrity pins, AUR PKGBUILD CI gate, distro CI/docs drift, Gateway Beta on site |
 | 0.16.1 | 2026-08-30 | Stable | Patch: per-engine model at startup, leftover tray idle, terminal Ctrl+Shift+V paste, GNOME XWayland layout after IBus, Python 3.11 floor + verified downloads, AppImage glibc that boots on Debian 12, Settings/About polish |
 
 ## Questions?

--- a/docs/UPDATE.md
+++ b/docs/UPDATE.md
@@ -2,6 +2,40 @@
 
 This guide explains how to update Vocalinux to the latest version.
 
+## What's New in v0.16.2
+
+0.16.2 is a **stability patch** on the 0.16 series. The feature set is the same as 0.16.x. This release fixes KDE leftover IBus so dictation types into real apps, Wayland and IBus keyboard shortcuts through wtype/ydotool, real BackSpace for "delete that", Fedora/Arch installer glslc packages, nightly version stamping, and release integrity pins. CI now gates AUR PKGBUILD builds and the distros the docs promise.
+
+### 0.16 series highlights
+
+| Feature | Description |
+|---------|-------------|
+| **Update checker** | Settings → About checks stable/nightly; tray shows Update Available for newer GitHub releases (#631, #645) |
+| **Right Alt PTT default** | New installs default to hold Right Alt (push-to-talk); existing configs keep their shortcut (#648) |
+| **Searchable languages** | Type to filter the Speech Model language list (#672) |
+| **Delete unused models** | Remove leftover downloaded speech models from Settings (#671) |
+| **AGPL-3.0** | License aligned with other VocaHQ projects (#660) |
+| **Family mic icons** | App icon, tray states, and site favicons use the shared Voca family mic (#704) |
+| **Tone picker** | Settings → Audio: Lift, Flick, Ember, Step, Voca, Soft, Chirp, Scale, Drop, Glass, Off, plus Preview. New installs default to Voca. Catalog uses family preview WAVs (#707, #708) |
+| **Installer** | Justfile, uv lockfiles, distro python3-gi required (no pip sdist of PyGObject). Epic #701 still open (#700, #705, #706) |
+
+### Bug fixes in v0.16.2
+
+- **KDE inject**: skip leftover IBus when it is not the session IM so dictation types into Kate, browsers, and terminals (#753 by @jatinkrmalik, fixes #752 by @justTravis)
+- **Wayland shortcuts**: wtype and ydotool deliver real chords instead of refusing or silently doing nothing (#715 by @eiseleb47)
+- **IBus shortcuts**: route X11_IBUS through xdotool and WAYLAND_IBUS through wtype/ydotool (#716 by @eiseleb47)
+- **Delete that**: send real BackSpace key events instead of U+0008 text (#714 by @eiseleb47)
+- **Installer**: Fedora and Arch need glslc/shaderc packages, not glslang (#763 by @jatinkrmalik, see #604)
+- **Nightly**: stamp `version.py` before `python -m build` so wheel metadata matches the filename (#762 by @sesav)
+- **Release integrity**: checksums, signatures, and pinned builders for release artifacts (#759 by @sesav, epic #701 phase 5)
+- **CI**: gate AUR PKGBUILD builds on every PR (#772 by @sesav)
+- **CI / docs**: test the distros the docs promise and fix docs drift (#773 by @sesav)
+- **Site**: VocaGateway family card is Beta; README logo, badges, and privacy copy (#765 by @jatinkrmalik, #764)
+
+See the [full changelog](https://github.com/VocaHQ/vocalinux/releases/tag/v0.16.2).
+
+---
+
 ## What's New in v0.16.1
 
 0.16.1 is a **stability patch** on the 0.16 series. The feature set is the same as 0.16.x. This release fixes wrong-model startup, leftover tray state after toggle stop, paste into terminals, GNOME XWayland layout after inject, and AppImages that needed a glibc newer than Debian 12. The installer now requires Python 3.11 and verifies model downloads.
@@ -488,7 +522,7 @@ The installer will:
 ```bash
 cd vocalinux
 git fetch origin
-git checkout v0.16.1
+git checkout v0.16.2
 ./install.sh
 ```
 

--- a/packaging/aur/vocalinux/PKGBUILD
+++ b/packaging/aur/vocalinux/PKGBUILD
@@ -3,8 +3,8 @@
 
 pkgname=vocalinux
 # AUR pkgver cannot contain hyphens (v0.14.0-beta -> 0.14.0beta).
-pkgver=0.16.1
-_tag=0.16.1
+pkgver=0.16.2
+_tag=0.16.2
 pkgrel=1
 pkgdesc="Free, offline voice dictation for Linux"
 arch=('any')

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -85,7 +85,7 @@ re-submitting without addressing that is a repeat. See
    sources:
      - type: git
        url: https://github.com/VocaHQ/vocalinux.git
-       tag: v0.16.1
+       tag: v0.16.2
        commit: <release-commit-sha>
    ```
 

--- a/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
+++ b/packaging/flatpak/com.vocalinux.Vocalinux.metainfo.xml
@@ -105,6 +105,11 @@
   </content_rating>
 
   <releases>
+    <release version="0.16.2" date="2026-09-05">
+      <description>
+        <p>Stability patch: skip leftover IBus on KDE so dictation types into real apps, Wayland/IBus shortcuts via wtype and ydotool, real BackSpace for "delete that", Fedora/Arch installer glslc (not glslang), nightly version stamp before build, release integrity checksums and pinned builders, AUR PKGBUILD CI gate, distro CI plus docs drift fixes, and VocaGateway Beta on the site.</p>
+      </description>
+    </release>
     <release version="0.16.1" date="2026-08-30">
       <description>
         <p>Stability patch: per-engine model size at startup, save the model only after it loaded, leftover-download list shows every row, one ConfigManager so Settings writes stick, tray stays idle after leftover transcription and can download the recommended model from the missing-model notification, Ctrl+Shift+V paste in terminals, GNOME XWayland layout after scoped IBus inject, Python 3.11 installer floor with verified model downloads, AppImage glibc that boots on Debian 12, AUR build against Arch extra setuptools 84, skip context_params on AUR pywhispercpp 1.4, and Settings/About layout polish.</p>

--- a/src/vocalinux/version.py
+++ b/src/vocalinux/version.py
@@ -2,8 +2,8 @@
 Version information for Vocalinux.
 """
 
-__version__ = "0.16.1"
-__version_info__ = (0, 16, 1)
+__version__ = "0.16.2"
+__version_info__ = (0, 16, 2)
 __author__ = "Jatin K Malik"
 __email__ = "jatinkrmalik@gmail.com"
 __license__ = "AGPL-3.0-only"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vocalinux-website",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vocalinux-website",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "dependencies": {
         "@types/node": "^20.14.10",
         "@types/react": "^18.3.3",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vocalinux-website",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/src/app/changelog/page.tsx
+++ b/web/src/app/changelog/page.tsx
@@ -15,6 +15,23 @@ import { absoluteUrl, buildPageMetadata } from "@/lib/seo";
 
 const releases = [
   {
+    version: "v0.16.2",
+    date: "2026-09-05",
+    type: "stable",
+    highlights: [
+      "KDE: skip leftover IBus when it is not the session IM so dictation types into Kate, browsers, and terminals (PR #753, fixes #752)",
+      "Wayland shortcuts: wtype and ydotool deliver real chords instead of refusing or silently doing nothing (PR #715)",
+      "IBus shortcuts: route X11_IBUS through xdotool and WAYLAND_IBUS through wtype/ydotool (PR #716)",
+      "Voice command delete that: send real BackSpace key events instead of U+0008 text (PR #714)",
+      "Installer: Fedora and Arch need glslc/shaderc packages, not glslang (PR #763, #604)",
+      "Nightly: stamp version.py before python -m build so wheel metadata matches the filename (PR #762)",
+      "Release integrity: checksums, signatures, and pinned builders for release artifacts (PR #759, epic #701 phase 5)",
+      "CI: gate AUR PKGBUILD builds on every PR; test the distros the docs promise and fix docs drift (PR #772, #773)",
+      "Site: VocaGateway family card is Beta; README logo, badges, and privacy copy (PR #765, #764)",
+      "Deps: bump the github-actions group (PR #766)",
+    ],
+  },
+  {
     version: "v0.16.1",
     date: "2026-08-30",
     type: "stable",

--- a/web/src/app/desktop-reliability/page.tsx
+++ b/web/src/app/desktop-reliability/page.tsx
@@ -55,6 +55,11 @@ const reliabilityFeatures = [
 
 const releaseMap = [
   {
+    version: "v0.16.2",
+    highlights:
+      "Skip leftover IBus on KDE so dictation types, Wayland and IBus shortcuts via wtype/ydotool, real BackSpace for delete that, Fedora/Arch glslc installer fix, nightly version stamp, and release integrity pins.",
+  },
+  {
     version: "v0.16.1",
     highlights:
       "Per-engine model at startup, leftover tray idle after toggle stop, Ctrl+Shift+V paste in terminals, GNOME XWayland layout after scoped IBus inject, Python 3.11 installer floor with verified downloads, and AppImage glibc that boots on Debian 12.",

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -40,7 +40,7 @@ const homeJsonLd = [
     },
     description:
       "Offline voice dictation and speech-to-text for Linux with whisper.cpp and VOSK.",
-    softwareVersion: "0.16.1",
+    softwareVersion: "0.16.2",
     author: {
       "@type": "Person",
       name: "Jatin K Malik",


### PR DESCRIPTION
## Summary

Prepares **v0.16.2**, a stability patch on the 0.16 series.

Same feature set as 0.16.x. This tag is the desktop, installer, release-integrity, and site work that landed after v0.16.1: leftover IBus on KDE, Wayland/IBus shortcuts through wtype and ydotool, real BackSpace for "delete that", Fedora/Arch glslc packages, nightly version stamp, release checksums and pinned builders, AUR PKGBUILD CI gate, distro CI/docs drift, and VocaGateway Beta on the site.

**Not in this cut** (still open): #780, #781, #774, and older conflicting parks. Leave those for a later tag.

### Already on main (this PR only bumps version + notes)

- **#753** by @jatinkrmalik - skip leftover IBus on KDE so dictation types (fixes #752 by @justTravis)
- **#715** by @eiseleb47 - Wayland shortcuts via wtype and ydotool
- **#716** by @eiseleb47 - IBus shortcut routing to a virtual-keyboard tool
- **#714** by @eiseleb47 - real BackSpace key events for "delete that"
- **#763** by @jatinkrmalik - Fedora/Arch installer needs glslc/shaderc, not glslang (see #604)
- **#762** by @sesav - nightly stamps `version.py` before build so metadata matches the filename
- **#759** by @sesav - release integrity: checksums, signatures, pinned builders (epic #701 phase 5)
- **#772** by @sesav - gate AUR PKGBUILD builds on every PR
- **#773** by @sesav - test the distros the docs promise; fix docs drift
- **#765** by @jatinkrmalik - VocaGateway family card is Beta (see #764)
- **#766** - github-actions group bump
- README logo / badges / privacy commits on main between tags

### Release prep in this PR

- Bump `0.16.1` to `0.16.2` (`version.py`, web package + lock metadata, AUR PKGBUILD with `sha256sums=('SKIP')`)
- Series-aware README / UPDATE: keep the 0.16 feature table, add "Bug fixes in this patch"
- Website changelog (delta only), schema `softwareVersion`, desktop-reliability map
- Flatpak AppStream short `<release>` + packaging README tag example
- Version history row in `docs/RELEASE_PROCESS.md` (2026-09-05)
- `SECURITY.md` stays on `0.16.x`

## After merge

1. Tag from main, not this branch: git tag -a v0.16.2 then git push origin v0.16.2
2. Confirm GitHub Release / PyPI / website / AUR / AppImage automation
3. Paste the draft notes (PR comment) onto the GitHub Release

Do not tag from this branch alone.

## Checklist

- [x] Version files updated
- [x] Series-aware README / UPDATE
- [x] Website + changelog
- [x] Flatpak metainfo
- [ ] CI green
- [ ] Tag after merge

Draft GitHub Release Notes will be posted as a follow-up comment.