### PR TITLE
feat(language): start a first run from the language the system points at

### DIFF
--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -173,6 +173,32 @@ class ConfigManager:
         """Ensure the configuration directory exists."""
         os.makedirs(CONFIG_DIR, exist_ok=True)
 
+    def _seed_language_from_system(self):
+        """Start a first run from the language the system points at (#777).
+
+        Only applied when there is no config file yet, so a saved choice — including
+        a deliberate "auto" — is never overwritten. When nothing decisive is found
+        the packaged default stays in place.
+        """
+        try:
+            from ..utils.system_language import detect_system_language
+            from ..utils.vosk_model_info import SUPPORTED_LANGUAGES
+        except ImportError as exc:  # pragma: no cover - defensive
+            logger.debug(f"Language detection unavailable: {exc}")
+            return
+
+        try:
+            detected = detect_system_language(SUPPORTED_LANGUAGES)
+        except Exception as exc:  # pragma: no cover - detection must never block startup
+            logger.debug(f"Language detection failed: {exc}")
+            return
+
+        if not detected:
+            return
+
+        self.config.setdefault("speech_recognition", {})["language"] = detected
+        logger.info(f"First run: starting with language {detected}")
+
     def load_config(self):
         """
         Load configuration from the config file.
@@ -181,6 +207,7 @@ class ConfigManager:
         """
         if not os.path.exists(CONFIG_FILE):
             logger.info(f"Config file not found at {CONFIG_FILE}. Using defaults.")
+            self._seed_language_from_system()
             return
 
         try:

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -173,7 +173,7 @@ class ConfigManager:
         """Ensure the configuration directory exists."""
         os.makedirs(CONFIG_DIR, exist_ok=True)
 
-    def _seed_language_from_system(self):
+    def _seed_language_from_system(self) -> None:
         """Start a first run from the language the system points at (#777).
 
         Only applied when there is no config file yet, so a saved choice — including

--- a/src/vocalinux/utils/system_language.py
+++ b/src/vocalinux/utils/system_language.py
@@ -150,11 +150,13 @@ def detect_locale_language(environ: Optional[dict] = None) -> Optional[str]:
 
 
 def _language_from_locale_env(environ: dict, supported: set[str] | dict) -> Optional[str]:
-    """Map the first locale env var onto a catalogue entry.
+    """Map locale env vars onto a catalogue entry, first supported win.
 
     LANGUAGE is a colon-separated preference list: each entry is tried through
-    ``_language_for_locale`` until one is supported. LC_ALL, LC_MESSAGES, and
-    LANG are single values and are not walked as lists.
+    ``_language_for_locale`` until one is supported. An env var whose values
+    are all unmapped is skipped so a later var (typically LANG) can still
+    win. LC_ALL, LC_MESSAGES, and LANG are single values and are not walked
+    as lists.
     """
     for name in _LOCALE_ENV_VARS:
         value = environ.get(name)
@@ -165,7 +167,7 @@ def _language_from_locale_env(environ: dict, supported: set[str] | dict) -> Opti
             mapped = _language_for_locale(candidate, supported)
             if mapped:
                 return mapped
-        return None
+        continue
     return None
 
 

--- a/src/vocalinux/utils/system_language.py
+++ b/src/vocalinux/utils/system_language.py
@@ -135,13 +135,39 @@ def detect_keyboard_layout() -> Optional[str]:
 
 
 def detect_locale_language(environ: Optional[dict] = None) -> Optional[str]:
-    """Return the first locale value the environment offers, or None."""
+    """Return the first locale value the environment offers, or None.
+
+    LANGUAGE is returned intact (a colon-separated preference list). Mapping
+    that list onto a supported catalogue entry happens in
+    ``_language_from_locale_env``.
+    """
     environ = os.environ if environ is None else environ
     for name in _LOCALE_ENV_VARS:
         value = environ.get(name)
         if value:
-            # LANGUAGE may hold a colon-separated preference list.
-            return value.split(":")[0]
+            return value
+    return None
+
+
+def _language_from_locale_env(
+    environ: dict, supported: set[str] | dict
+) -> Optional[str]:
+    """Map the first locale env var onto a catalogue entry.
+
+    LANGUAGE is a colon-separated preference list: each entry is tried through
+    ``_language_for_locale`` until one is supported. LC_ALL, LC_MESSAGES, and
+    LANG are single values and are not walked as lists.
+    """
+    for name in _LOCALE_ENV_VARS:
+        value = environ.get(name)
+        if not value:
+            continue
+        candidates = value.split(":") if name == "LANGUAGE" else (value,)
+        for candidate in candidates:
+            mapped = _language_for_locale(candidate, supported)
+            if mapped:
+                return mapped
+        return None
     return None
 
 
@@ -162,12 +188,11 @@ def detect_system_language(
             logger.info(f"Language {layout_language} taken from keyboard layout {layout!r}")
             return layout_language
 
-    locale_value = detect_locale_language(environ)
-    if locale_value:
-        locale_language = _language_for_locale(locale_value, supported)
-        if locale_language:
-            logger.info(f"Language {locale_language} taken from locale {locale_value!r}")
-            return locale_language
+    environ = os.environ if environ is None else environ
+    locale_language = _language_from_locale_env(environ, supported)
+    if locale_language:
+        logger.info(f"Language {locale_language} taken from locale environment")
+        return locale_language
 
     if layout_language:
         logger.info(f"Language {layout_language} taken from keyboard layout {layout!r}")

--- a/src/vocalinux/utils/system_language.py
+++ b/src/vocalinux/utils/system_language.py
@@ -1,0 +1,169 @@
+"""Work out which language the user probably speaks (#777).
+
+Nothing used to ask the system this, so whisper.cpp always started on auto-detect
+and VOSK on a hardcoded ``en-us``. Both are wrong for anyone who does not speak
+English, and neither ever improves on its own.
+
+The keyboard layout is consulted before the locale on purpose. Plenty of people
+run their desktop in English and speak something else — among the people who
+install a Linux dictation tool that is closer to the rule than the exception —
+so the interface language is a weak signal for *spoken* language. What someone
+types in tracks what they say far more closely.
+"""
+
+import logging
+import os
+import re
+import subprocess
+from typing import Optional
+
+from .host_process import host_env
+
+logger = logging.getLogger(__name__)
+
+# xkb layout names that do not match the language id we use. Layouts not listed
+# here are looked up as-is, which covers pl, de, fr, it, es, ru and the rest.
+_LAYOUT_TO_LANGUAGE = {
+    "us": "en-us",
+    "gb": "en-us",
+    "cz": "cs",
+    "se": "sv",
+    "dk": "da",
+    "gr": "el",
+    "ua": "uk",
+    "jp": "ja",
+    "kr": "ko",
+    "cn": "zh",
+    "ir": "fa",
+    "il": "he",
+    "br": "pt",
+    "nb": "no",
+    "nn": "no",
+    "vn": "vi",
+}
+
+# Locale territory codes that pick a specific catalogue entry.
+_LOCALE_TO_LANGUAGE = {
+    "en_in": "en-in",
+    "nb": "no",
+    "nn": "no",
+    "zh_cn": "zh",
+    "zh_tw": "zh",
+}
+
+_LOCALE_ENV_VARS = ("LC_ALL", "LC_MESSAGES", "LANG", "LANGUAGE")
+
+
+def _normalise(value: str) -> str:
+    return value.strip().lower().replace("-", "_")
+
+
+def _language_for_layout(layout: str, supported) -> Optional[str]:
+    layout = _normalise(layout)
+    if not layout:
+        return None
+    mapped = _LAYOUT_TO_LANGUAGE.get(layout, layout)
+    return mapped if mapped in supported else None
+
+
+def _language_for_locale(value: str, supported) -> Optional[str]:
+    """Map a locale string such as ``pl_PL.UTF-8`` onto a catalogue entry."""
+    value = _normalise(value)
+    if not value or value.startswith(("c", "posix")) and "_" not in value:
+        return None
+
+    # Strip the encoding and any modifier: pl_pl.utf_8@euro -> pl_pl
+    value = re.split(r"[.@]", value, maxsplit=1)[0]
+
+    if value in _LOCALE_TO_LANGUAGE:
+        candidate = _LOCALE_TO_LANGUAGE[value]
+        return candidate if candidate in supported else None
+
+    if value in supported:
+        return value
+
+    base = value.split("_", 1)[0]
+    if base == "en":
+        return "en-us" if "en-us" in supported else None
+    return base if base in supported else None
+
+
+def detect_keyboard_layout() -> Optional[str]:
+    """Return the primary xkb layout, or None when it cannot be read.
+
+    ``localectl`` is used rather than ``setxkbmap`` because the latter reports
+    nothing useful on Wayland, where the compositor owns the keyboard.
+    """
+    try:
+        result = subprocess.run(
+            ["localectl", "status"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            env=host_env(),
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError) as exc:
+        logger.debug(f"Could not query localectl: {exc}")
+        return None
+
+    if result.returncode != 0:
+        logger.debug(f"localectl exited with {result.returncode}")
+        return None
+
+    layout = None
+    keymap = None
+    for line in result.stdout.splitlines():
+        key, _, value = line.partition(":")
+        key = key.strip().lower()
+        value = value.strip()
+        if key == "x11 layout" and value:
+            layout = value
+        elif key == "vc keymap" and value:
+            keymap = value
+
+    # A multi-layout setup lists the primary one first: "pl,us".
+    chosen = layout or keymap
+    if not chosen:
+        return None
+    return chosen.split(",")[0].strip() or None
+
+
+def detect_locale_language(environ=None) -> Optional[str]:
+    """Return the first locale value the environment offers, or None."""
+    environ = os.environ if environ is None else environ
+    for name in _LOCALE_ENV_VARS:
+        value = environ.get(name)
+        if value:
+            # LANGUAGE may hold a colon-separated preference list.
+            return value.split(":")[0]
+    return None
+
+
+def detect_system_language(supported, environ=None) -> Optional[str]:
+    """Return the language id to start from, or None when nothing is decisive.
+
+    A non-English keyboard layout is the strongest signal available and wins.
+    "us" is the fallback layout on a great many installs and therefore says very
+    little, so the locale gets a say before that layout is accepted.
+    """
+    layout_language = None
+    layout = detect_keyboard_layout()
+    if layout:
+        layout_language = _language_for_layout(layout, supported)
+        if layout_language and not layout_language.startswith("en"):
+            logger.info(f"Language {layout_language} taken from keyboard layout {layout!r}")
+            return layout_language
+
+    locale_value = detect_locale_language(environ)
+    if locale_value:
+        locale_language = _language_for_locale(locale_value, supported)
+        if locale_language:
+            logger.info(f"Language {locale_language} taken from locale {locale_value!r}")
+            return locale_language
+
+    if layout_language:
+        logger.info(f"Language {layout_language} taken from keyboard layout {layout!r}")
+        return layout_language
+
+    logger.info("Could not work out a language from the system")
+    return None

--- a/src/vocalinux/utils/system_language.py
+++ b/src/vocalinux/utils/system_language.py
@@ -51,14 +51,14 @@ _LOCALE_TO_LANGUAGE = {
     "zh_tw": "zh",
 }
 
-_LOCALE_ENV_VARS = ("LC_ALL", "LC_MESSAGES", "LANG", "LANGUAGE")
+_LOCALE_ENV_VARS = ("LC_ALL", "LC_MESSAGES", "LANGUAGE", "LANG")
 
 
 def _normalise(value: str) -> str:
     return value.strip().lower().replace("-", "_")
 
 
-def _language_for_layout(layout: str, supported) -> Optional[str]:
+def _language_for_layout(layout: str, supported: set[str] | dict) -> Optional[str]:
     layout = _normalise(layout)
     if not layout:
         return None
@@ -66,14 +66,17 @@ def _language_for_layout(layout: str, supported) -> Optional[str]:
     return mapped if mapped in supported else None
 
 
-def _language_for_locale(value: str, supported) -> Optional[str]:
+def _language_for_locale(value: str, supported: set[str] | dict) -> Optional[str]:
     """Map a locale string such as ``pl_PL.UTF-8`` onto a catalogue entry."""
     value = _normalise(value)
-    if not value or value.startswith(("c", "posix")) and "_" not in value:
+    if not value:
         return None
 
     # Strip the encoding and any modifier: pl_pl.utf_8@euro -> pl_pl
     value = re.split(r"[.@]", value, maxsplit=1)[0]
+    # Exact C/POSIX only — startswith("c") wrongly rejects cs/ca/cy.
+    if value in ("c", "posix"):
+        return None
 
     if value in _LOCALE_TO_LANGUAGE:
         candidate = _LOCALE_TO_LANGUAGE[value]
@@ -83,6 +86,9 @@ def _language_for_locale(value: str, supported) -> Optional[str]:
         return value
 
     base = value.split("_", 1)[0]
+    if base in _LOCALE_TO_LANGUAGE:
+        candidate = _LOCALE_TO_LANGUAGE[base]
+        return candidate if candidate in supported else None
     if base == "en":
         return "en-us" if "en-us" in supported else None
     return base if base in supported else None
@@ -128,7 +134,7 @@ def detect_keyboard_layout() -> Optional[str]:
     return chosen.split(",")[0].strip() or None
 
 
-def detect_locale_language(environ=None) -> Optional[str]:
+def detect_locale_language(environ: Optional[dict] = None) -> Optional[str]:
     """Return the first locale value the environment offers, or None."""
     environ = os.environ if environ is None else environ
     for name in _LOCALE_ENV_VARS:
@@ -139,7 +145,9 @@ def detect_locale_language(environ=None) -> Optional[str]:
     return None
 
 
-def detect_system_language(supported, environ=None) -> Optional[str]:
+def detect_system_language(
+    supported: set[str] | dict, environ: Optional[dict] = None
+) -> Optional[str]:
     """Return the language id to start from, or None when nothing is decisive.
 
     A non-English keyboard layout is the strongest signal available and wins.

--- a/src/vocalinux/utils/system_language.py
+++ b/src/vocalinux/utils/system_language.py
@@ -149,9 +149,7 @@ def detect_locale_language(environ: Optional[dict] = None) -> Optional[str]:
     return None
 
 
-def _language_from_locale_env(
-    environ: dict, supported: set[str] | dict
-) -> Optional[str]:
+def _language_from_locale_env(environ: dict, supported: set[str] | dict) -> Optional[str]:
     """Map the first locale env var onto a catalogue entry.
 
     LANGUAGE is a colon-separated preference list: each entry is tried through

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -52,6 +52,15 @@ class TestConfigManager(unittest.TestCase):
         # Recreate after patching so each test starts from a known config path.
         _ensure_test_config_dir(self.temp_config_dir)
 
+        # Every test here starts without a config file, which is a first run, so
+        # language detection would shell out to localectl and make the result depend
+        # on the machine's keyboard layout. The seeding itself is covered in
+        # tests/test_system_language.py.
+        self.detect_patcher = patch(
+            "vocalinux.utils.system_language.detect_system_language", return_value=None
+        )
+        self.detect_patcher.start()
+
         # Patch logging to avoid actual logging
         self.logger_patcher = patch("vocalinux.ui.config_manager.logger")
         self.mock_logger = self.logger_patcher.start()
@@ -61,6 +70,7 @@ class TestConfigManager(unittest.TestCase):
         self.config_dir_patcher.stop()
         self.config_file_patcher.stop()
         self.makedirs_patcher.stop()
+        self.detect_patcher.stop()
         self.logger_patcher.stop()
         self.temp_dir.cleanup()
 

--- a/tests/test_system_language.py
+++ b/tests/test_system_language.py
@@ -1,0 +1,113 @@
+"""First run should start from the language the system points at (#777)."""
+
+from unittest.mock import patch
+
+import pytest
+
+from vocalinux.ui import config_manager as cm
+from vocalinux.utils import system_language as sl
+from vocalinux.utils.vosk_model_info import SUPPORTED_LANGUAGES
+
+
+@pytest.fixture
+def isolated_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(cm, "CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(cm, "CONFIG_FILE", str(tmp_path / "config.json"))
+    monkeypatch.setattr(cm, "_shared_instance", None)
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "layout,expected",
+    [
+        ("pl", "pl"),
+        ("de", "de"),
+        ("cz", "cs"),
+        ("se", "sv"),
+        ("us", "en-us"),
+        ("gb", "en-us"),
+        ("xyz", None),
+    ],
+)
+def test_layouts_map_onto_catalogue_entries(layout, expected):
+    assert sl._language_for_layout(layout, SUPPORTED_LANGUAGES) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("pl_PL.UTF-8", "pl"),
+        ("de_DE@euro", "de"),
+        ("en_US.UTF-8", "en-us"),
+        ("en_GB", "en-us"),
+        ("en_IN", "en-in"),
+        ("C", None),
+        ("POSIX", None),
+        ("xx_YY", None),
+    ],
+)
+def test_locales_map_onto_catalogue_entries(value, expected):
+    assert sl._language_for_locale(value, SUPPORTED_LANGUAGES) == expected
+
+
+def test_a_non_english_layout_beats_an_english_locale():
+    """The reported case: desktop in English, keyboard in Polish, speaks Polish."""
+    with patch.object(sl, "detect_keyboard_layout", return_value="pl"):
+        detected = sl.detect_system_language(SUPPORTED_LANGUAGES, {"LANG": "en_US.UTF-8"})
+
+    assert detected == "pl"
+
+
+def test_a_us_layout_defers_to_the_locale():
+    """ "us" is the default layout on many installs, so it carries little signal."""
+    with patch.object(sl, "detect_keyboard_layout", return_value="us"):
+        detected = sl.detect_system_language(SUPPORTED_LANGUAGES, {"LANG": "pl_PL.UTF-8"})
+
+    assert detected == "pl"
+
+
+def test_a_us_layout_is_used_when_the_locale_says_nothing():
+    with patch.object(sl, "detect_keyboard_layout", return_value="us"):
+        detected = sl.detect_system_language(SUPPORTED_LANGUAGES, {"LANG": "C"})
+
+    assert detected == "en-us"
+
+
+def test_nothing_decisive_returns_none():
+    with patch.object(sl, "detect_keyboard_layout", return_value=None):
+        assert sl.detect_system_language(SUPPORTED_LANGUAGES, {}) is None
+
+
+def test_a_missing_localectl_does_not_raise():
+    with patch.object(sl.subprocess, "run", side_effect=FileNotFoundError):
+        assert sl.detect_keyboard_layout() is None
+
+
+def test_first_run_starts_from_the_detected_language(isolated_config):
+    """Without this the fresh config keeps the packaged "auto"."""
+    with patch.object(sl, "detect_keyboard_layout", return_value="pl"):
+        with patch.dict("os.environ", {"LANG": "en_US.UTF-8"}, clear=False):
+            manager = cm.ConfigManager()
+
+    assert manager.get("speech_recognition", "language") == "pl"
+
+
+def test_first_run_keeps_the_default_when_detection_finds_nothing(isolated_config):
+    with patch.object(sl, "detect_keyboard_layout", return_value=None):
+        with patch.dict("os.environ", {"LANG": "C", "LC_ALL": "C"}, clear=True):
+            manager = cm.ConfigManager()
+
+    assert manager.get("speech_recognition", "language") == "auto"
+
+
+def test_a_saved_language_is_never_overwritten(isolated_config):
+    """A returning user who chose auto-detect keeps it."""
+    import json
+
+    with open(cm.CONFIG_FILE, "w") as handle:
+        json.dump({"speech_recognition": {"language": "auto"}}, handle)
+
+    with patch.object(sl, "detect_keyboard_layout", return_value="pl"):
+        manager = cm.ConfigManager()
+
+    assert manager.get("speech_recognition", "language") == "auto"

--- a/tests/test_system_language.py
+++ b/tests/test_system_language.py
@@ -143,6 +143,17 @@ def test_language_env_skips_unsupported_preferences():
     assert detected == "pl"
 
 
+def test_unmapped_language_env_falls_through_to_lang():
+    """An unsupported LANGUAGE list must not hide LANG (#796)."""
+    with patch.object(sl, "detect_keyboard_layout", return_value="us"):
+        detected = sl.detect_system_language(
+            SUPPORTED_LANGUAGES,
+            {"LANGUAGE": "xx:yy", "LANG": "pl_PL.UTF-8"},
+        )
+
+    assert detected == "pl"
+
+
 def test_language_env_czech_is_not_treated_as_c():
     with patch.object(sl, "detect_keyboard_layout", return_value="us"):
         detected = sl.detect_system_language(

--- a/tests/test_system_language.py
+++ b/tests/test_system_language.py
@@ -132,6 +132,17 @@ def test_language_env_beats_lang_when_both_set():
     assert detected == "pl"
 
 
+def test_language_env_skips_unsupported_preferences():
+    """An unsupported first LANGUAGE pref must not hide a later supported one."""
+    with patch.object(sl, "detect_keyboard_layout", return_value="us"):
+        detected = sl.detect_system_language(
+            SUPPORTED_LANGUAGES,
+            {"LANG": "en_US.UTF-8", "LANGUAGE": "xx:pl:en"},
+        )
+
+    assert detected == "pl"
+
+
 def test_language_env_czech_is_not_treated_as_c():
     with patch.object(sl, "detect_keyboard_layout", return_value="us"):
         detected = sl.detect_system_language(

--- a/tests/test_system_language.py
+++ b/tests/test_system_language.py
@@ -41,8 +41,16 @@ def test_layouts_map_onto_catalogue_entries(layout, expected):
         ("en_US.UTF-8", "en-us"),
         ("en_GB", "en-us"),
         ("en_IN", "en-in"),
+        ("cs", "cs"),
+        ("cs_CZ.UTF-8", "cs"),
+        ("ca", "ca"),
+        ("ca_ES.UTF-8", "ca"),
+        ("nb_NO", "no"),
+        ("nb_NO.UTF-8", "no"),
+        ("nn_NO", "no"),
         ("C", None),
         ("POSIX", None),
+        ("C.UTF-8", None),
         ("xx_YY", None),
     ],
 )
@@ -111,3 +119,34 @@ def test_a_saved_language_is_never_overwritten(isolated_config):
         manager = cm.ConfigManager()
 
     assert manager.get("speech_recognition", "language") == "auto"
+
+
+def test_language_env_beats_lang_when_both_set():
+    """LANGUAGE is the gettext preference list; LANG must not mask it (#796)."""
+    with patch.object(sl, "detect_keyboard_layout", return_value="us"):
+        detected = sl.detect_system_language(
+            SUPPORTED_LANGUAGES,
+            {"LANG": "en_US.UTF-8", "LANGUAGE": "pl:en"},
+        )
+
+    assert detected == "pl"
+
+
+def test_language_env_czech_is_not_treated_as_c():
+    with patch.object(sl, "detect_keyboard_layout", return_value="us"):
+        detected = sl.detect_system_language(
+            SUPPORTED_LANGUAGES,
+            {"LANG": "en_US.UTF-8", "LANGUAGE": "cs"},
+        )
+
+    assert detected == "cs"
+
+
+def test_nb_no_locale_maps_to_norwegian():
+    with patch.object(sl, "detect_keyboard_layout", return_value="us"):
+        detected = sl.detect_system_language(
+            SUPPORTED_LANGUAGES,
+            {"LANG": "nb_NO.UTF-8"},
+        )
+
+    assert detected == "no"


### PR DESCRIPTION
Closes #777

Nothing asked the system what language the user speaks, so whisper.cpp always began on auto-detect and VOSK on a hardcoded en-us.

The language is seeded on first run only, so a saved choice — including a deliberate "auto" — is never touched. The keyboard layout is consulted before the locale: running the desktop in English while speaking something else is common among people who install a Linux dictation tool, which makes the interface language a weak signal. A "us" layout is the default on many installs and says little, so the locale gets a say before it is accepted. `localectl` is used rather than `setxkbmap`, which reports nothing useful on Wayland. Detection failures leave the packaged default in place.

On this machine: layout `pl`, locale `en_US.UTF-8` → `pl`.

**Testing:** `tests/test_system_language.py` — layout and locale mapping, the precedence rules, first-run seeding, and that a saved language is never overwritten. The seeding test fails without the fix (`'auto' == 'pl'`). `tests/test_config_manager.py` patches detection off so it does not depend on the machine's layout. Full suite: no new failures against main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKVa2qTLQYMCHffjp97yqT
