### PR TITLE
feat(settings): simple setup for the speech model, with Advanced as an island

### DIFF
--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -69,9 +69,9 @@ DEFAULT_CONFIG = {
         "vosk_model_size": "small",  # Default model for VOSK engine
         "whisper_model_size": "tiny",  # Default model for Whisper engine
         "whisper_cpp_model_size": "tiny",  # Default model for whisper.cpp engine
-        # Whether the detailed engine/size/specialization rows are revealed under
-        # the simple questions. Simple is the panel; this only adds detail (#779).
-        "show_advanced": False,
+        # The second language offered once "I also dictate in other languages" is
+        # on. Empty means the main language is pinned on its own (#779).
+        "simple_second_language": "",
         "vad_sensitivity": 3,  # Voice Activity Detection sensitivity (1-5)
         "silence_timeout": 2.0,  # Seconds of silence before stopping
         "stop_sound_guard_ms": 200,  # Small tail trim to avoid the stop sound without clipping speech

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -69,9 +69,9 @@ DEFAULT_CONFIG = {
         "vosk_model_size": "small",  # Default model for VOSK engine
         "whisper_model_size": "tiny",  # Default model for Whisper engine
         "whisper_cpp_model_size": "tiny",  # Default model for whisper.cpp engine
-        # "simple" asks for language and priority and derives the rest; "advanced"
-        # exposes engine, size and specialization directly (#779).
-        "settings_mode": "simple",
+        # Whether the detailed engine/size/specialization rows are revealed under
+        # the simple questions. Simple is the panel; this only adds detail (#779).
+        "show_advanced": False,
         "vad_sensitivity": 3,  # Voice Activity Detection sensitivity (1-5)
         "silence_timeout": 2.0,  # Seconds of silence before stopping
         "stop_sound_guard_ms": 200,  # Small tail trim to avoid the stop sound without clipping speech

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -69,6 +69,9 @@ DEFAULT_CONFIG = {
         "vosk_model_size": "small",  # Default model for VOSK engine
         "whisper_model_size": "tiny",  # Default model for Whisper engine
         "whisper_cpp_model_size": "tiny",  # Default model for whisper.cpp engine
+        # "simple" asks for language and priority and derives the rest; "advanced"
+        # exposes engine, size and specialization directly (#779).
+        "settings_mode": "simple",
         "vad_sensitivity": 3,  # Voice Activity Detection sensitivity (1-5)
         "silence_timeout": 2.0,  # Seconds of silence before stopping
         "stop_sound_guard_ms": 200,  # Small tail trim to avoid the stop sound without clipping speech

--- a/src/vocalinux/ui/config_manager.py
+++ b/src/vocalinux/ui/config_manager.py
@@ -72,6 +72,8 @@ DEFAULT_CONFIG = {
         # The second language offered once "I also dictate in other languages" is
         # on. Empty means the main language is pinned on its own (#779).
         "simple_second_language": "",
+        # Whether the Advanced island under the simple questions is left open.
+        "show_advanced": False,
         "vad_sensitivity": 3,  # Voice Activity Detection sensitivity (1-5)
         "silence_timeout": 2.0,  # Seconds of silence before stopping
         "stop_sound_guard_ms": 200,  # Small tail trim to avoid the stop sound without clipping speech

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -249,6 +249,25 @@ def _language_is_english(language_id: str) -> bool:
     return SUPPORTED_LANGUAGES.get(language_id, {}).get("whisper") == "en"
 
 
+def _decode_simple_languages(primary: str, wants_second: bool, secondary: Optional[str]) -> str:
+    """Resolve the two simple language answers into what the engine accepts.
+
+    whisper takes one language or none, so naming a second language has to mean
+    automatic detection. The one exception is two English entries — en-US plus
+    en-IN, say — where English can still be pinned and the English-only weights,
+    which are the same size and better at English, stay available.
+    """
+    if not wants_second:
+        return primary
+    if not secondary or secondary == primary:
+        return primary
+    if secondary == "auto":
+        return "auto"
+    if _language_is_english(primary) and _language_is_english(secondary):
+        return primary
+    return "auto"
+
+
 def _recommended_whispercpp_variant_for_language(
     recommended_model: str,
     reason: str,
@@ -5600,9 +5619,10 @@ class SettingsDialog(Gtk.Dialog):
         Switching modes must not change the model on its own, so the priority is
         read back from the size already chosen rather than reset to a default.
 
-        A pinned Advanced language must win over a leftover simple multi answer:
-        restoring the switch and ``simple_second_language`` would make the next
-        simple edit decode to auto and silently replace the pin.
+        A leftover simple multi answer that would decode to auto must not be
+        restored over a pinned Advanced language: the next simple edit would
+        silently replace the pin. Two English answers still pin English, so
+        that configuration is kept.
         """
         language = self.language_combo.get_active_id() or self.language or "auto"
         is_auto = language == "auto"
@@ -5621,13 +5641,20 @@ class SettingsDialog(Gtk.Dialog):
                     # Detection with no named second language is the "any" answer.
                     self.simple_second_language_combo.set_active_id("auto")
             else:
-                self.simple_multi_switch.set_active(False)
                 self.simple_language_combo.set_active_id(language)
-                if stored_second:
-                    self.config_manager.set("speech_recognition", "simple_second_language", "")
-                # Reset so turning the switch on later starts from "any", not a
-                # stale pick that Advanced already superseded.
-                self.simple_second_language_combo.set_active_id("auto")
+                keeps_pin = bool(stored_second) and (
+                    _decode_simple_languages(language, True, stored_second) == language
+                )
+                if keeps_pin:
+                    self.simple_multi_switch.set_active(True)
+                    self.simple_second_language_combo.set_active_id(stored_second)
+                else:
+                    self.simple_multi_switch.set_active(False)
+                    if stored_second:
+                        self.config_manager.set("speech_recognition", "simple_second_language", "")
+                    # Reset so turning the switch on later starts from "any", not
+                    # a stale pick that Advanced already superseded.
+                    self.simple_second_language_combo.set_active_id("auto")
 
             recommended, _ = self._get_recommended_whispercpp_model_for_language()
             current = self._get_selected_whispercpp_model()
@@ -5640,25 +5667,13 @@ class SettingsDialog(Gtk.Dialog):
         self._update_simple_visibility()
 
     def _simple_decoding_language(self) -> str:
-        """Resolve the two simple language answers into what the engine accepts.
-
-        whisper takes one language or none, so naming a second language has to mean
-        automatic detection. The one exception is two English entries — en-US plus
-        en-IN, say — where English can still be pinned and the English-only weights,
-        which are the same size and better at English, stay available.
-        """
+        """Resolve the two simple language answers into what the engine accepts."""
         primary = self.simple_language_combo.get_active_id() or "en-us"
-        if not self.simple_multi_switch.get_active():
-            return primary
-
-        secondary = self.simple_second_language_combo.get_active_id()
-        if not secondary or secondary == primary:
-            return primary
-        if secondary == "auto":
-            return "auto"
-        if _language_is_english(primary) and _language_is_english(secondary):
-            return primary
-        return "auto"
+        return _decode_simple_languages(
+            primary,
+            self.simple_multi_switch.get_active(),
+            self.simple_second_language_combo.get_active_id(),
+        )
 
     def _on_disk_stand_in(self, variant: str, size: str, language: str) -> str:
         """Prefer a downloaded weight of the same size over fetching a sibling.

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1845,8 +1845,9 @@ class SettingsDialog(Gtk.Dialog):
         # Set while simple mode steers the advanced controls, so their own change
         # handlers do not each trigger a separate engine reload.
         self._simple_driving = False
-        self.advanced_toggle = None
-        self.advanced_revealer = None
+        self.advanced_button = None
+        self.advanced_box = None
+        self.advanced_window = None
         self.simple_group = None
         self.engine_group = None
         self._processing_language_change = (
@@ -2000,9 +2001,6 @@ class SettingsDialog(Gtk.Dialog):
 
         # Restore the saved mode and point the simple questions at the live model
         # before the first visibility pass, so nothing flashes the wrong group.
-        self.advanced_toggle.set_active(
-            bool(self.config_manager.get("speech_recognition", "show_advanced", False))
-        )
         self._sync_simple_from_advanced()
 
         # Then update visibility of engine-specific elements
@@ -2897,6 +2895,27 @@ class SettingsDialog(Gtk.Dialog):
         )
         self.simple_group.add_row(self.simple_multi_row)
 
+        self.simple_second_language_combo = Gtk.ComboBoxText.new_with_entry()
+        _style_combo(self.simple_second_language_combo)
+        _prevent_scroll_on_hover(self.simple_second_language_combo)
+        for language_id, info in SUPPORTED_LANGUAGES.items():
+            if language_id != "auto":
+                self.simple_second_language_combo.append(language_id, info["name"])
+        _attach_language_combo_search(self.simple_second_language_combo)
+        second_entry = self.simple_second_language_combo.get_child()
+        if second_entry is not None:
+            second_entry.connect("activate", self._on_simple_choice_changed)
+        self.simple_second_language_row = PreferenceRow(
+            title="Other language",
+            # Honest about what the engine does: whisper takes one language or
+            # none, so naming a second one switches decoding to detection.
+            subtitle="Recognition switches to automatic detection so both work",
+            widget=self.simple_second_language_combo,
+            keywords=("second", "language", "other"),
+        )
+        self.simple_second_language_row.set_no_show_all(True)
+        self.simple_group.add_row(self.simple_second_language_row)
+
         self.simple_priority_combo = Gtk.ComboBoxText()
         _style_combo(self.simple_priority_combo)
         _prevent_scroll_on_hover(self.simple_priority_combo)
@@ -2910,27 +2929,28 @@ class SettingsDialog(Gtk.Dialog):
         )
         self.simple_group.add_row(self.simple_priority_row)
 
-        # Advanced is an addition, not a separate mode: the detailed controls slide
-        # out underneath and keep showing what the simple answers resolved to.
-        self.advanced_toggle = Gtk.Switch()
-        self.advanced_toggle.set_valign(Gtk.Align.CENTER)
+        self.advanced_button = Gtk.Button(label="Open…")
+        self.advanced_button.set_valign(Gtk.Align.CENTER)
+        self.advanced_button.set_size_request(_ACTION_WIDTH, -1)
+        self.advanced_button.set_halign(Gtk.Align.END)
         self.advanced_row = PreferenceRow(
             title="Advanced",
-            subtitle="Show engine, model size and specialization",
-            widget=self.advanced_toggle,
+            subtitle="Engine, model size, specialization and the rest, in their own window",
+            widget=self.advanced_button,
             keywords=("advanced", "engine", "model", "specialization"),
         )
         self.simple_group.add_row(self.advanced_row)
 
         self.content_box.pack_start(self.simple_group, False, False, 0)
 
-        self.advanced_revealer = Gtk.Revealer()
-        self.advanced_revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN)
-        self.advanced_revealer.set_transition_duration(200)
-        self.content_box.pack_start(self.advanced_revealer, False, False, 0)
+        # Everything the detailed view holds is packed in here instead of into the
+        # page, and this box becomes the content of the advanced window.
+        self.advanced_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        self.advanced_box.set_border_width(12)
 
-        self.advanced_toggle.connect("notify::active", self._on_advanced_toggled)
+        self.advanced_button.connect("clicked", self._on_open_advanced_window)
         self.simple_language_combo.connect("changed", self._on_simple_choice_changed)
+        self.simple_second_language_combo.connect("changed", self._on_simple_choice_changed)
         self.simple_multi_switch.connect("notify::active", self._on_simple_choice_changed)
         self.simple_priority_combo.connect("changed", self._on_simple_choice_changed)
 
@@ -2995,7 +3015,7 @@ class SettingsDialog(Gtk.Dialog):
         group.add_row(self.language_row)
 
         # Lives inside the revealer built above, so the Advanced switch slides it out.
-        self.advanced_revealer.add(group)
+        self.advanced_box.pack_start(group, False, False, 0)
 
         # Model info card (shown below the group)
         self.model_info_card = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
@@ -3023,7 +3043,7 @@ class SettingsDialog(Gtk.Dialog):
         self.language_warning.set_no_show_all(True)
         self.model_info_card.pack_start(self.language_warning, False, False, 0)
 
-        self.content_box.pack_start(self.model_info_card, False, False, 0)
+        self.advanced_box.pack_start(self.model_info_card, False, False, 0)
 
         self.unused_models_group = PreferencesGroup(
             keywords=("delete", "remove", "unused", "disk", "storage", "downloaded"),
@@ -3062,7 +3082,7 @@ class SettingsDialog(Gtk.Dialog):
             "notify::expanded", lambda *_args: self._fit_unused_downloads_height()
         )
         self.unused_models_group.pack_start(self.unused_expander, False, False, 0)
-        self.content_box.pack_start(self.unused_models_group, False, False, 0)
+        self.advanced_box.pack_start(self.unused_models_group, False, False, 0)
 
         # Connect signals
         self.engine_combo.connect("changed", self._on_engine_changed)
@@ -4623,14 +4643,14 @@ class SettingsDialog(Gtk.Dialog):
         )
         self.remote_server_group.add_row(remote_test_row)
 
-        self.content_box.pack_start(self.remote_server_group, False, False, 0)
+        self.advanced_box.pack_start(self.remote_server_group, False, False, 0)
 
         # Status label below the group
         self.remote_status_label = Gtk.Label(label="", use_markup=True, xalign=0)
         self.remote_status_label.set_margin_start(16)
         self.remote_status_label.set_margin_top(4)
         self.remote_status_label.get_style_context().add_class("status-info")
-        self.content_box.pack_start(self.remote_status_label, False, False, 0)
+        self.advanced_box.pack_start(self.remote_status_label, False, False, 0)
 
         # Load saved values into the widgets
         saved_url = self.config_manager.get("speech_recognition", "remote_api_url", "")
@@ -5549,13 +5569,17 @@ class SettingsDialog(Gtk.Dialog):
         language = self.language_combo.get_active_id() or self.language or "auto"
         is_auto = language == "auto"
 
+        stored_second = self.config_manager.get("speech_recognition", "simple_second_language", "")
+
         self._simple_syncing = True
         try:
-            self.simple_multi_switch.set_active(is_auto)
+            self.simple_multi_switch.set_active(is_auto or bool(stored_second))
             if not is_auto:
                 self.simple_language_combo.set_active_id(language)
             elif not self.simple_language_combo.get_active_id():
                 self.simple_language_combo.set_active_id("en-us")
+            if stored_second:
+                self.simple_second_language_combo.set_active_id(stored_second)
 
             recommended, _ = self._get_recommended_whispercpp_model_for_language()
             current = self._get_selected_whispercpp_model()
@@ -5566,6 +5590,25 @@ class SettingsDialog(Gtk.Dialog):
         finally:
             self._simple_syncing = False
 
+    def _simple_decoding_language(self) -> str:
+        """Resolve the two simple language answers into what the engine accepts.
+
+        whisper takes one language or none, so naming a second language has to mean
+        automatic detection. The one exception is two English entries — en-US plus
+        en-IN, say — where English can still be pinned and the English-only weights,
+        which are the same size and better at English, stay available.
+        """
+        primary = self.simple_language_combo.get_active_id() or "en-us"
+        if not self.simple_multi_switch.get_active():
+            return primary
+
+        secondary = self.simple_second_language_combo.get_active_id()
+        if not secondary or secondary == primary:
+            return primary
+        if _language_is_english(primary) and _language_is_english(secondary):
+            return primary
+        return "auto"
+
     def _apply_simple_choice(self):
         """Drive the advanced controls from the simple questions.
 
@@ -5573,11 +5616,7 @@ class SettingsDialog(Gtk.Dialog):
         configuration itself, so applying, downloading and the info card keep going
         through exactly one code path.
         """
-        language = (
-            "auto"
-            if self.simple_multi_switch.get_active()
-            else (self.simple_language_combo.get_active_id() or "en-us")
-        )
+        language = self._simple_decoding_language()
         priority = self.simple_priority_combo.get_active_id() or BALANCED
 
         self.engine_combo.set_active_id("whisper_cpp")
@@ -5592,14 +5631,31 @@ class SettingsDialog(Gtk.Dialog):
         self._populate_whispercpp_variant_options(size, variant)
         self.model_variant_combo.set_active_id(variant)
 
-    def _on_advanced_toggled(self, *_args):
-        """Slide the detailed controls in or out and remember the choice."""
-        if self._initializing:
-            return
-        expanded = self.advanced_toggle.get_active()
-        self.config_manager.set("speech_recognition", "show_advanced", expanded)
-        self.config_manager.save_settings()
-        self._update_advanced_visibility()
+    def _on_open_advanced_window(self, _button):
+        """Open the detailed controls in their own window."""
+        if self.advanced_window is None:
+            window = Gtk.Window(title="Advanced speech model settings")
+            window.set_transient_for(self)
+            window.set_default_size(680, 720)
+            scroller = Gtk.ScrolledWindow()
+            scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+            scroller.add(self.advanced_box)
+            window.add(scroller)
+            # Keep the widgets alive: closing must hide, not destroy, or reopening
+            # would find the controls gone.
+            window.connect("delete-event", self._on_advanced_window_close)
+            self.advanced_window = window
+
+        self.advanced_window.show_all()
+        # Per-engine visibility has to run after show_all, which would otherwise
+        # reveal rows the active engine does not use.
+        self._update_engine_specific_ui()
+        self.advanced_window.present()
+
+    def _on_advanced_window_close(self, window, _event):
+        """Hide the advanced window instead of destroying its widgets."""
+        window.hide()
+        return True
 
     def _on_simple_choice_changed(self, *_args):
         """React to one of the simple questions changing.
@@ -5620,6 +5676,13 @@ class SettingsDialog(Gtk.Dialog):
         finally:
             self._simple_driving = False
 
+        second = (
+            self.simple_second_language_combo.get_active_id()
+            if self.simple_multi_switch.get_active()
+            else ""
+        )
+        self.config_manager.set("speech_recognition", "simple_second_language", second or "")
+        self._update_simple_visibility()
         self._auto_apply_settings()
 
     def _commit_or_restore_simple_language_entry(self) -> bool:
@@ -5651,18 +5714,14 @@ class SettingsDialog(Gtk.Dialog):
     def _on_simple_language_entry_focus_out(self, _entry, _event):
         return self._commit_or_restore_simple_language_entry()
 
-    def _update_advanced_visibility(self):
-        """Reveal or hide the detailed controls.
-
-        The simple questions stay on screen either way: Advanced adds detail rather
-        than replacing the summary, so the detailed rows double as a readout of what
-        the simple answers resolved to.
-        """
+    def _update_simple_visibility(self):
+        """Show the simple questions, with the second language only when asked for."""
         self.simple_group.show_all()
-        expanded = self.advanced_toggle.get_active()
-        if expanded:
-            self.engine_group.show_all()
-        self.advanced_revealer.set_reveal_child(expanded)
+        wants_second = self.simple_multi_switch.get_active()
+        if wants_second:
+            self.simple_second_language_row.show_all()
+        else:
+            self.simple_second_language_row.hide()
 
     def _update_engine_specific_ui(self):
         """Show/hide UI elements driven by the active engine."""
@@ -5686,7 +5745,7 @@ class SettingsDialog(Gtk.Dialog):
             self.remote_server_group.hide()
             self.remote_status_label.hide()
 
-        self._update_advanced_visibility()
+        self._update_simple_visibility()
 
         self._update_model_info()
         self._refresh_unused_downloads()

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -5647,6 +5647,36 @@ class SettingsDialog(Gtk.Dialog):
             return primary
         return "auto"
 
+    def _on_disk_stand_in(self, variant: str, size: str, language: str) -> str:
+        """Prefer a downloaded weight of the same size over fetching a sibling.
+
+        Flipping the "other languages" switch swapped base for base.en, or back:
+        same size, different weights, and a modal download each way, blocking the
+        window for it. A same-size weight already on disk that can serve the
+        language stands in instead; the info card still offers the better variant
+        as a download, it just no longer forces it.
+        """
+        if is_whispercpp_model_downloaded(variant):
+            return variant
+        wants_english = _language_is_english(language)
+        candidates = [
+            name
+            for name in get_whispercpp_model_variants(size)
+            if is_whispercpp_model_downloaded(name)
+            and (wants_english or not is_english_only_whispercpp_model(name))
+        ]
+        if not candidates:
+            return variant
+
+        def rank(name: str) -> tuple:
+            # Closest to what was derived: English-only first when English is
+            # wanted, the plain multilingual next, quantized ones last.
+            english_first = 0 if wants_english and is_english_only_whispercpp_model(name) else 1
+            quantized = 1 if "-q" in name else 0
+            return (english_first, quantized, name)
+
+        return min(candidates, key=rank)
+
     def _apply_simple_choice(self):
         """Drive the advanced controls from the simple questions.
 
@@ -5664,6 +5694,7 @@ class SettingsDialog(Gtk.Dialog):
         recommended, _ = self._get_recommended_whispercpp_model_for_language()
         size = size_for_priority(get_whispercpp_model_size(recommended), priority)
         variant = _default_whispercpp_variant_for_size(size, language) or size
+        variant = self._on_disk_stand_in(variant, size, language)
 
         self.model_combo.set_active_id(size)
         self._populate_whispercpp_variant_options(size, variant)

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1048,7 +1048,7 @@ class SearchablePicker(Gtk.Box):
 
     _LIST_HEIGHT = 300
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
         self.base_model = []
         self._active_id = None
@@ -1093,7 +1093,7 @@ class SearchablePicker(Gtk.Box):
 
     # -- GtkComboBoxText-compatible surface --------------------------------
 
-    def append(self, item_id, text):
+    def append(self, item_id: str, text: str) -> None:
         """Add a row, taking the arguments in GtkComboBoxText order."""
         self.base_model.append([text, item_id])
         row = Gtk.ListBoxRow()
@@ -1109,7 +1109,7 @@ class SearchablePicker(Gtk.Box):
         self._list.add(row)
         self._rows_by_id[item_id] = row
 
-    def remove_all(self):
+    def remove_all(self) -> None:
         self.base_model.clear()
         self._rows_by_id.clear()
         for row in list(self._list.get_children()):
@@ -1117,29 +1117,29 @@ class SearchablePicker(Gtk.Box):
         self._active_id = None
         self._label.set_text("")
 
-    def get_model(self):
+    def get_model(self) -> list:
         return self.base_model
 
-    def get_active_id(self):
+    def get_active_id(self) -> Optional[str]:
         return self._active_id
 
-    def get_active_text(self):
+    def get_active_text(self) -> Optional[str]:
         row = self._rows_by_id.get(self._active_id)
         return row.item_text if row is not None else None
 
-    def set_active_id(self, item_id) -> bool:
+    def set_active_id(self, item_id: Optional[str]) -> bool:
         row = self._rows_by_id.get(item_id)
         if row is None:
             return False
         self._select(item_id, row.item_text)
         return True
 
-    def set_active(self, index):
+    def set_active(self, index: int) -> None:
         if 0 <= index < len(self.base_model):
             text, item_id = self.base_model[index]
             self._select(item_id, text)
 
-    def get_child(self):
+    def get_child(self) -> Gtk.SearchEntry:
         """The search entry, for callers that hook a ComboBoxText's entry."""
         return self._search
 
@@ -2910,9 +2910,8 @@ class SettingsDialog(Gtk.Dialog):
             if language_id != "auto":
                 self.simple_second_language_combo.append(language_id, info["name"])
         _attach_language_combo_search(self.simple_second_language_combo)
-        second_entry = self.simple_second_language_combo.get_child()
-        if second_entry is not None:
-            second_entry.connect("activate", self._on_simple_choice_changed)
+        # SearchablePicker already emits "changed" on Enter/row pick; do not also
+        # hook activate or a single choice would apply twice.
         self.simple_second_language_row = PreferenceRow(
             title="Other language",
             # Honest about what the engine does: whisper takes one language or
@@ -5558,6 +5557,9 @@ class SettingsDialog(Gtk.Dialog):
             self.language = lang_code
             self._populate_model_options()
             self._update_language_warning()
+            # Drop stale simple multi widgets / persisted second when Advanced
+            # pins a language (skipped while simple mode is itself steering).
+            self._refresh_simple_readout()
             self._auto_apply_settings()
         finally:
             self._processing_language_change = False
@@ -5592,11 +5594,15 @@ class SettingsDialog(Gtk.Dialog):
             self._processing_language_change = False
         return False
 
-    def _sync_simple_from_advanced(self):
+    def _sync_simple_from_advanced(self) -> None:
         """Point the simple questions at the configuration that is actually live.
 
         Switching modes must not change the model on its own, so the priority is
         read back from the size already chosen rather than reset to a default.
+
+        A pinned Advanced language must win over a leftover simple multi answer:
+        restoring the switch and ``simple_second_language`` would make the next
+        simple edit decode to auto and silently replace the pin.
         """
         language = self.language_combo.get_active_id() or self.language or "auto"
         is_auto = language == "auto"
@@ -5605,15 +5611,22 @@ class SettingsDialog(Gtk.Dialog):
 
         self._simple_syncing = True
         try:
-            self.simple_multi_switch.set_active(is_auto or bool(stored_second))
-            if not is_auto:
+            if is_auto:
+                self.simple_multi_switch.set_active(True)
+                if not self.simple_language_combo.get_active_id():
+                    self.simple_language_combo.set_active_id("en-us")
+                if stored_second:
+                    self.simple_second_language_combo.set_active_id(stored_second)
+                else:
+                    # Detection with no named second language is the "any" answer.
+                    self.simple_second_language_combo.set_active_id("auto")
+            else:
+                self.simple_multi_switch.set_active(False)
                 self.simple_language_combo.set_active_id(language)
-            elif not self.simple_language_combo.get_active_id():
-                self.simple_language_combo.set_active_id("en-us")
-            if stored_second:
-                self.simple_second_language_combo.set_active_id(stored_second)
-            elif is_auto:
-                # Detection with no named second language is the "any" answer.
+                if stored_second:
+                    self.config_manager.set("speech_recognition", "simple_second_language", "")
+                # Reset so turning the switch on later starts from "any", not a
+                # stale pick that Advanced already superseded.
                 self.simple_second_language_combo.set_active_id("auto")
 
             recommended, _ = self._get_recommended_whispercpp_model_for_language()
@@ -5677,7 +5690,7 @@ class SettingsDialog(Gtk.Dialog):
 
         return min(candidates, key=rank)
 
-    def _apply_simple_choice(self):
+    def _apply_simple_choice(self) -> None:
         """Drive the advanced controls from the simple questions.
 
         Simple mode deliberately steers the existing widgets instead of writing the
@@ -5700,7 +5713,7 @@ class SettingsDialog(Gtk.Dialog):
         self._populate_whispercpp_variant_options(size, variant)
         self.model_variant_combo.set_active_id(variant)
 
-    def _on_advanced_expanded(self, expander, _param):
+    def _on_advanced_expanded(self, expander, _param) -> None:
         """Expand or collapse the advanced island, remembering the choice."""
         expanded = expander.get_expanded()
         if expanded:
@@ -5714,7 +5727,7 @@ class SettingsDialog(Gtk.Dialog):
             self.config_manager.set("speech_recognition", "show_advanced", expanded)
             self.config_manager.save_settings()
 
-    def _refresh_simple_readout(self):
+    def _refresh_simple_readout(self) -> None:
         """Keep the simple answers describing the live model.
 
         With both cards on screen, a change made in the advanced rows has to show
@@ -5725,7 +5738,7 @@ class SettingsDialog(Gtk.Dialog):
             return
         self._sync_simple_from_advanced()
 
-    def _on_simple_choice_changed(self, *_args):
+    def _on_simple_choice_changed(self, *_args) -> None:
         """React to one of the simple questions changing.
 
         Driving the four advanced controls emits "changed" on each of them, and
@@ -5794,7 +5807,7 @@ class SettingsDialog(Gtk.Dialog):
     def _on_simple_language_entry_focus_out(self, _entry, _event):
         return self._commit_or_restore_simple_language_entry()
 
-    def _update_simple_visibility(self):
+    def _update_simple_visibility(self) -> None:
         """Show the simple questions, with the second language only when asked for."""
         self.simple_group.show_all()
         wants_second = self.simple_multi_switch.get_active()

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -30,7 +30,7 @@ import gi
 gi.require_version("Gtk", "3.0")
 gi.require_version("Gdk", "3.0")
 # Need GLib for idle_add
-from gi.repository import Gdk, GLib, Gtk, Pango  # noqa: E402
+from gi.repository import Gdk, GLib, GObject, Gtk, Pango  # noqa: E402
 
 from ..common_types import RecognitionState  # noqa: E402
 from ..speech_recognition.silero_vad import is_silero_available  # noqa: E402
@@ -290,6 +290,8 @@ def _style_combo(combo: Gtk.ComboBox, width: int = _CONTROL_WIDTH) -> Gtk.ComboB
     combo.set_size_request(width, -1)
     combo.set_halign(Gtk.Align.END)
     combo.set_hexpand(False)
+    if not isinstance(combo, Gtk.ComboBox):
+        return combo  # a SearchablePicker sizes its own button
     combo.set_popup_fixed_width(False)
     for cell in combo.get_cells():
         cell.set_property("ellipsize", Pango.EllipsizeMode.END)
@@ -1005,7 +1007,9 @@ def _combo_text_rows(combo: Gtk.ComboBoxText) -> list:
 
     Gtk.ComboBoxText stores display text in column 0 and the id in column 1.
     """
-    model = combo.get_model()
+    # A SearchablePicker keeps its rows in base_model (ComboBoxText column order);
+    # resolve typed text against every row, not only the ones currently shown.
+    model = getattr(combo, "base_model", None) or combo.get_model()
     if not model:
         return []
     return [(row[1], row[0]) for row in model]
@@ -1020,14 +1024,174 @@ def _combo_completion_match(completion, key, tree_iter, *_args) -> bool:
     return _combo_text_matches_query(key, row[1], row[0])
 
 
+class SearchablePicker(Gtk.Box):
+    """A picker you can type into while its list is open.
+
+    A GtkComboBox dropdown takes the keyboard for its own first-letter jump the
+    moment it opens, so nothing typed reaches a filter. This one opens a popover
+    holding a search entry, focused on open, above the list; every keystroke
+    narrows the rows, Enter takes the first match, a click takes that row.
+
+    Keeps the handful of GtkComboBoxText methods the dialog relies on, so it
+    drops in where one stood. ``base_model`` mirrors the ComboBoxText store —
+    display text in column 0, id in column 1 — for the shared row helpers.
+    """
+
+    __gsignals__ = {"changed": (GObject.SignalFlags.RUN_FIRST, None, ())}
+
+    _LIST_HEIGHT = 300
+
+    def __init__(self):
+        super().__init__(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+        self.base_model = []
+        self._active_id = None
+        self._rows_by_id = {}
+
+        self._label = Gtk.Label(xalign=0)
+        self._label.set_ellipsize(Pango.EllipsizeMode.END)
+        arrow = Gtk.Image.new_from_icon_name("pan-down-symbolic", Gtk.IconSize.BUTTON)
+        button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        button_box.pack_start(self._label, True, True, 0)
+        button_box.pack_end(arrow, False, False, 0)
+        self._button = Gtk.Button()
+        self._button.add(button_box)
+        self._button.connect("clicked", self._on_button_clicked)
+        self.pack_start(self._button, True, True, 0)
+
+        self._search = Gtk.SearchEntry()
+        self._search.set_placeholder_text("Type to search…")
+        self._search.connect("search-changed", self._on_search_changed)
+        self._search.connect("activate", self._on_search_activate)
+
+        self._list = Gtk.ListBox()
+        self._list.set_selection_mode(Gtk.SelectionMode.NONE)
+        self._list.set_filter_func(self._row_is_visible)
+        self._list.connect("row-activated", self._on_row_activated)
+
+        scroller = Gtk.ScrolledWindow()
+        scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroller.set_size_request(-1, self._LIST_HEIGHT)
+        scroller.add(self._list)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        content.set_border_width(6)
+        content.pack_start(self._search, False, False, 0)
+        content.pack_start(scroller, True, True, 0)
+        content.show_all()
+
+        self._popover = Gtk.Popover.new(self._button)
+        self._popover.set_position(Gtk.PositionType.BOTTOM)
+        self._popover.add(content)
+        self._popover.connect("closed", self._on_popover_closed)
+
+    # -- GtkComboBoxText-compatible surface --------------------------------
+
+    def append(self, item_id, text):
+        """Add a row, taking the arguments in GtkComboBoxText order."""
+        self.base_model.append([text, item_id])
+        row = Gtk.ListBoxRow()
+        label = Gtk.Label(label=text, xalign=0)
+        label.set_margin_top(6)
+        label.set_margin_bottom(6)
+        label.set_margin_start(8)
+        label.set_margin_end(8)
+        row.add(label)
+        row.item_id = item_id
+        row.item_text = text
+        row.show_all()
+        self._list.add(row)
+        self._rows_by_id[item_id] = row
+
+    def remove_all(self):
+        self.base_model.clear()
+        self._rows_by_id.clear()
+        for row in list(self._list.get_children()):
+            self._list.remove(row)
+        self._active_id = None
+        self._label.set_text("")
+
+    def get_model(self):
+        return self.base_model
+
+    def get_active_id(self):
+        return self._active_id
+
+    def get_active_text(self):
+        row = self._rows_by_id.get(self._active_id)
+        return row.item_text if row is not None else None
+
+    def set_active_id(self, item_id) -> bool:
+        row = self._rows_by_id.get(item_id)
+        if row is None:
+            return False
+        self._select(item_id, row.item_text)
+        return True
+
+    def set_active(self, index):
+        if 0 <= index < len(self.base_model):
+            text, item_id = self.base_model[index]
+            self._select(item_id, text)
+
+    def get_child(self):
+        """The search entry, for callers that hook a ComboBoxText's entry."""
+        return self._search
+
+    # -- behaviour ---------------------------------------------------------
+
+    def _select(self, item_id, text):
+        changed = item_id != self._active_id
+        self._active_id = item_id
+        self._label.set_text(text or "")
+        if changed:
+            self.emit("changed")
+
+    def _on_button_clicked(self, _button):
+        self._search.set_text("")
+        self._list.invalidate_filter()
+        self._popover.show_all()
+        self._popover.popup()
+        self._search.grab_focus()
+
+    def _on_popover_closed(self, _popover):
+        self._search.set_text("")
+        self._list.invalidate_filter()
+
+    def _row_is_visible(self, row):
+        needle = (self._search.get_text() or "").strip()
+        if not needle:
+            return True
+        # Same rule the typed-text resolver uses, so the list and Enter agree.
+        return _combo_text_matches_query(needle, row.item_id, row.item_text)
+
+    def _on_search_changed(self, _entry):
+        self._list.invalidate_filter()
+
+    def _first_visible_row(self):
+        for row in self._list.get_children():
+            if row.get_visible() and row.get_child_visible() and self._row_is_visible(row):
+                return row
+        return None
+
+    def _on_search_activate(self, _entry):
+        row = self._first_visible_row()
+        if row is not None:
+            self._on_row_activated(self._list, row)
+
+    def _on_row_activated(self, _listbox, row):
+        self._popover.popdown()
+        self._select(row.item_id, row.item_text)
+
+
 def _attach_language_combo_search(combo: Gtk.ComboBoxText) -> None:
     """Filter language choices as the user types in a ComboBoxText entry."""
+    if isinstance(combo, SearchablePicker):
+        return  # the picker filters its own list; a completion popup would fight it
     entry = combo.get_child()
     if entry is None:
         return
     entry.set_placeholder_text("Search languages…")
     completion = Gtk.EntryCompletion()
-    completion.set_model(combo.get_model())
+    completion.set_model(getattr(combo, "base_model", None) or combo.get_model())
     # ComboBoxText store: column 0 is display text, column 1 is id.
     completion.set_text_column(0)
     completion.set_inline_completion(False)
@@ -2710,7 +2874,7 @@ class SettingsDialog(Gtk.Dialog):
         group.add_row(self.model_variant_row)
 
         # Language selection (searchable: type to filter the 30+ language list)
-        self.language_combo = Gtk.ComboBoxText.new_with_entry()
+        self.language_combo = SearchablePicker()
         _style_combo(self.language_combo)
         self.language_combo.set_tooltip_text(LANGUAGE_TOOLTIP)
         _prevent_scroll_on_hover(self.language_combo)

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1842,6 +1842,9 @@ class SettingsDialog(Gtk.Dialog):
         # Guards the simple-mode widgets while they are being pointed at the
         # live configuration, so syncing them does not look like a user edit.
         self._simple_syncing = False
+        # Set while simple mode steers the advanced controls, so their own change
+        # handlers do not each trigger a separate engine reload.
+        self._simple_driving = False
         self.settings_mode_combo = None
         self.simple_group = None
         self.engine_group = None
@@ -2874,16 +2877,25 @@ class SettingsDialog(Gtk.Dialog):
 
         self.simple_group = PreferencesGroup(title="What you dictate")
 
-        self.simple_language_combo = Gtk.ComboBoxText()
+        # Searchable, like the advanced row: over thirty languages is too many to
+        # scroll, and a list you cannot type into is a step backwards.
+        self.simple_language_combo = Gtk.ComboBoxText.new_with_entry()
         _style_combo(self.simple_language_combo)
         _prevent_scroll_on_hover(self.simple_language_combo)
         for language_id, info in SUPPORTED_LANGUAGES.items():
             # Auto-detect is the switch below, not a language you speak.
             if language_id != "auto":
                 self.simple_language_combo.append(language_id, info["name"])
+        _attach_language_combo_search(self.simple_language_combo)
+        simple_language_entry = self.simple_language_combo.get_child()
+        if simple_language_entry is not None:
+            simple_language_entry.connect("activate", self._on_simple_language_entry_activate)
+            simple_language_entry.connect(
+                "focus-out-event", self._on_simple_language_entry_focus_out
+            )
         self.simple_language_row = PreferenceRow(
             title="Main language",
-            subtitle="The language you speak most of the time",
+            subtitle="Type to search, or pick from the list",
             widget=self.simple_language_combo,
             keywords=("language", "speak"),
         )
@@ -5595,11 +5607,54 @@ class SettingsDialog(Gtk.Dialog):
         self._update_settings_mode_visibility()
 
     def _on_simple_choice_changed(self, *_args):
-        """React to one of the simple questions changing."""
+        """React to one of the simple questions changing.
+
+        Driving the four advanced controls emits "changed" on each of them, and
+        every one of those handlers ends in _auto_apply_settings, so a single pick
+        used to reconfigure the engine up to four times and freeze the window while
+        each reload ran. Suppress those while steering, then apply exactly once.
+        """
         if self._initializing or self._simple_syncing or self._applying_settings:
             return
-        self._apply_simple_choice()
+        if self._simple_driving:
+            return
+
+        self._simple_driving = True
+        try:
+            self._apply_simple_choice()
+        finally:
+            self._simple_driving = False
+
         self._auto_apply_settings()
+
+    def _commit_or_restore_simple_language_entry(self) -> bool:
+        """Resolve text typed into the simple language box, or restore the last pick."""
+        if self._initializing or self._simple_syncing:
+            return False
+        if self.simple_language_combo.get_active_id():
+            return False
+
+        entry = self.simple_language_combo.get_child()
+        typed = entry.get_text() if entry is not None else ""
+        match_id = _resolve_combo_text_query(typed, _combo_text_rows(self.simple_language_combo))
+        if match_id:
+            self.simple_language_combo.set_active_id(match_id)
+            return False
+
+        # Restoring the same language must not re-apply settings.
+        self._simple_syncing = True
+        try:
+            fallback = self.language if self.language != "auto" else "en-us"
+            self._set_combo_active_id_or_first(self.simple_language_combo, fallback)
+        finally:
+            self._simple_syncing = False
+        return False
+
+    def _on_simple_language_entry_activate(self, _entry):
+        self._commit_or_restore_simple_language_entry()
+
+    def _on_simple_language_entry_focus_out(self, _entry, _event):
+        return self._commit_or_restore_simple_language_entry()
 
     def _update_settings_mode_visibility(self):
         """Show the group the active mode calls for."""
@@ -5751,6 +5806,11 @@ class SettingsDialog(Gtk.Dialog):
             return
 
         if self._populating_models:
+            return
+
+        # Simple mode is mid-way through steering the advanced controls; it applies
+        # once itself when it is done.
+        if self._simple_driving:
             return
 
         self._applying_settings = True

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -2861,7 +2861,7 @@ class SettingsDialog(Gtk.Dialog):
 
         # Searchable, like the advanced row: over thirty languages is too many to
         # scroll, and a list you cannot type into is a step backwards.
-        self.simple_language_combo = SearchableComboBox()
+        self.simple_language_combo = SearchablePicker()
         _style_combo(self.simple_language_combo)
         _prevent_scroll_on_hover(self.simple_language_combo)
         for language_id, info in SUPPORTED_LANGUAGES.items():
@@ -2895,9 +2895,13 @@ class SettingsDialog(Gtk.Dialog):
         )
         self.simple_group.add_row(self.simple_multi_row)
 
-        self.simple_second_language_combo = SearchableComboBox()
+        self.simple_second_language_combo = SearchablePicker()
         _style_combo(self.simple_second_language_combo)
         _prevent_scroll_on_hover(self.simple_second_language_combo)
+        # First entry is the multilingual answer: any language, detected per
+        # utterance. Naming one specific second language means the same thing
+        # to the engine, but lets the user say which one they had in mind.
+        self.simple_second_language_combo.append("auto", "Any language (auto-detect)")
         for language_id, info in SUPPORTED_LANGUAGES.items():
             if language_id != "auto":
                 self.simple_second_language_combo.append(language_id, info["name"])
@@ -2908,8 +2912,8 @@ class SettingsDialog(Gtk.Dialog):
         self.simple_second_language_row = PreferenceRow(
             title="Other language",
             # Honest about what the engine does: whisper takes one language or
-            # none, so naming a second one switches decoding to detection.
-            subtitle="Recognition switches to automatic detection so both work",
+            # none, so any second language means detection per utterance.
+            subtitle="Recognition detects the language of each utterance",
             widget=self.simple_second_language_combo,
             keywords=("second", "language", "other"),
         )
@@ -3043,7 +3047,9 @@ class SettingsDialog(Gtk.Dialog):
         self.language_warning.set_no_show_all(True)
         self.model_info_card.pack_start(self.language_warning, False, False, 0)
 
-        self.advanced_box.pack_start(self.model_info_card, False, False, 0)
+        # On the page, under the simple questions: it is the only feedback that a
+        # priority or language change did anything, and what it will cost.
+        self.content_box.pack_start(self.model_info_card, False, False, 0)
 
         self.unused_models_group = PreferencesGroup(
             keywords=("delete", "remove", "unused", "disk", "storage", "downloaded"),
@@ -5580,6 +5586,9 @@ class SettingsDialog(Gtk.Dialog):
                 self.simple_language_combo.set_active_id("en-us")
             if stored_second:
                 self.simple_second_language_combo.set_active_id(stored_second)
+            elif is_auto:
+                # Detection with no named second language is the "any" answer.
+                self.simple_second_language_combo.set_active_id("auto")
 
             recommended, _ = self._get_recommended_whispercpp_model_for_language()
             current = self._get_selected_whispercpp_model()
@@ -5605,6 +5614,8 @@ class SettingsDialog(Gtk.Dialog):
         secondary = self.simple_second_language_combo.get_active_id()
         if not secondary or secondary == primary:
             return primary
+        if secondary == "auto":
+            return "auto"
         if _language_is_english(primary) and _language_is_english(secondary):
             return primary
         return "auto"
@@ -5632,29 +5643,41 @@ class SettingsDialog(Gtk.Dialog):
         self.model_variant_combo.set_active_id(variant)
 
     def _on_open_advanced_window(self, _button):
-        """Open the detailed controls in their own window."""
-        if self.advanced_window is None:
-            window = Gtk.Window(title="Advanced speech model settings")
-            window.set_transient_for(self)
-            window.set_default_size(680, 720)
-            scroller = Gtk.ScrolledWindow()
-            scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-            scroller.add(self.advanced_box)
-            window.add(scroller)
-            # Keep the widgets alive: closing must hide, not destroy, or reopening
-            # would find the controls gone.
-            window.connect("delete-event", self._on_advanced_window_close)
-            self.advanced_window = window
+        """Open the detailed controls in their own window.
 
-        self.advanced_window.show_all()
+        Built fresh on every open and torn down on close. The first version kept
+        one window alive, transient for this dialog, hidden on close and shown
+        again with present(); on KWin 6.7 (Wayland) that crashed the compositor
+        with unbounded recursion in KWin::Window::findModal(), i.e. a cycle in
+        its transient-for chain. Neither ingredient is needed: the window stands
+        on its own, and the controls are re-parented out before it is destroyed.
+        """
+        if self.advanced_window is not None:
+            self.advanced_window.present_with_time(Gdk.CURRENT_TIME)
+            return
+
+        window = Gtk.Window(title="Advanced speech model settings")
+        window.set_default_size(680, 720)
+        window.set_type_hint(Gdk.WindowTypeHint.NORMAL)
+        scroller = Gtk.ScrolledWindow()
+        scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroller.add(self.advanced_box)
+        window.add(scroller)
+        window.connect("delete-event", self._on_advanced_window_close)
+        self.advanced_window = window
+
+        window.show_all()
         # Per-engine visibility has to run after show_all, which would otherwise
         # reveal rows the active engine does not use.
         self._update_engine_specific_ui()
-        self.advanced_window.present()
 
     def _on_advanced_window_close(self, window, _event):
-        """Hide the advanced window instead of destroying its widgets."""
-        window.hide()
+        """Tear the window down, keeping the controls for the next open."""
+        parent = self.advanced_box.get_parent()
+        if parent is not None:
+            parent.remove(self.advanced_box)
+        self.advanced_window = None
+        window.destroy()
         return True
 
     def _on_simple_choice_changed(self, *_args):
@@ -5669,6 +5692,18 @@ class SettingsDialog(Gtk.Dialog):
             return
         if self._simple_driving:
             return
+
+        # Turning the switch on with nothing picked yet means "any language";
+        # otherwise the switch alone would visibly do nothing.
+        if (
+            self.simple_multi_switch.get_active()
+            and not self.simple_second_language_combo.get_active_id()
+        ):
+            self._simple_syncing = True
+            try:
+                self.simple_second_language_combo.set_active_id("auto")
+            finally:
+                self._simple_syncing = False
 
         self._simple_driving = True
         try:
@@ -5718,10 +5753,15 @@ class SettingsDialog(Gtk.Dialog):
         """Show the simple questions, with the second language only when asked for."""
         self.simple_group.show_all()
         wants_second = self.simple_multi_switch.get_active()
+        # show_all() is a no-op on a widget flagged no_show_all, so the flag has
+        # to be cleared before showing and restored after hiding — the same
+        # dance _set_custom_shortcut_row_visible does.
         if wants_second:
+            self.simple_second_language_row.set_no_show_all(False)
             self.simple_second_language_row.show_all()
         else:
             self.simple_second_language_row.hide()
+            self.simple_second_language_row.set_no_show_all(True)
 
     def _update_engine_specific_ui(self):
         """Show/hide UI elements driven by the active engine."""

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -34,6 +34,13 @@ from gi.repository import Gdk, GLib, GObject, Gtk, Pango  # noqa: E402
 
 from ..common_types import RecognitionState  # noqa: E402
 from ..speech_recognition.silero_vad import is_silero_available  # noqa: E402
+from ..utils.model_choice import (
+    BALANCED,
+    PRIORITIES,
+    PRIORITY_LABELS,
+    priority_for_size,
+    size_for_priority,
+)
 from ..utils.paths import models_dir  # noqa: E402
 from ..utils.update_checker import (  # noqa: E402
     DEFAULT_UPDATE_CHANNEL,
@@ -1832,6 +1839,12 @@ class SettingsDialog(Gtk.Dialog):
         self._test_result = ""
         self._initializing = True  # Flag to prevent auto-apply during initialization
         self._populating_models = False  # Flag to prevent model change handler during population
+        # Guards the simple-mode widgets while they are being pointed at the
+        # live configuration, so syncing them does not look like a user edit.
+        self._simple_syncing = False
+        self.settings_mode_combo = None
+        self.simple_group = None
+        self.engine_group = None
         self._processing_language_change = (
             False  # Flag to prevent recursive language change handling
         )
@@ -1946,6 +1959,7 @@ class SettingsDialog(Gtk.Dialog):
         # Build UI sections into their topic pages
         self._build_shortcuts_section()
         self._build_recognition_section()
+        self._build_settings_mode_section()
         self._build_engine_section()
         self._build_remote_server_section()
         self._build_audio_section()
@@ -1979,6 +1993,14 @@ class SettingsDialog(Gtk.Dialog):
             self.navigate_to_page(self._initial_page)
         else:
             self.sidebar_listbox.select_row(self.sidebar_listbox.get_row_at_index(0))
+
+        # Restore the saved mode and point the simple questions at the live model
+        # before the first visibility pass, so nothing flashes the wrong group.
+        saved_mode = self.config_manager.get("speech_recognition", "settings_mode", "simple")
+        self.settings_mode_combo.set_active_id(
+            saved_mode if saved_mode in ("simple", "advanced") else "simple"
+        )
+        self._sync_simple_from_advanced()
 
         # Then update visibility of engine-specific elements
         self._update_engine_specific_ui()
@@ -2832,9 +2854,77 @@ class SettingsDialog(Gtk.Dialog):
         self._tone_preview_kind = "stop" if kind == "start" else "start"
         self._sync_tone_preview_button(tone_id)
 
+    def _build_settings_mode_section(self):
+        """Build the mode switch and the simple-mode questions (#779)."""
+        mode_group = PreferencesGroup(title="Speech Model")
+
+        self.settings_mode_combo = Gtk.ComboBoxText()
+        _style_combo(self.settings_mode_combo)
+        _prevent_scroll_on_hover(self.settings_mode_combo)
+        self.settings_mode_combo.append("simple", "Simple")
+        self.settings_mode_combo.append("advanced", "Advanced")
+        mode_row = PreferenceRow(
+            title="Setup",
+            subtitle="Simple picks the model for you; Advanced exposes every control",
+            widget=self.settings_mode_combo,
+            keywords=("simple", "advanced", "mode"),
+        )
+        mode_group.add_row(mode_row)
+        self.content_box.pack_start(mode_group, False, False, 0)
+
+        self.simple_group = PreferencesGroup(title="What you dictate")
+
+        self.simple_language_combo = Gtk.ComboBoxText()
+        _style_combo(self.simple_language_combo)
+        _prevent_scroll_on_hover(self.simple_language_combo)
+        for language_id, info in SUPPORTED_LANGUAGES.items():
+            # Auto-detect is the switch below, not a language you speak.
+            if language_id != "auto":
+                self.simple_language_combo.append(language_id, info["name"])
+        self.simple_language_row = PreferenceRow(
+            title="Main language",
+            subtitle="The language you speak most of the time",
+            widget=self.simple_language_combo,
+            keywords=("language", "speak"),
+        )
+        self.simple_group.add_row(self.simple_language_row)
+
+        # The engine takes one language or none, so this is the only other option
+        # that exists. A second language field would promise something it cannot do.
+        self.simple_multi_switch = Gtk.Switch()
+        self.simple_multi_switch.set_valign(Gtk.Align.CENTER)
+        self.simple_multi_row = PreferenceRow(
+            title="I also dictate whole texts in other languages",
+            subtitle="Detects the language per utterance; can be wrong on short ones",
+            widget=self.simple_multi_switch,
+            keywords=("multilingual", "auto", "detect"),
+        )
+        self.simple_group.add_row(self.simple_multi_row)
+
+        self.simple_priority_combo = Gtk.ComboBoxText()
+        _style_combo(self.simple_priority_combo)
+        _prevent_scroll_on_hover(self.simple_priority_combo)
+        for priority in PRIORITIES:
+            self.simple_priority_combo.append(priority, PRIORITY_LABELS[priority])
+        self.simple_priority_row = PreferenceRow(
+            title="Priority",
+            subtitle="Balanced follows what your hardware can run",
+            widget=self.simple_priority_combo,
+            keywords=("speed", "accuracy", "priority"),
+        )
+        self.simple_group.add_row(self.simple_priority_row)
+
+        self.content_box.pack_start(self.simple_group, False, False, 0)
+
+        self.settings_mode_combo.connect("changed", self._on_settings_mode_changed)
+        self.simple_language_combo.connect("changed", self._on_simple_choice_changed)
+        self.simple_multi_switch.connect("notify::active", self._on_simple_choice_changed)
+        self.simple_priority_combo.connect("changed", self._on_simple_choice_changed)
+
     def _build_engine_section(self):
         """Build the Speech Engine section."""
         group = PreferencesGroup(title="Speech Engine")
+        self.engine_group = group
 
         # Engine selection
         self.engine_combo = Gtk.ComboBoxText()
@@ -5436,6 +5526,91 @@ class SettingsDialog(Gtk.Dialog):
             self._processing_language_change = False
         return False
 
+    def _get_settings_mode(self) -> str:
+        """Return the active mode, defaulting to simple."""
+        mode = self.settings_mode_combo.get_active_id() if self.settings_mode_combo else None
+        return mode if mode in ("simple", "advanced") else "simple"
+
+    def _sync_simple_from_advanced(self):
+        """Point the simple questions at the configuration that is actually live.
+
+        Switching modes must not change the model on its own, so the priority is
+        read back from the size already chosen rather than reset to a default.
+        """
+        language = self.language_combo.get_active_id() or self.language or "auto"
+        is_auto = language == "auto"
+
+        self._simple_syncing = True
+        try:
+            self.simple_multi_switch.set_active(is_auto)
+            if not is_auto:
+                self.simple_language_combo.set_active_id(language)
+            elif not self.simple_language_combo.get_active_id():
+                self.simple_language_combo.set_active_id("en-us")
+
+            recommended, _ = self._get_recommended_whispercpp_model_for_language()
+            current = self._get_selected_whispercpp_model()
+            priority = priority_for_size(
+                get_whispercpp_model_size(recommended), get_whispercpp_model_size(current)
+            )
+            self.simple_priority_combo.set_active_id(priority)
+        finally:
+            self._simple_syncing = False
+
+    def _apply_simple_choice(self):
+        """Drive the advanced controls from the simple questions.
+
+        Simple mode deliberately steers the existing widgets instead of writing the
+        configuration itself, so applying, downloading and the info card keep going
+        through exactly one code path.
+        """
+        language = (
+            "auto"
+            if self.simple_multi_switch.get_active()
+            else (self.simple_language_combo.get_active_id() or "en-us")
+        )
+        priority = self.simple_priority_combo.get_active_id() or BALANCED
+
+        self.engine_combo.set_active_id("whisper_cpp")
+        self._set_combo_active_id_or_first(self.language_combo, language)
+        self.language = language
+
+        recommended, _ = self._get_recommended_whispercpp_model_for_language()
+        size = size_for_priority(get_whispercpp_model_size(recommended), priority)
+        variant = _default_whispercpp_variant_for_size(size, language) or size
+
+        self.model_combo.set_active_id(size)
+        self._populate_whispercpp_variant_options(size, variant)
+        self.model_variant_combo.set_active_id(variant)
+
+    def _on_settings_mode_changed(self, _combo):
+        """Persist the mode and reshape the page."""
+        if self._initializing:
+            return
+        mode = self._get_settings_mode()
+        self.config_manager.set("speech_recognition", "settings_mode", mode)
+        self.config_manager.save_settings()
+        if mode == "simple":
+            self._sync_simple_from_advanced()
+        self._update_settings_mode_visibility()
+
+    def _on_simple_choice_changed(self, *_args):
+        """React to one of the simple questions changing."""
+        if self._initializing or self._simple_syncing or self._applying_settings:
+            return
+        self._apply_simple_choice()
+        self._auto_apply_settings()
+
+    def _update_settings_mode_visibility(self):
+        """Show the group the active mode calls for."""
+        simple = self._get_settings_mode() == "simple"
+        if simple:
+            self.simple_group.show_all()
+            self.engine_group.hide()
+        else:
+            self.simple_group.hide()
+            self.engine_group.show_all()
+
     def _update_engine_specific_ui(self):
         """Show/hide UI elements driven by the active engine."""
         engine_text = self.engine_combo.get_active_text()
@@ -5457,6 +5632,8 @@ class SettingsDialog(Gtk.Dialog):
                 self.model_variant_row.hide()
             self.remote_server_group.hide()
             self.remote_status_label.hide()
+
+        self._update_settings_mode_visibility()
 
         self._update_model_info()
         self._refresh_unused_downloads()

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -2861,7 +2861,7 @@ class SettingsDialog(Gtk.Dialog):
 
         # Searchable, like the advanced row: over thirty languages is too many to
         # scroll, and a list you cannot type into is a step backwards.
-        self.simple_language_combo = Gtk.ComboBoxText.new_with_entry()
+        self.simple_language_combo = SearchableComboBox()
         _style_combo(self.simple_language_combo)
         _prevent_scroll_on_hover(self.simple_language_combo)
         for language_id, info in SUPPORTED_LANGUAGES.items():
@@ -2895,7 +2895,7 @@ class SettingsDialog(Gtk.Dialog):
         )
         self.simple_group.add_row(self.simple_multi_row)
 
-        self.simple_second_language_combo = Gtk.ComboBoxText.new_with_entry()
+        self.simple_second_language_combo = SearchableComboBox()
         _style_combo(self.simple_second_language_combo)
         _prevent_scroll_on_hover(self.simple_second_language_combo)
         for language_id, info in SUPPORTED_LANGUAGES.items():

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -5653,7 +5653,7 @@ class SettingsDialog(Gtk.Dialog):
         on its own, and the controls are re-parented out before it is destroyed.
         """
         if self.advanced_window is not None:
-            self.advanced_window.present_with_time(Gdk.CURRENT_TIME)
+            self._raise_advanced_window()
             return
 
         window = Gtk.Window(title="Advanced speech model settings")
@@ -5670,6 +5670,23 @@ class SettingsDialog(Gtk.Dialog):
         # Per-engine visibility has to run after show_all, which would otherwise
         # reveal rows the active engine does not use.
         self._update_engine_specific_ui()
+        self._raise_advanced_window()
+
+    def _raise_advanced_window(self):
+        """Bring the advanced window above the dialog.
+
+        With no transient parent the compositor has no reason to stack it over
+        the dialog, and on Wayland a toplevel mapped without an activation token
+        lands behind the focused window. Presenting with the timestamp of the
+        click that opened it asks for both, and needs no transient link — which
+        is what crashed KWin (see _on_open_advanced_window).
+        """
+        if self.advanced_window is None:
+            return
+        timestamp = Gtk.get_current_event_time()
+        if not timestamp:
+            timestamp = Gdk.CURRENT_TIME
+        self.advanced_window.present_with_time(timestamp)
 
     def _on_advanced_window_close(self, window, _event):
         """Tear the window down, keeping the controls for the next open."""

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -5619,10 +5619,12 @@ class SettingsDialog(Gtk.Dialog):
         Switching modes must not change the model on its own, so the priority is
         read back from the size already chosen rather than reset to a default.
 
-        A leftover simple multi answer that would decode to auto must not be
-        restored over a pinned Advanced language: the next simple edit would
-        silently replace the pin. Two English answers still pin English, so
-        that configuration is kept.
+        A leftover simple multi answer is restored only when it still decodes
+        to the live Advanced language. Otherwise the next simple edit would
+        silently replace it: a named second language over a pin becomes auto,
+        and two English answers over Advanced auto pin English. Two English
+        answers still pin English, so that configuration is kept on an English
+        pin and dropped when Advanced is auto.
         """
         language = self.language_combo.get_active_id() or self.language or "auto"
         is_auto = language == "auto"
@@ -5633,28 +5635,29 @@ class SettingsDialog(Gtk.Dialog):
         try:
             if is_auto:
                 self.simple_multi_switch.set_active(True)
-                if not self.simple_language_combo.get_active_id():
+                primary = self.simple_language_combo.get_active_id()
+                if not primary:
                     self.simple_language_combo.set_active_id("en-us")
-                if stored_second:
-                    self.simple_second_language_combo.set_active_id(stored_second)
-                else:
-                    # Detection with no named second language is the "any" answer.
-                    self.simple_second_language_combo.set_active_id("auto")
+                    primary = "en-us"
             else:
                 self.simple_language_combo.set_active_id(language)
-                keeps_pin = bool(stored_second) and (
-                    _decode_simple_languages(language, True, stored_second) == language
-                )
-                if keeps_pin:
+                primary = language
+
+            keeps_live = bool(stored_second) and (
+                _decode_simple_languages(primary, True, stored_second) == language
+            )
+            if keeps_live:
+                if not is_auto:
                     self.simple_multi_switch.set_active(True)
-                    self.simple_second_language_combo.set_active_id(stored_second)
-                else:
+                self.simple_second_language_combo.set_active_id(stored_second)
+            else:
+                if not is_auto:
                     self.simple_multi_switch.set_active(False)
-                    if stored_second:
-                        self.config_manager.set("speech_recognition", "simple_second_language", "")
-                    # Reset so turning the switch on later starts from "any", not
-                    # a stale pick that Advanced already superseded.
-                    self.simple_second_language_combo.set_active_id("auto")
+                if stored_second:
+                    self.config_manager.set("speech_recognition", "simple_second_language", "")
+                # Reset so turning the switch on later starts from "any", not a
+                # stale pick that Advanced already superseded.
+                self.simple_second_language_combo.set_active_id("auto")
 
             recommended, _ = self._get_recommended_whispercpp_model_for_language()
             current = self._get_selected_whispercpp_model()

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1845,7 +1845,8 @@ class SettingsDialog(Gtk.Dialog):
         # Set while simple mode steers the advanced controls, so their own change
         # handlers do not each trigger a separate engine reload.
         self._simple_driving = False
-        self.settings_mode_combo = None
+        self.advanced_toggle = None
+        self.advanced_revealer = None
         self.simple_group = None
         self.engine_group = None
         self._processing_language_change = (
@@ -1962,7 +1963,7 @@ class SettingsDialog(Gtk.Dialog):
         # Build UI sections into their topic pages
         self._build_shortcuts_section()
         self._build_recognition_section()
-        self._build_settings_mode_section()
+        self._build_simple_model_section()
         self._build_engine_section()
         self._build_remote_server_section()
         self._build_audio_section()
@@ -1999,9 +2000,8 @@ class SettingsDialog(Gtk.Dialog):
 
         # Restore the saved mode and point the simple questions at the live model
         # before the first visibility pass, so nothing flashes the wrong group.
-        saved_mode = self.config_manager.get("speech_recognition", "settings_mode", "simple")
-        self.settings_mode_combo.set_active_id(
-            saved_mode if saved_mode in ("simple", "advanced") else "simple"
+        self.advanced_toggle.set_active(
+            bool(self.config_manager.get("speech_recognition", "show_advanced", False))
         )
         self._sync_simple_from_advanced()
 
@@ -2857,24 +2857,8 @@ class SettingsDialog(Gtk.Dialog):
         self._tone_preview_kind = "stop" if kind == "start" else "start"
         self._sync_tone_preview_button(tone_id)
 
-    def _build_settings_mode_section(self):
-        """Build the mode switch and the simple-mode questions (#779)."""
-        mode_group = PreferencesGroup(title="Speech Model")
-
-        self.settings_mode_combo = Gtk.ComboBoxText()
-        _style_combo(self.settings_mode_combo)
-        _prevent_scroll_on_hover(self.settings_mode_combo)
-        self.settings_mode_combo.append("simple", "Simple")
-        self.settings_mode_combo.append("advanced", "Advanced")
-        mode_row = PreferenceRow(
-            title="Setup",
-            subtitle="Simple picks the model for you; Advanced exposes every control",
-            widget=self.settings_mode_combo,
-            keywords=("simple", "advanced", "mode"),
-        )
-        mode_group.add_row(mode_row)
-        self.content_box.pack_start(mode_group, False, False, 0)
-
+    def _build_simple_model_section(self):
+        """Build the simple questions and the Advanced reveal (#779)."""
         self.simple_group = PreferencesGroup(title="What you dictate")
 
         # Searchable, like the advanced row: over thirty languages is too many to
@@ -2926,9 +2910,26 @@ class SettingsDialog(Gtk.Dialog):
         )
         self.simple_group.add_row(self.simple_priority_row)
 
+        # Advanced is an addition, not a separate mode: the detailed controls slide
+        # out underneath and keep showing what the simple answers resolved to.
+        self.advanced_toggle = Gtk.Switch()
+        self.advanced_toggle.set_valign(Gtk.Align.CENTER)
+        self.advanced_row = PreferenceRow(
+            title="Advanced",
+            subtitle="Show engine, model size and specialization",
+            widget=self.advanced_toggle,
+            keywords=("advanced", "engine", "model", "specialization"),
+        )
+        self.simple_group.add_row(self.advanced_row)
+
         self.content_box.pack_start(self.simple_group, False, False, 0)
 
-        self.settings_mode_combo.connect("changed", self._on_settings_mode_changed)
+        self.advanced_revealer = Gtk.Revealer()
+        self.advanced_revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN)
+        self.advanced_revealer.set_transition_duration(200)
+        self.content_box.pack_start(self.advanced_revealer, False, False, 0)
+
+        self.advanced_toggle.connect("notify::active", self._on_advanced_toggled)
         self.simple_language_combo.connect("changed", self._on_simple_choice_changed)
         self.simple_multi_switch.connect("notify::active", self._on_simple_choice_changed)
         self.simple_priority_combo.connect("changed", self._on_simple_choice_changed)
@@ -2993,7 +2994,8 @@ class SettingsDialog(Gtk.Dialog):
         self.language_row.set_tooltip_text(LANGUAGE_TOOLTIP)
         group.add_row(self.language_row)
 
-        self.content_box.pack_start(group, False, False, 0)
+        # Lives inside the revealer built above, so the Advanced switch slides it out.
+        self.advanced_revealer.add(group)
 
         # Model info card (shown below the group)
         self.model_info_card = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
@@ -5538,11 +5540,6 @@ class SettingsDialog(Gtk.Dialog):
             self._processing_language_change = False
         return False
 
-    def _get_settings_mode(self) -> str:
-        """Return the active mode, defaulting to simple."""
-        mode = self.settings_mode_combo.get_active_id() if self.settings_mode_combo else None
-        return mode if mode in ("simple", "advanced") else "simple"
-
     def _sync_simple_from_advanced(self):
         """Point the simple questions at the configuration that is actually live.
 
@@ -5595,16 +5592,14 @@ class SettingsDialog(Gtk.Dialog):
         self._populate_whispercpp_variant_options(size, variant)
         self.model_variant_combo.set_active_id(variant)
 
-    def _on_settings_mode_changed(self, _combo):
-        """Persist the mode and reshape the page."""
+    def _on_advanced_toggled(self, *_args):
+        """Slide the detailed controls in or out and remember the choice."""
         if self._initializing:
             return
-        mode = self._get_settings_mode()
-        self.config_manager.set("speech_recognition", "settings_mode", mode)
+        expanded = self.advanced_toggle.get_active()
+        self.config_manager.set("speech_recognition", "show_advanced", expanded)
         self.config_manager.save_settings()
-        if mode == "simple":
-            self._sync_simple_from_advanced()
-        self._update_settings_mode_visibility()
+        self._update_advanced_visibility()
 
     def _on_simple_choice_changed(self, *_args):
         """React to one of the simple questions changing.
@@ -5656,15 +5651,18 @@ class SettingsDialog(Gtk.Dialog):
     def _on_simple_language_entry_focus_out(self, _entry, _event):
         return self._commit_or_restore_simple_language_entry()
 
-    def _update_settings_mode_visibility(self):
-        """Show the group the active mode calls for."""
-        simple = self._get_settings_mode() == "simple"
-        if simple:
-            self.simple_group.show_all()
-            self.engine_group.hide()
-        else:
-            self.simple_group.hide()
+    def _update_advanced_visibility(self):
+        """Reveal or hide the detailed controls.
+
+        The simple questions stay on screen either way: Advanced adds detail rather
+        than replacing the summary, so the detailed rows double as a readout of what
+        the simple answers resolved to.
+        """
+        self.simple_group.show_all()
+        expanded = self.advanced_toggle.get_active()
+        if expanded:
             self.engine_group.show_all()
+        self.advanced_revealer.set_reveal_child(expanded)
 
     def _update_engine_specific_ui(self):
         """Show/hide UI elements driven by the active engine."""
@@ -5688,7 +5686,7 @@ class SettingsDialog(Gtk.Dialog):
             self.remote_server_group.hide()
             self.remote_status_label.hide()
 
-        self._update_settings_mode_visibility()
+        self._update_advanced_visibility()
 
         self._update_model_info()
         self._refresh_unused_downloads()

--- a/src/vocalinux/ui/settings_dialog.py
+++ b/src/vocalinux/ui/settings_dialog.py
@@ -1845,9 +1845,10 @@ class SettingsDialog(Gtk.Dialog):
         # Set while simple mode steers the advanced controls, so their own change
         # handlers do not each trigger a separate engine reload.
         self._simple_driving = False
-        self.advanced_button = None
         self.advanced_box = None
-        self.advanced_window = None
+        self.advanced_island = None
+        self.advanced_expander = None
+        self.simple_page = None
         self.simple_group = None
         self.engine_group = None
         self._processing_language_change = (
@@ -2002,6 +2003,9 @@ class SettingsDialog(Gtk.Dialog):
         # Restore the saved mode and point the simple questions at the live model
         # before the first visibility pass, so nothing flashes the wrong group.
         self._sync_simple_from_advanced()
+        self.advanced_expander.set_expanded(
+            bool(self.config_manager.get("speech_recognition", "show_advanced", False))
+        )
 
         # Then update visibility of engine-specific elements
         self._update_engine_specific_ui()
@@ -2933,26 +2937,48 @@ class SettingsDialog(Gtk.Dialog):
         )
         self.simple_group.add_row(self.simple_priority_row)
 
-        self.advanced_button = Gtk.Button(label="Open…")
-        self.advanced_button.set_valign(Gtk.Align.CENTER)
-        self.advanced_button.set_size_request(_ACTION_WIDTH, -1)
-        self.advanced_button.set_halign(Gtk.Align.END)
-        self.advanced_row = PreferenceRow(
-            title="Advanced",
-            subtitle="Engine, model size, specialization and the rest, in their own window",
-            widget=self.advanced_button,
-            keywords=("advanced", "engine", "model", "specialization"),
+        # The simple card and, under it, the info card the engine section adds.
+        self.simple_page = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        self.simple_page.pack_start(self.simple_group, False, False, 0)
+        self.content_box.pack_start(self.simple_page, False, False, 0)
+
+        # Advanced is its own island under the simple card: collapsed to a
+        # header by default, expanding in place. Not a second window — that went
+        # wrong twice on KWin/Wayland: transient for the dialog it crashed the
+        # compositor (findModal recursion, tag kwin-crash-repro); standing alone
+        # it could not be raised above the dialog at all. Both cards visible at
+        # once also makes the expanded rows a readout of what the simple answers
+        # resolved to.
+        self.advanced_island = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        self.advanced_island.get_style_context().add_class("preferences-group")
+
+        self.advanced_expander = Gtk.Expander()
+        header = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        title = Gtk.Label(label="Advanced", xalign=0)
+        title.get_style_context().add_class("preferences-group-title")
+        subtitle = Gtk.Label(
+            label="Engine, model size, specialization, downloads and the remote server",
+            xalign=0,
+            wrap=True,
         )
-        self.simple_group.add_row(self.advanced_row)
+        subtitle.get_style_context().add_class("preference-row-subtitle")
+        header.pack_start(title, False, False, 0)
+        header.pack_start(subtitle, False, False, 0)
+        self.advanced_expander.set_label_widget(header)
+        self.advanced_expander.set_margin_top(12)
+        self.advanced_expander.set_margin_bottom(12)
+        self.advanced_expander.set_margin_start(16)
+        self.advanced_expander.set_margin_end(16)
 
-        self.content_box.pack_start(self.simple_group, False, False, 0)
-
-        # Everything the detailed view holds is packed in here instead of into the
-        # page, and this box becomes the content of the advanced window.
+        # Everything the detailed view holds is packed in here; the sections
+        # built after this one append to it.
         self.advanced_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
-        self.advanced_box.set_border_width(12)
+        self.advanced_box.set_margin_top(8)
+        self.advanced_expander.add(self.advanced_box)
+        self.advanced_island.pack_start(self.advanced_expander, False, False, 0)
+        self.content_box.pack_start(self.advanced_island, False, False, 0)
 
-        self.advanced_button.connect("clicked", self._on_open_advanced_window)
+        self.advanced_expander.connect("notify::expanded", self._on_advanced_expanded)
         self.simple_language_combo.connect("changed", self._on_simple_choice_changed)
         self.simple_second_language_combo.connect("changed", self._on_simple_choice_changed)
         self.simple_multi_switch.connect("notify::active", self._on_simple_choice_changed)
@@ -3049,7 +3075,7 @@ class SettingsDialog(Gtk.Dialog):
 
         # On the page, under the simple questions: it is the only feedback that a
         # priority or language change did anything, and what it will cost.
-        self.content_box.pack_start(self.model_info_card, False, False, 0)
+        self.simple_page.pack_start(self.model_info_card, False, False, 0)
 
         self.unused_models_group = PreferencesGroup(
             keywords=("delete", "remove", "unused", "disk", "storage", "downloaded"),
@@ -5598,6 +5624,7 @@ class SettingsDialog(Gtk.Dialog):
             self.simple_priority_combo.set_active_id(priority)
         finally:
             self._simple_syncing = False
+        self._update_simple_visibility()
 
     def _simple_decoding_language(self) -> str:
         """Resolve the two simple language answers into what the engine accepts.
@@ -5642,60 +5669,30 @@ class SettingsDialog(Gtk.Dialog):
         self._populate_whispercpp_variant_options(size, variant)
         self.model_variant_combo.set_active_id(variant)
 
-    def _on_open_advanced_window(self, _button):
-        """Open the detailed controls in their own window.
+    def _on_advanced_expanded(self, expander, _param):
+        """Expand or collapse the advanced island, remembering the choice."""
+        expanded = expander.get_expanded()
+        if expanded:
+            self.advanced_box.show_all()
+            # Per-engine visibility has to run after show_all, which would
+            # otherwise reveal rows the active engine does not use.
+            self._update_engine_specific_ui()
+        else:
+            self._sync_simple_from_advanced()
+        if not self._initializing:
+            self.config_manager.set("speech_recognition", "show_advanced", expanded)
+            self.config_manager.save_settings()
 
-        Built fresh on every open and torn down on close. The first version kept
-        one window alive, transient for this dialog, hidden on close and shown
-        again with present(); on KWin 6.7 (Wayland) that crashed the compositor
-        with unbounded recursion in KWin::Window::findModal(), i.e. a cycle in
-        its transient-for chain. Neither ingredient is needed: the window stands
-        on its own, and the controls are re-parented out before it is destroyed.
+    def _refresh_simple_readout(self):
+        """Keep the simple answers describing the live model.
+
+        With both cards on screen, a change made in the advanced rows has to show
+        in the simple ones too, or the two would contradict each other. Skipped
+        while simple mode is itself steering the advanced rows, and during init.
         """
-        if self.advanced_window is not None:
-            self._raise_advanced_window()
+        if self._initializing or self._simple_driving or self._simple_syncing:
             return
-
-        window = Gtk.Window(title="Advanced speech model settings")
-        window.set_default_size(680, 720)
-        window.set_type_hint(Gdk.WindowTypeHint.NORMAL)
-        scroller = Gtk.ScrolledWindow()
-        scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        scroller.add(self.advanced_box)
-        window.add(scroller)
-        window.connect("delete-event", self._on_advanced_window_close)
-        self.advanced_window = window
-
-        window.show_all()
-        # Per-engine visibility has to run after show_all, which would otherwise
-        # reveal rows the active engine does not use.
-        self._update_engine_specific_ui()
-        self._raise_advanced_window()
-
-    def _raise_advanced_window(self):
-        """Bring the advanced window above the dialog.
-
-        With no transient parent the compositor has no reason to stack it over
-        the dialog, and on Wayland a toplevel mapped without an activation token
-        lands behind the focused window. Presenting with the timestamp of the
-        click that opened it asks for both, and needs no transient link — which
-        is what crashed KWin (see _on_open_advanced_window).
-        """
-        if self.advanced_window is None:
-            return
-        timestamp = Gtk.get_current_event_time()
-        if not timestamp:
-            timestamp = Gdk.CURRENT_TIME
-        self.advanced_window.present_with_time(timestamp)
-
-    def _on_advanced_window_close(self, window, _event):
-        """Tear the window down, keeping the controls for the next open."""
-        parent = self.advanced_box.get_parent()
-        if parent is not None:
-            parent.remove(self.advanced_box)
-        self.advanced_window = None
-        window.destroy()
-        return True
+        self._sync_simple_from_advanced()
 
     def _on_simple_choice_changed(self, *_args):
         """React to one of the simple questions changing.
@@ -5837,6 +5834,7 @@ class SettingsDialog(Gtk.Dialog):
 
     def _update_model_info(self):
         """Update the model info card display."""
+        self._refresh_simple_readout()
         engine_text = self.engine_combo.get_active_text()
         if not engine_text:
             self.model_info_card.hide()

--- a/src/vocalinux/utils/model_choice.py
+++ b/src/vocalinux/utils/model_choice.py
@@ -1,0 +1,58 @@
+"""Turn what the user actually knows into a model choice (#779).
+
+The Speech Model panel asks four questions, but only two of them are answerable
+without knowing the hardware: what language you speak, and whether you want it
+faster or more accurate. Size follows from the machine, and the specialization
+follows from the language. These helpers do the size half; the language half is
+the variant derivation that already lives in the settings dialog.
+
+Priority is expressed relative to what the hardware detection recommends rather
+than as an absolute size, so "most accurate" means something different on a
+laptop and on a workstation, which is the point.
+"""
+
+from .whispercpp_model_info import MODEL_SIZES
+
+FASTEST = "fastest"
+BALANCED = "balanced"
+ACCURATE = "accurate"
+
+PRIORITIES = (FASTEST, BALANCED, ACCURATE)
+
+PRIORITY_LABELS = {
+    FASTEST: "Fastest",
+    BALANCED: "Balanced",
+    ACCURATE: "Most accurate",
+}
+
+# How far to move from the hardware recommendation, in size steps.
+_PRIORITY_OFFSET = {FASTEST: -1, BALANCED: 0, ACCURATE: 1}
+
+
+def _clamp(index: int) -> int:
+    return max(0, min(len(MODEL_SIZES) - 1, index))
+
+
+def size_for_priority(recommended_size: str, priority: str) -> str:
+    """Return the size a priority asks for, relative to the recommendation."""
+    if recommended_size not in MODEL_SIZES:
+        recommended_size = MODEL_SIZES[0]
+    offset = _PRIORITY_OFFSET.get(priority, 0)
+    return MODEL_SIZES[_clamp(MODEL_SIZES.index(recommended_size) + offset)]
+
+
+def priority_for_size(recommended_size: str, size: str) -> str:
+    """Return the priority that best describes an already-chosen size.
+
+    Used to open simple mode showing the truth about the current configuration
+    instead of resetting it, so switching modes never silently changes the model.
+    """
+    if recommended_size not in MODEL_SIZES or size not in MODEL_SIZES:
+        return BALANCED
+
+    delta = MODEL_SIZES.index(size) - MODEL_SIZES.index(recommended_size)
+    if delta < 0:
+        return FASTEST
+    if delta > 0:
+        return ACCURATE
+    return BALANCED

--- a/tests/test_language_list_filtering.py
+++ b/tests/test_language_list_filtering.py
@@ -1,0 +1,187 @@
+"""The language list must be searchable while it is open.
+
+A GtkComboBox dropdown takes the keyboard for its own first-letter jump the
+moment it opens, so nothing typed reaches a filter. The picker opens a popover
+with a search entry above the list instead; every keystroke narrows the rows.
+"""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+import vocalinux.ui
+
+
+@pytest.fixture(scope="module")
+def settings_dialog():
+    """Import settings_dialog with real base classes for its GTK subclasses.
+
+    Box is already among the bases the module needs; SearchablePicker subclasses
+    it. Both sys.modules and the package attribute are restored so later tests
+    patching the module by name do not reach a second module object (#686).
+    """
+    repository = sys.modules["gi.repository"]
+    bases = {name: type(name, (), {}) for name in ("Box", "ListBoxRow", "Dialog", "ComboBox")}
+    saved_module = sys.modules.pop("vocalinux.ui.settings_dialog", None)
+    saved_attribute = getattr(vocalinux.ui, "settings_dialog", None)
+    try:
+        with patch.object(repository, "Gtk", MagicMock(**bases)):
+            module = importlib.import_module("vocalinux.ui.settings_dialog")
+        yield module
+    finally:
+        sys.modules.pop("vocalinux.ui.settings_dialog", None)
+        if saved_module is not None:
+            sys.modules["vocalinux.ui.settings_dialog"] = saved_module
+        if saved_attribute is not None:
+            vocalinux.ui.settings_dialog = saved_attribute
+        elif hasattr(vocalinux.ui, "settings_dialog"):
+            del vocalinux.ui.settings_dialog
+
+
+def _row(item_id, text):
+    row = Mock()
+    row.item_id = item_id
+    row.item_text = text
+    return row
+
+
+def _picker_stub(settings_dialog, typed="", rows=(), active=None):
+    """A stand-in ``self``: GTK is mocked, the picker's own logic is not."""
+    picker = Mock()
+    picker.base_model = [[text, item_id] for item_id, text in rows]
+    picker._rows_by_id = {item_id: _row(item_id, text) for item_id, text in rows}
+    picker._active_id = active
+    picker._search.get_text.return_value = typed
+    picker._list.get_children.return_value = list(picker._rows_by_id.values())
+    # These are the picker's own logic, not collaborators, so they stay real:
+    # _select decides whether "changed" fires, _row_is_visible is the filter.
+    picker._select.side_effect = lambda item_id, text: settings_dialog.SearchablePicker._select(
+        picker, item_id, text
+    )
+    picker._row_is_visible.side_effect = (
+        lambda row: settings_dialog.SearchablePicker._row_is_visible(picker, row)
+    )
+    return picker
+
+
+LANGS = (("en-us", "English (US)"), ("pl", "Polish"), ("ja", "Japanese"))
+
+
+@pytest.mark.parametrize(
+    "typed,expected",
+    [
+        ("pol", ["Polish"]),
+        ("POL", ["Polish"]),
+        ("ja", ["Japanese"]),
+        ("en", ["English (US)"]),
+        ("", ["English (US)", "Polish", "Japanese"]),
+        ("zzz", []),
+    ],
+)
+def test_typing_narrows_the_list(settings_dialog, typed, expected):
+    picker = _picker_stub(settings_dialog, typed=typed, rows=LANGS)
+    shown = [
+        row.item_text
+        for row in picker._rows_by_id.values()
+        if settings_dialog.SearchablePicker._row_is_visible(picker, row)
+    ]
+    assert shown == expected
+
+
+def test_enter_takes_the_first_row_still_showing(settings_dialog):
+    """Typing then Enter must not require reaching for the mouse."""
+    picker = _picker_stub(settings_dialog, typed="pol", rows=LANGS)
+    for row in picker._list.get_children.return_value:
+        row.get_visible.return_value = True
+        row.get_child_visible.return_value = True
+    picker._first_visible_row.side_effect = (
+        lambda: settings_dialog.SearchablePicker._first_visible_row(picker)
+    )
+
+    settings_dialog.SearchablePicker._on_search_activate(picker, picker._search)
+
+    picker._on_row_activated.assert_called_once()
+    assert picker._on_row_activated.call_args[0][1].item_id == "pl"
+
+
+def test_enter_with_nothing_matching_selects_nothing(settings_dialog):
+    picker = _picker_stub(settings_dialog, typed="zzz", rows=LANGS)
+    for row in picker._list.get_children.return_value:
+        row.get_visible.return_value = True
+        row.get_child_visible.return_value = True
+    picker._first_visible_row.side_effect = (
+        lambda: settings_dialog.SearchablePicker._first_visible_row(picker)
+    )
+
+    settings_dialog.SearchablePicker._on_search_activate(picker, picker._search)
+
+    picker._on_row_activated.assert_not_called()
+
+
+def test_selecting_by_id_reports_whether_the_row_exists(settings_dialog):
+    """_set_combo_active_id_or_first relies on the boolean to fall back."""
+    picker = _picker_stub(settings_dialog, rows=LANGS)
+
+    assert settings_dialog.SearchablePicker.set_active_id(picker, "pl") is True
+    assert settings_dialog.SearchablePicker.set_active_id(picker, "xx") is False
+
+
+def test_changed_fires_only_when_the_selection_actually_changes(settings_dialog):
+    """Re-selecting the saved language on open must not look like a user edit."""
+    picker = _picker_stub(settings_dialog, rows=LANGS, active="pl")
+
+    settings_dialog.SearchablePicker._select(picker, "pl", "Polish")
+    picker.emit.assert_not_called()
+
+    settings_dialog.SearchablePicker._select(picker, "ja", "Japanese")
+    picker.emit.assert_called_once_with("changed")
+    assert picker._active_id == "ja"
+
+
+def test_opening_starts_from_an_empty_search(settings_dialog):
+    """Leftover text from last time would hide most of the list on open."""
+    picker = _picker_stub(settings_dialog, rows=LANGS)
+
+    settings_dialog.SearchablePicker._on_button_clicked(picker, None)
+
+    picker._search.set_text.assert_called_once_with("")
+    picker._search.grab_focus.assert_called_once()
+
+
+def test_the_row_helpers_read_the_picker_store(settings_dialog):
+    """Resolving typed text must see every language, not only the shown ones."""
+    picker = _picker_stub(settings_dialog, rows=LANGS)
+    picker.get_model.return_value = []  # would be wrong to consult
+
+    assert settings_dialog._combo_text_rows(picker) == [
+        ("en-us", "English (US)"),
+        ("pl", "Polish"),
+        ("ja", "Japanese"),
+    ]
+
+
+def test_completion_is_not_bolted_onto_the_picker(settings_dialog):
+    """Its own filter and a completion popup would fight over the same entry."""
+    # A plain Mock wearing the picker's class: isinstance() says picker, and the
+    # Box methods GTK would provide are auto-created rather than spec-blocked.
+    picker = Mock()
+    picker.__class__ = settings_dialog.SearchablePicker
+
+    with patch.object(settings_dialog.Gtk, "EntryCompletion") as completion:
+        settings_dialog._attach_language_combo_search(picker)
+
+    completion.assert_not_called()
+
+
+def test_combo_styling_skips_combo_only_calls_on_the_picker(settings_dialog):
+    """get_cells and set_popup_fixed_width do not exist on a Box."""
+    picker = Mock()
+    picker.__class__ = settings_dialog.SearchablePicker
+
+    settings_dialog._style_combo(picker)
+
+    picker.set_size_request.assert_called_once()
+    picker.set_popup_fixed_width.assert_not_called()
+    picker.get_cells.assert_not_called()

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -683,7 +683,9 @@ class TestSettingsDialogHelperFunctions(unittest.TestCase):
             source_code,
         )
         self.assertIn("self.language_row.set_tooltip_text(LANGUAGE_TOOLTIP)", source_code)
-        self.assertIn("Gtk.ComboBoxText.new_with_entry()", source_code)
+        self.assertIn("self.language_combo = SearchablePicker()", source_code)
+        # SearchablePicker opens a popover with a search entry above the list,
+        # so typing works while the list is open, which no combo dropdown allows.
         self.assertIn("_attach_language_combo_search", source_code)
 
     def test_whispercpp_recommendation_uses_language_for_specialization(self):
@@ -791,7 +793,7 @@ class TestLanguageComboSearch(unittest.TestCase):
         with open(source_path, "r") as f:
             source_code = f.read()
 
-        self.assertIn("Gtk.ComboBoxText.new_with_entry()", source_code)
+        self.assertIn("self.language_combo = SearchablePicker()", source_code)
         self.assertIn("Gtk.EntryCompletion()", source_code)
         self.assertIn("completion.set_text_column(0)", source_code)
         self.assertIn("Search languages…", source_code)

--- a/tests/test_settings_dialog.py
+++ b/tests/test_settings_dialog.py
@@ -528,8 +528,12 @@ class TestSettingsDialogInstantApply(unittest.TestCase):
         with open(source_path, "r") as f:
             source_code = f.read()
 
-        self.assertIn("self.content_box.pack_start(self.remote_server_group", source_code)
-        self.assertIn("self.content_box.pack_start(self.remote_status_label", source_code)
+        # Reached from the Speech Model page: the detailed controls now live in the
+        # window the Advanced button opens, next to the engine picker that selects
+        # remote_api. The point of this test is that they are not exiled to the
+        # separate Advanced page, which the advanced_tab assertions below still guard.
+        self.assertIn("self.advanced_box.pack_start(self.remote_server_group", source_code)
+        self.assertIn("self.advanced_box.pack_start(self.remote_status_label", source_code)
         self.assertIn("self.remote_api_model_entry", source_code)
         self.assertIn("OpenAI/FunASR", source_code)
         self.assertNotIn("advanced_tab.pack_start(self.remote_server_group", source_code)

--- a/tests/test_settings_model_state.py
+++ b/tests/test_settings_model_state.py
@@ -55,6 +55,9 @@ def _dialog_stub():
     dialog._initializing = False
     dialog._test_active = False
     dialog._populating_models = False
+    # A Mock attribute is truthy, which would make _auto_apply_settings think
+    # simple mode is mid-way through steering the controls (#779).
+    dialog._simple_driving = False
     dialog.language = "en-us"
     # The real attribute is an enum member; a bare "idle" string would compare
     # unequal and send every test down the stop_recognition + sleep(0.5) branch.

--- a/tests/test_simple_model_settings.py
+++ b/tests/test_simple_model_settings.py
@@ -292,8 +292,27 @@ def test_the_advanced_window_is_never_transient_for_the_dialog(settings_dialog, 
     source = inspect.getsource(dialog_class._on_open_advanced_window)
 
     assert "set_transient_for" not in source
-    assert ".present()" not in source
     assert ".hide()" not in source
+
+
+def test_the_advanced_window_is_raised_with_the_clicks_timestamp(settings_dialog, dialog_class):
+    """Reported: it opened behind the dialog. Without a transient parent only an
+    activation request with a real timestamp brings it to the front on Wayland."""
+    dialog = Mock()
+
+    with patch.object(settings_dialog.Gtk, "get_current_event_time", return_value=123456):
+        dialog_class._raise_advanced_window(dialog)
+
+    dialog.advanced_window.present_with_time.assert_called_once_with(123456)
+
+
+def test_raising_the_advanced_window_still_never_makes_it_transient(settings_dialog, dialog_class):
+    import inspect
+
+    source = inspect.getsource(dialog_class._raise_advanced_window)
+
+    assert "set_transient_for" not in source
+    assert "present_with_time" in source
 
 
 def test_opening_simple_mode_describes_the_current_model_instead_of_resetting_it(

--- a/tests/test_simple_model_settings.py
+++ b/tests/test_simple_model_settings.py
@@ -235,7 +235,7 @@ def test_the_info_card_stays_on_the_page(settings_dialog):
 
     source = inspect.getsource(settings_dialog.SettingsDialog._build_engine_section)
 
-    assert "self.content_box.pack_start(self.model_info_card" in source
+    assert "self.simple_page.pack_start(self.model_info_card" in source
     assert "self.advanced_box.pack_start(self.model_info_card" not in source
 
 
@@ -265,54 +265,86 @@ def test_no_switch_pins_the_main_language(settings_dialog, dialog_class):
     assert dialog_class._simple_decoding_language(dialog) == "pl"
 
 
-def test_closing_the_advanced_window_reparents_the_controls_then_destroys_it(
+def test_expanding_the_island_shows_the_rows_for_the_active_engine(settings_dialog, dialog_class):
+    """show_all() first, then the per-engine pass, or rows the engine does not
+    use would be revealed."""
+    dialog = Mock()
+    dialog._initializing = False
+    expander = Mock()
+    expander.get_expanded.return_value = True
+    order = []
+    dialog.advanced_box.show_all.side_effect = lambda: order.append("show_all")
+    dialog._update_engine_specific_ui.side_effect = lambda: order.append("engine_ui")
+
+    dialog_class._on_advanced_expanded(dialog, expander, None)
+
+    assert order == ["show_all", "engine_ui"]
+    dialog.config_manager.set.assert_called_once_with("speech_recognition", "show_advanced", True)
+
+
+def test_collapsing_the_island_rereads_the_live_model(settings_dialog, dialog_class):
+    dialog = Mock()
+    dialog._initializing = False
+    expander = Mock()
+    expander.get_expanded.return_value = False
+
+    dialog_class._on_advanced_expanded(dialog, expander, None)
+
+    dialog._sync_simple_from_advanced.assert_called_once()
+    dialog.config_manager.set.assert_called_once_with("speech_recognition", "show_advanced", False)
+
+
+def test_restoring_the_island_on_open_does_not_write_the_config(settings_dialog, dialog_class):
+    """Setting the saved state during init must not count as a user choice."""
+    dialog = Mock()
+    dialog._initializing = True
+    expander = Mock()
+    expander.get_expanded.return_value = True
+
+    dialog_class._on_advanced_expanded(dialog, expander, None)
+
+    dialog.config_manager.set.assert_not_called()
+
+
+def test_a_change_in_the_advanced_rows_shows_up_in_the_simple_answers(
     settings_dialog, dialog_class
 ):
-    """The controls must outlive the window, or the second open finds them gone."""
+    """Both cards are on screen; they must not contradict each other."""
     dialog = Mock()
-    window = Mock()
-    order = []
-    dialog.advanced_box.get_parent.return_value.remove.side_effect = lambda box: order.append(
-        "remove"
-    )
-    window.destroy.side_effect = lambda: order.append("destroy")
+    dialog._initializing = False
+    dialog._simple_driving = False
+    dialog._simple_syncing = False
 
-    handled = dialog_class._on_advanced_window_close(dialog, window, None)
+    dialog_class._refresh_simple_readout(dialog)
 
-    assert order == ["remove", "destroy"]
-    assert dialog.advanced_window is None
-    assert handled is True
+    dialog._sync_simple_from_advanced.assert_called_once()
 
 
-def test_the_advanced_window_is_never_transient_for_the_dialog(settings_dialog, dialog_class):
-    """A transient, hidden-then-presented toplevel crashed KWin 6.7 (findModal
-    recursion — a cycle in its transient-for chain). See tag kwin-crash-repro."""
+@pytest.mark.parametrize("flag", ["_initializing", "_simple_driving", "_simple_syncing"])
+def test_the_readout_stays_quiet_while_simple_mode_is_steering(settings_dialog, dialog_class, flag):
+    """Re-syncing mid-steer would read half-set controls back into the answers."""
+    dialog = Mock()
+    dialog._initializing = False
+    dialog._simple_driving = False
+    dialog._simple_syncing = False
+    setattr(dialog, flag, True)
+
+    dialog_class._refresh_simple_readout(dialog)
+
+    dialog._sync_simple_from_advanced.assert_not_called()
+
+
+def test_no_second_toplevel_is_created_for_advanced(settings_dialog, dialog_class):
+    """A second window failed twice on KWin/Wayland: transient for the dialog it
+    crashed the compositor (tag kwin-crash-repro); standing alone it could not
+    be raised above the dialog. The island lives in the same window."""
     import inspect
 
-    source = inspect.getsource(dialog_class._on_open_advanced_window)
+    source = inspect.getsource(dialog_class._build_simple_model_section)
 
+    assert "Gtk.Window(" not in source
     assert "set_transient_for" not in source
-    assert ".hide()" not in source
-
-
-def test_the_advanced_window_is_raised_with_the_clicks_timestamp(settings_dialog, dialog_class):
-    """Reported: it opened behind the dialog. Without a transient parent only an
-    activation request with a real timestamp brings it to the front on Wayland."""
-    dialog = Mock()
-
-    with patch.object(settings_dialog.Gtk, "get_current_event_time", return_value=123456):
-        dialog_class._raise_advanced_window(dialog)
-
-    dialog.advanced_window.present_with_time.assert_called_once_with(123456)
-
-
-def test_raising_the_advanced_window_still_never_makes_it_transient(settings_dialog, dialog_class):
-    import inspect
-
-    source = inspect.getsource(dialog_class._raise_advanced_window)
-
-    assert "set_transient_for" not in source
-    assert "present_with_time" in source
+    assert "Gtk.Expander" in source
 
 
 def test_opening_simple_mode_describes_the_current_model_instead_of_resetting_it(

--- a/tests/test_simple_model_settings.py
+++ b/tests/test_simple_model_settings.py
@@ -1,0 +1,212 @@
+"""Simple mode asks what the user knows and derives the rest (#779)."""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+import vocalinux.ui
+from vocalinux.utils.model_choice import (
+    ACCURATE,
+    BALANCED,
+    FASTEST,
+    priority_for_size,
+    size_for_priority,
+)
+
+
+@pytest.fixture(scope="module")
+def settings_dialog():
+    """Import settings_dialog with real base classes for its GTK subclasses.
+
+    Same reasoning as tests/test_settings_model_state.py; both sys.modules and the
+    package attribute are restored so later tests patching the module by name do
+    not reach a second module object (#686).
+    """
+    repository = sys.modules["gi.repository"]
+    bases = {name: type(name, (), {}) for name in ("Box", "ListBoxRow", "Dialog")}
+    saved_module = sys.modules.pop("vocalinux.ui.settings_dialog", None)
+    saved_attribute = getattr(vocalinux.ui, "settings_dialog", None)
+    try:
+        with patch.object(repository, "Gtk", MagicMock(**bases)):
+            module = importlib.import_module("vocalinux.ui.settings_dialog")
+        yield module
+    finally:
+        sys.modules.pop("vocalinux.ui.settings_dialog", None)
+        if saved_module is not None:
+            sys.modules["vocalinux.ui.settings_dialog"] = saved_module
+        if saved_attribute is not None:
+            vocalinux.ui.settings_dialog = saved_attribute
+        elif hasattr(vocalinux.ui, "settings_dialog"):
+            del vocalinux.ui.settings_dialog
+
+
+@pytest.fixture
+def dialog_class(settings_dialog):
+    return settings_dialog.SettingsDialog
+
+
+def _dialog_stub(language="pl", multi=False, priority=BALANCED, recommended="small"):
+    dialog = Mock()
+    dialog._initializing = False
+    dialog._simple_syncing = False
+    dialog._applying_settings = False
+    dialog.language = language
+    dialog.simple_language_combo.get_active_id.return_value = language
+    dialog.simple_multi_switch.get_active.return_value = multi
+    dialog.simple_priority_combo.get_active_id.return_value = priority
+    dialog._get_recommended_whispercpp_model_for_language.return_value = (recommended, "reason")
+    return dialog
+
+
+# --- the size half of the derivation -------------------------------------
+
+
+@pytest.mark.parametrize(
+    "recommended,priority,expected",
+    [
+        ("small", FASTEST, "base"),
+        ("small", BALANCED, "small"),
+        ("small", ACCURATE, "medium"),
+        ("tiny", FASTEST, "tiny"),  # clamped at the bottom
+        ("large", ACCURATE, "large"),  # clamped at the top
+    ],
+)
+def test_priority_moves_relative_to_the_hardware_recommendation(recommended, priority, expected):
+    assert size_for_priority(recommended, priority) == expected
+
+
+def test_priority_reads_back_from_an_already_chosen_size():
+    """Opening simple mode must describe the current model, not reset it."""
+    assert priority_for_size("small", "base") == FASTEST
+    assert priority_for_size("small", "small") == BALANCED
+    assert priority_for_size("small", "medium") == ACCURATE
+
+
+# --- simple mode driving the advanced controls ---------------------------
+
+
+def test_a_single_language_pins_it_and_picks_the_matching_variant(settings_dialog, dialog_class):
+    dialog = _dialog_stub(language="pl", multi=False, priority=BALANCED, recommended="small")
+
+    dialog_class._apply_simple_choice(dialog)
+
+    dialog.engine_combo.set_active_id.assert_called_once_with("whisper_cpp")
+    dialog._set_combo_active_id_or_first.assert_called_once_with(dialog.language_combo, "pl")
+    dialog.model_combo.set_active_id.assert_called_once_with("small")
+    # Polish has no English-only weights, so the multilingual variant is correct.
+    dialog.model_variant_combo.set_active_id.assert_called_once_with("small")
+
+
+def test_english_gets_the_english_only_variant(settings_dialog, dialog_class):
+    """Same size, better recognition, so simple mode must not leave it on multilingual."""
+    dialog = _dialog_stub(language="en-us", multi=False, priority=BALANCED, recommended="small")
+
+    dialog_class._apply_simple_choice(dialog)
+
+    dialog.model_variant_combo.set_active_id.assert_called_once_with("small.en")
+
+
+def test_the_other_languages_switch_turns_on_auto_detect(settings_dialog, dialog_class):
+    """The engine takes one language or none; this is the "none" case."""
+    dialog = _dialog_stub(language="en-us", multi=True, priority=BALANCED, recommended="small")
+
+    dialog_class._apply_simple_choice(dialog)
+
+    dialog._set_combo_active_id_or_first.assert_called_once_with(dialog.language_combo, "auto")
+    assert dialog.language == "auto"
+    # Auto-detect cannot use English-only weights.
+    dialog.model_variant_combo.set_active_id.assert_called_once_with("small")
+
+
+def test_most_accurate_moves_a_size_up(settings_dialog, dialog_class):
+    dialog = _dialog_stub(language="en-us", multi=False, priority=ACCURATE, recommended="small")
+
+    dialog_class._apply_simple_choice(dialog)
+
+    dialog.model_combo.set_active_id.assert_called_once_with("medium")
+    dialog.model_variant_combo.set_active_id.assert_called_once_with("medium.en")
+
+
+def test_most_accurate_on_large_falls_back_to_multilingual_for_english(
+    settings_dialog, dialog_class
+):
+    """large ships no English-only weights, so the variant must stay real."""
+    dialog = _dialog_stub(language="en-us", multi=False, priority=ACCURATE, recommended="large")
+
+    dialog_class._apply_simple_choice(dialog)
+
+    dialog.model_combo.set_active_id.assert_called_once_with("large")
+    chosen = dialog.model_variant_combo.set_active_id.call_args[0][0]
+    assert chosen in settings_dialog.WHISPERCPP_MODEL_INFO
+    assert not settings_dialog.is_english_only_whispercpp_model(chosen)
+
+
+# --- guards ---------------------------------------------------------------
+
+
+def test_syncing_the_widgets_does_not_count_as_a_user_edit(settings_dialog, dialog_class):
+    """Otherwise opening the page would re-apply and trigger a download."""
+    dialog = _dialog_stub()
+    dialog._simple_syncing = True
+
+    dialog_class._on_simple_choice_changed(dialog)
+
+    dialog._apply_simple_choice.assert_not_called()
+    dialog._auto_apply_settings.assert_not_called()
+
+
+def test_a_real_edit_applies_and_saves(settings_dialog, dialog_class):
+    dialog = _dialog_stub()
+
+    dialog_class._on_simple_choice_changed(dialog)
+
+    dialog._apply_simple_choice.assert_called_once()
+    dialog._auto_apply_settings.assert_called_once()
+
+
+def test_switching_modes_shows_one_group_and_hides_the_other(settings_dialog, dialog_class):
+    dialog = Mock()
+    dialog._get_settings_mode.return_value = "simple"
+    dialog_class._update_settings_mode_visibility(dialog)
+    dialog.simple_group.show_all.assert_called_once()
+    dialog.engine_group.hide.assert_called_once()
+
+    dialog = Mock()
+    dialog._get_settings_mode.return_value = "advanced"
+    dialog_class._update_settings_mode_visibility(dialog)
+    dialog.engine_group.show_all.assert_called_once()
+    dialog.simple_group.hide.assert_called_once()
+
+
+def test_opening_simple_mode_describes_the_current_model_instead_of_resetting_it(
+    settings_dialog, dialog_class
+):
+    """Switching to simple must not silently change which model is loaded."""
+    dialog = Mock()
+    dialog.language = "en-us"
+    dialog.language_combo.get_active_id.return_value = "en-us"
+    dialog._get_recommended_whispercpp_model_for_language.return_value = ("small.en", "reason")
+    dialog._get_selected_whispercpp_model.return_value = "medium.en"
+
+    dialog_class._sync_simple_from_advanced(dialog)
+
+    dialog.simple_multi_switch.set_active.assert_called_once_with(False)
+    dialog.simple_language_combo.set_active_id.assert_called_once_with("en-us")
+    # medium sits one step above the recommended small, which is "most accurate".
+    dialog.simple_priority_combo.set_active_id.assert_called_once_with(ACCURATE)
+    assert dialog._simple_syncing is False
+
+
+def test_auto_detect_shows_up_as_the_other_languages_switch(settings_dialog, dialog_class):
+    dialog = Mock()
+    dialog.language = "auto"
+    dialog.language_combo.get_active_id.return_value = "auto"
+    dialog.simple_language_combo.get_active_id.return_value = None
+    dialog._get_recommended_whispercpp_model_for_language.return_value = ("small", "reason")
+    dialog._get_selected_whispercpp_model.return_value = "small"
+
+    dialog_class._sync_simple_from_advanced(dialog)
+
+    dialog.simple_multi_switch.set_active.assert_called_once_with(True)

--- a/tests/test_simple_model_settings.py
+++ b/tests/test_simple_model_settings.py
@@ -47,7 +47,7 @@ def dialog_class(settings_dialog):
     return settings_dialog.SettingsDialog
 
 
-def _dialog_stub(language="pl", multi=False, priority=BALANCED, recommended="small"):
+def _dialog_stub(language="pl", multi=False, priority=BALANCED, recommended="small", second=None):
     dialog = Mock()
     dialog._initializing = False
     dialog._simple_syncing = False
@@ -57,9 +57,20 @@ def _dialog_stub(language="pl", multi=False, priority=BALANCED, recommended="sma
     dialog.language = language
     dialog.simple_language_combo.get_active_id.return_value = language
     dialog.simple_multi_switch.get_active.return_value = multi
+    dialog.simple_second_language_combo.get_active_id.return_value = second
     dialog.simple_priority_combo.get_active_id.return_value = priority
     dialog._get_recommended_whispercpp_model_for_language.return_value = (recommended, "reason")
+    # The language resolution is the code under test's own helper, not a mock.
+    dialog._simple_decoding_language.side_effect = (
+        lambda: _sd().SettingsDialog._simple_decoding_language(dialog)
+    )
     return dialog
+
+
+def _sd():
+    import vocalinux.ui.settings_dialog as module
+
+    return module
 
 
 # --- the size half of the derivation -------------------------------------
@@ -110,15 +121,15 @@ def test_english_gets_the_english_only_variant(settings_dialog, dialog_class):
     dialog.model_variant_combo.set_active_id.assert_called_once_with("small.en")
 
 
-def test_the_other_languages_switch_turns_on_auto_detect(settings_dialog, dialog_class):
-    """The engine takes one language or none; this is the "none" case."""
-    dialog = _dialog_stub(language="en-us", multi=True, priority=BALANCED, recommended="small")
+def test_naming_a_second_language_turns_on_auto_detect(settings_dialog, dialog_class):
+    """Two languages cannot be pinned, so the engine gets detection instead."""
+    dialog = _dialog_stub(language="pl", multi=True, second="en-us", recommended="small")
 
     dialog_class._apply_simple_choice(dialog)
 
     dialog._set_combo_active_id_or_first.assert_called_once_with(dialog.language_combo, "auto")
     assert dialog.language == "auto"
-    # Auto-detect cannot use English-only weights.
+    # Detection cannot use English-only weights.
     dialog.model_variant_combo.set_active_id.assert_called_once_with("small")
 
 
@@ -168,36 +179,60 @@ def test_a_real_edit_applies_and_saves(settings_dialog, dialog_class):
     dialog._auto_apply_settings.assert_called_once()
 
 
-def test_the_simple_questions_stay_visible_when_advanced_is_revealed(settings_dialog, dialog_class):
-    """Advanced adds detail under the summary; it does not replace it."""
+def test_the_second_language_list_appears_only_when_asked_for(settings_dialog, dialog_class):
     dialog = Mock()
-    dialog.advanced_toggle.get_active.return_value = True
+    dialog.simple_multi_switch.get_active.return_value = True
 
-    dialog_class._update_advanced_visibility(dialog)
+    dialog_class._update_simple_visibility(dialog)
 
-    dialog.simple_group.show_all.assert_called_once()
-    dialog.advanced_revealer.set_reveal_child.assert_called_once_with(True)
+    dialog.simple_second_language_row.show_all.assert_called_once()
 
 
-def test_advanced_starts_collapsed(settings_dialog, dialog_class):
+def test_the_second_language_list_is_hidden_by_default(settings_dialog, dialog_class):
     dialog = Mock()
-    dialog.advanced_toggle.get_active.return_value = False
+    dialog.simple_multi_switch.get_active.return_value = False
 
-    dialog_class._update_advanced_visibility(dialog)
+    dialog_class._update_simple_visibility(dialog)
 
-    dialog.simple_group.show_all.assert_called_once()
-    dialog.advanced_revealer.set_reveal_child.assert_called_once_with(False)
+    dialog.simple_second_language_row.hide.assert_called_once()
 
 
-def test_toggling_advanced_is_remembered(settings_dialog, dialog_class):
+def test_a_second_language_switches_decoding_to_detection(settings_dialog, dialog_class):
+    """whisper takes one language or none, so two means automatic detection."""
+    dialog = _dialog_stub(language="pl", multi=True, second="en-us")
+
+    assert dialog_class._simple_decoding_language(dialog) == "auto"
+
+
+def test_two_english_entries_still_pin_english(settings_dialog, dialog_class):
+    """en-US plus en-IN is still English, so the .en weights stay usable."""
+    dialog = _dialog_stub(language="en-us", multi=True, second="en-in")
+
+    assert dialog_class._simple_decoding_language(dialog) == "en-us"
+
+
+def test_the_switch_without_a_second_language_keeps_the_main_one(settings_dialog, dialog_class):
+    dialog = _dialog_stub(language="pl", multi=True, second=None)
+
+    assert dialog_class._simple_decoding_language(dialog) == "pl"
+
+
+def test_no_switch_pins_the_main_language(settings_dialog, dialog_class):
+    dialog = _dialog_stub(language="pl", multi=False, second="en-us")
+
+    assert dialog_class._simple_decoding_language(dialog) == "pl"
+
+
+def test_the_advanced_window_hides_instead_of_destroying_its_widgets(settings_dialog, dialog_class):
+    """Destroying it would leave the controls gone the second time it is opened."""
     dialog = Mock()
-    dialog._initializing = False
-    dialog.advanced_toggle.get_active.return_value = True
+    window = Mock()
 
-    dialog_class._on_advanced_toggled(dialog)
+    handled = dialog_class._on_advanced_window_close(dialog, window, None)
 
-    dialog.config_manager.set.assert_called_once_with("speech_recognition", "show_advanced", True)
-    dialog._update_advanced_visibility.assert_called_once()
+    window.hide.assert_called_once()
+    window.destroy.assert_not_called()
+    assert handled is True
 
 
 def test_opening_simple_mode_describes_the_current_model_instead_of_resetting_it(
@@ -207,6 +242,7 @@ def test_opening_simple_mode_describes_the_current_model_instead_of_resetting_it
     dialog = Mock()
     dialog.language = "en-us"
     dialog.language_combo.get_active_id.return_value = "en-us"
+    dialog.config_manager.get.return_value = ""
     dialog._get_recommended_whispercpp_model_for_language.return_value = ("small.en", "reason")
     dialog._get_selected_whispercpp_model.return_value = "medium.en"
 
@@ -224,6 +260,7 @@ def test_auto_detect_shows_up_as_the_other_languages_switch(settings_dialog, dia
     dialog.language = "auto"
     dialog.language_combo.get_active_id.return_value = "auto"
     dialog.simple_language_combo.get_active_id.return_value = None
+    dialog.config_manager.get.return_value = ""
     dialog._get_recommended_whispercpp_model_for_language.return_value = ("small", "reason")
     dialog._get_selected_whispercpp_model.return_value = "small"
 

--- a/tests/test_simple_model_settings.py
+++ b/tests/test_simple_model_settings.py
@@ -383,8 +383,9 @@ def test_auto_detect_shows_up_as_the_other_languages_switch(settings_dialog, dia
     dialog.simple_multi_switch.set_active.assert_called_once_with(True)
 
 
+@pytest.mark.parametrize("stale_second", ["auto", "en-us"])
 def test_pinned_advanced_language_plus_stale_stored_second_does_not_replace_the_pin(
-    settings_dialog, dialog_class
+    settings_dialog, dialog_class, stale_second
 ):
     """A leftover simple second answer must not override a pinned Advanced language.
 
@@ -394,7 +395,7 @@ def test_pinned_advanced_language_plus_stale_stored_second_does_not_replace_the_
     dialog = Mock()
     dialog.language = "pl"
     dialog.language_combo.get_active_id.return_value = "pl"
-    dialog.config_manager.get.return_value = "auto"  # stale leftover
+    dialog.config_manager.get.return_value = stale_second
     dialog._get_recommended_whispercpp_model_for_language.return_value = ("small", "reason")
     dialog._get_selected_whispercpp_model.return_value = "small"
 
@@ -402,9 +403,7 @@ def test_pinned_advanced_language_plus_stale_stored_second_does_not_replace_the_
 
     dialog.simple_multi_switch.set_active.assert_called_once_with(False)
     dialog.simple_language_combo.set_active_id.assert_called_once_with("pl")
-    dialog.config_manager.set.assert_called_with(
-        "speech_recognition", "simple_second_language", ""
-    )
+    dialog.config_manager.set.assert_called_with("speech_recognition", "simple_second_language", "")
     dialog.simple_second_language_combo.set_active_id.assert_called_with("auto")
 
     # Widgets after sync: multi off, main language pinned. A later simple apply
@@ -413,8 +412,8 @@ def test_pinned_advanced_language_plus_stale_stored_second_does_not_replace_the_
     dialog.simple_language_combo.get_active_id.return_value = "pl"
     dialog.simple_second_language_combo.get_active_id.return_value = "auto"
     dialog.simple_priority_combo.get_active_id.return_value = BALANCED
-    dialog._simple_decoding_language.side_effect = (
-        lambda: dialog_class._simple_decoding_language(dialog)
+    dialog._simple_decoding_language.side_effect = lambda: dialog_class._simple_decoding_language(
+        dialog
     )
     dialog._on_disk_stand_in.side_effect = lambda variant, size, language: variant
 
@@ -424,9 +423,42 @@ def test_pinned_advanced_language_plus_stale_stored_second_does_not_replace_the_
     assert dialog.language == "pl"
 
 
-def test_changing_advanced_language_refreshes_the_simple_readout(
-    settings_dialog, dialog_class
-):
+def test_two_english_second_language_survives_sync_from_a_pin(settings_dialog, dialog_class):
+    """en-US plus en-IN still pins English; sync must not treat that as leftover auto.
+
+    Dropping the switch and wiping ``simple_second_language`` on every pinned
+    readout would forget the second English answer the next time settings open.
+    """
+    dialog = Mock()
+    dialog.language = "en-us"
+    dialog.language_combo.get_active_id.return_value = "en-us"
+    dialog.config_manager.get.return_value = "en-in"
+    dialog._get_recommended_whispercpp_model_for_language.return_value = ("small.en", "reason")
+    dialog._get_selected_whispercpp_model.return_value = "small.en"
+
+    dialog_class._sync_simple_from_advanced(dialog)
+
+    dialog.simple_multi_switch.set_active.assert_called_once_with(True)
+    dialog.simple_language_combo.set_active_id.assert_called_once_with("en-us")
+    dialog.simple_second_language_combo.set_active_id.assert_called_once_with("en-in")
+    dialog.config_manager.set.assert_not_called()
+
+    dialog.simple_multi_switch.get_active.return_value = True
+    dialog.simple_language_combo.get_active_id.return_value = "en-us"
+    dialog.simple_second_language_combo.get_active_id.return_value = "en-in"
+    dialog.simple_priority_combo.get_active_id.return_value = BALANCED
+    dialog._simple_decoding_language.side_effect = lambda: dialog_class._simple_decoding_language(
+        dialog
+    )
+    dialog._on_disk_stand_in.side_effect = lambda variant, size, language: variant
+
+    dialog_class._apply_simple_choice(dialog)
+
+    dialog._set_combo_active_id_or_first.assert_called_once_with(dialog.language_combo, "en-us")
+    assert dialog.language == "en-us"
+
+
+def test_changing_advanced_language_refreshes_the_simple_readout(settings_dialog, dialog_class):
     """Otherwise a pin in Advanced leaves a stale multi switch on screen."""
     dialog = Mock()
     dialog._processing_language_change = False

--- a/tests/test_simple_model_settings.py
+++ b/tests/test_simple_model_settings.py
@@ -180,21 +180,63 @@ def test_a_real_edit_applies_and_saves(settings_dialog, dialog_class):
 
 
 def test_the_second_language_list_appears_only_when_asked_for(settings_dialog, dialog_class):
+    """show_all() is a no-op on a no_show_all widget: the flag must go first.
+
+    Reported from the installed build — the switch turned on and nothing
+    appeared, because the row was shown with the flag still set.
+    """
     dialog = Mock()
     dialog.simple_multi_switch.get_active.return_value = True
+    row = dialog.simple_second_language_row
+    order = []
+    row.set_no_show_all.side_effect = lambda flag: order.append(("no_show_all", flag))
+    row.show_all.side_effect = lambda: order.append(("show_all", None))
 
     dialog_class._update_simple_visibility(dialog)
 
-    dialog.simple_second_language_row.show_all.assert_called_once()
+    assert order == [("no_show_all", False), ("show_all", None)]
 
 
 def test_the_second_language_list_is_hidden_by_default(settings_dialog, dialog_class):
     dialog = Mock()
     dialog.simple_multi_switch.get_active.return_value = False
+    row = dialog.simple_second_language_row
+    order = []
+    row.hide.side_effect = lambda: order.append("hide")
+    row.set_no_show_all.side_effect = lambda flag: order.append(("no_show_all", flag))
 
     dialog_class._update_simple_visibility(dialog)
 
-    dialog.simple_second_language_row.hide.assert_called_once()
+    assert order == ["hide", ("no_show_all", True)]
+
+
+def test_any_language_as_the_second_answer_means_detection(settings_dialog, dialog_class):
+    """The explicit multilingual option."""
+    dialog = _dialog_stub(language="pl", multi=True, second="auto")
+
+    assert dialog_class._simple_decoding_language(dialog) == "auto"
+
+
+def test_turning_the_switch_on_defaults_the_second_list_to_any_language(
+    settings_dialog, dialog_class
+):
+    """Otherwise flipping the switch alone would visibly do nothing."""
+    dialog = _dialog_stub(language="pl", multi=True, second=None)
+
+    dialog_class._on_simple_choice_changed(dialog)
+
+    dialog.simple_second_language_combo.set_active_id.assert_called_once_with("auto")
+    dialog._apply_simple_choice.assert_called_once()
+
+
+def test_the_info_card_stays_on_the_page(settings_dialog):
+    """It is the only feedback that a priority change did anything, and its cost."""
+    import inspect
+
+    source = inspect.getsource(settings_dialog.SettingsDialog._build_engine_section)
+
+    assert "self.content_box.pack_start(self.model_info_card" in source
+    assert "self.advanced_box.pack_start(self.model_info_card" not in source
 
 
 def test_a_second_language_switches_decoding_to_detection(settings_dialog, dialog_class):
@@ -223,16 +265,35 @@ def test_no_switch_pins_the_main_language(settings_dialog, dialog_class):
     assert dialog_class._simple_decoding_language(dialog) == "pl"
 
 
-def test_the_advanced_window_hides_instead_of_destroying_its_widgets(settings_dialog, dialog_class):
-    """Destroying it would leave the controls gone the second time it is opened."""
+def test_closing_the_advanced_window_reparents_the_controls_then_destroys_it(
+    settings_dialog, dialog_class
+):
+    """The controls must outlive the window, or the second open finds them gone."""
     dialog = Mock()
     window = Mock()
+    order = []
+    dialog.advanced_box.get_parent.return_value.remove.side_effect = lambda box: order.append(
+        "remove"
+    )
+    window.destroy.side_effect = lambda: order.append("destroy")
 
     handled = dialog_class._on_advanced_window_close(dialog, window, None)
 
-    window.hide.assert_called_once()
-    window.destroy.assert_not_called()
+    assert order == ["remove", "destroy"]
+    assert dialog.advanced_window is None
     assert handled is True
+
+
+def test_the_advanced_window_is_never_transient_for_the_dialog(settings_dialog, dialog_class):
+    """A transient, hidden-then-presented toplevel crashed KWin 6.7 (findModal
+    recursion — a cycle in its transient-for chain). See tag kwin-crash-repro."""
+    import inspect
+
+    source = inspect.getsource(dialog_class._on_open_advanced_window)
+
+    assert "set_transient_for" not in source
+    assert ".present()" not in source
+    assert ".hide()" not in source
 
 
 def test_opening_simple_mode_describes_the_current_model_instead_of_resetting_it(

--- a/tests/test_simple_model_settings.py
+++ b/tests/test_simple_model_settings.py
@@ -168,18 +168,36 @@ def test_a_real_edit_applies_and_saves(settings_dialog, dialog_class):
     dialog._auto_apply_settings.assert_called_once()
 
 
-def test_switching_modes_shows_one_group_and_hides_the_other(settings_dialog, dialog_class):
+def test_the_simple_questions_stay_visible_when_advanced_is_revealed(settings_dialog, dialog_class):
+    """Advanced adds detail under the summary; it does not replace it."""
     dialog = Mock()
-    dialog._get_settings_mode.return_value = "simple"
-    dialog_class._update_settings_mode_visibility(dialog)
-    dialog.simple_group.show_all.assert_called_once()
-    dialog.engine_group.hide.assert_called_once()
+    dialog.advanced_toggle.get_active.return_value = True
 
+    dialog_class._update_advanced_visibility(dialog)
+
+    dialog.simple_group.show_all.assert_called_once()
+    dialog.advanced_revealer.set_reveal_child.assert_called_once_with(True)
+
+
+def test_advanced_starts_collapsed(settings_dialog, dialog_class):
     dialog = Mock()
-    dialog._get_settings_mode.return_value = "advanced"
-    dialog_class._update_settings_mode_visibility(dialog)
-    dialog.engine_group.show_all.assert_called_once()
-    dialog.simple_group.hide.assert_called_once()
+    dialog.advanced_toggle.get_active.return_value = False
+
+    dialog_class._update_advanced_visibility(dialog)
+
+    dialog.simple_group.show_all.assert_called_once()
+    dialog.advanced_revealer.set_reveal_child.assert_called_once_with(False)
+
+
+def test_toggling_advanced_is_remembered(settings_dialog, dialog_class):
+    dialog = Mock()
+    dialog._initializing = False
+    dialog.advanced_toggle.get_active.return_value = True
+
+    dialog_class._on_advanced_toggled(dialog)
+
+    dialog.config_manager.set.assert_called_once_with("speech_recognition", "show_advanced", True)
+    dialog._update_advanced_visibility.assert_called_once()
 
 
 def test_opening_simple_mode_describes_the_current_model_instead_of_resetting_it(

--- a/tests/test_simple_model_settings.py
+++ b/tests/test_simple_model_settings.py
@@ -383,6 +383,61 @@ def test_auto_detect_shows_up_as_the_other_languages_switch(settings_dialog, dia
     dialog.simple_multi_switch.set_active.assert_called_once_with(True)
 
 
+def test_pinned_advanced_language_plus_stale_stored_second_does_not_replace_the_pin(
+    settings_dialog, dialog_class
+):
+    """A leftover simple second answer must not override a pinned Advanced language.
+
+    Sync used to re-enable the multi switch from persisted ``simple_second_language``.
+    The next simple edit then decoded to auto and silently replaced the pin.
+    """
+    dialog = Mock()
+    dialog.language = "pl"
+    dialog.language_combo.get_active_id.return_value = "pl"
+    dialog.config_manager.get.return_value = "auto"  # stale leftover
+    dialog._get_recommended_whispercpp_model_for_language.return_value = ("small", "reason")
+    dialog._get_selected_whispercpp_model.return_value = "small"
+
+    dialog_class._sync_simple_from_advanced(dialog)
+
+    dialog.simple_multi_switch.set_active.assert_called_once_with(False)
+    dialog.simple_language_combo.set_active_id.assert_called_once_with("pl")
+    dialog.config_manager.set.assert_called_with(
+        "speech_recognition", "simple_second_language", ""
+    )
+    dialog.simple_second_language_combo.set_active_id.assert_called_with("auto")
+
+    # Widgets after sync: multi off, main language pinned. A later simple apply
+    # must keep the pin rather than silently writing auto.
+    dialog.simple_multi_switch.get_active.return_value = False
+    dialog.simple_language_combo.get_active_id.return_value = "pl"
+    dialog.simple_second_language_combo.get_active_id.return_value = "auto"
+    dialog.simple_priority_combo.get_active_id.return_value = BALANCED
+    dialog._simple_decoding_language.side_effect = (
+        lambda: dialog_class._simple_decoding_language(dialog)
+    )
+    dialog._on_disk_stand_in.side_effect = lambda variant, size, language: variant
+
+    dialog_class._apply_simple_choice(dialog)
+
+    dialog._set_combo_active_id_or_first.assert_called_once_with(dialog.language_combo, "pl")
+    assert dialog.language == "pl"
+
+
+def test_changing_advanced_language_refreshes_the_simple_readout(
+    settings_dialog, dialog_class
+):
+    """Otherwise a pin in Advanced leaves a stale multi switch on screen."""
+    dialog = Mock()
+    dialog._processing_language_change = False
+    dialog.language_combo.get_active_id.return_value = "pl"
+    dialog.engine_combo.get_active_text.return_value = "Local (whisper.cpp)"
+
+    dialog_class._on_language_changed(dialog, None)
+
+    dialog._refresh_simple_readout.assert_called_once()
+
+
 # --- regressions reported from the installed build -----------------------
 
 

--- a/tests/test_simple_model_settings.py
+++ b/tests/test_simple_model_settings.py
@@ -458,6 +458,78 @@ def test_two_english_second_language_survives_sync_from_a_pin(settings_dialog, d
     assert dialog.language == "en-us"
 
 
+@pytest.mark.parametrize("stale_second", ["en-in", "en-us"])
+def test_two_english_second_language_does_not_override_advanced_auto(
+    settings_dialog, dialog_class, stale_second
+):
+    """en-US plus another English still pins English, so it cannot sit on auto.
+
+    Restoring that leftover over Advanced auto would make the next simple edit
+    silently replace auto with en-us. Duplicate en-US is the same pin.
+    """
+    dialog = Mock()
+    dialog.language = "auto"
+    dialog.language_combo.get_active_id.return_value = "auto"
+    dialog.simple_language_combo.get_active_id.return_value = "en-us"
+    dialog.config_manager.get.return_value = stale_second
+    dialog._get_recommended_whispercpp_model_for_language.return_value = ("small", "reason")
+    dialog._get_selected_whispercpp_model.return_value = "small"
+
+    dialog_class._sync_simple_from_advanced(dialog)
+
+    dialog.simple_multi_switch.set_active.assert_called_once_with(True)
+    dialog.simple_language_combo.set_active_id.assert_not_called()
+    dialog.simple_second_language_combo.set_active_id.assert_called_once_with("auto")
+    dialog.config_manager.set.assert_called_with("speech_recognition", "simple_second_language", "")
+
+    dialog.simple_multi_switch.get_active.return_value = True
+    dialog.simple_language_combo.get_active_id.return_value = "en-us"
+    dialog.simple_second_language_combo.get_active_id.return_value = "auto"
+    dialog.simple_priority_combo.get_active_id.return_value = BALANCED
+    dialog._simple_decoding_language.side_effect = lambda: dialog_class._simple_decoding_language(
+        dialog
+    )
+    dialog._on_disk_stand_in.side_effect = lambda variant, size, language: variant
+
+    dialog_class._apply_simple_choice(dialog)
+
+    dialog._set_combo_active_id_or_first.assert_called_once_with(dialog.language_combo, "auto")
+    assert dialog.language == "auto"
+
+
+def test_named_second_language_that_still_means_auto_survives_auto_sync(
+    settings_dialog, dialog_class
+):
+    """English plus Polish is detection; Advanced auto must keep that second pick."""
+    dialog = Mock()
+    dialog.language = "auto"
+    dialog.language_combo.get_active_id.return_value = "auto"
+    dialog.simple_language_combo.get_active_id.return_value = "en-us"
+    dialog.config_manager.get.return_value = "pl"
+    dialog._get_recommended_whispercpp_model_for_language.return_value = ("small", "reason")
+    dialog._get_selected_whispercpp_model.return_value = "small"
+
+    dialog_class._sync_simple_from_advanced(dialog)
+
+    dialog.simple_multi_switch.set_active.assert_called_once_with(True)
+    dialog.simple_second_language_combo.set_active_id.assert_called_once_with("pl")
+    dialog.config_manager.set.assert_not_called()
+
+    dialog.simple_multi_switch.get_active.return_value = True
+    dialog.simple_language_combo.get_active_id.return_value = "en-us"
+    dialog.simple_second_language_combo.get_active_id.return_value = "pl"
+    dialog.simple_priority_combo.get_active_id.return_value = BALANCED
+    dialog._simple_decoding_language.side_effect = lambda: dialog_class._simple_decoding_language(
+        dialog
+    )
+    dialog._on_disk_stand_in.side_effect = lambda variant, size, language: variant
+
+    dialog_class._apply_simple_choice(dialog)
+
+    dialog._set_combo_active_id_or_first.assert_called_once_with(dialog.language_combo, "auto")
+    assert dialog.language == "auto"
+
+
 def test_changing_advanced_language_refreshes_the_simple_readout(settings_dialog, dialog_class):
     """Otherwise a pin in Advanced leaves a stale multi switch on screen."""
     dialog = Mock()

--- a/tests/test_simple_model_settings.py
+++ b/tests/test_simple_model_settings.py
@@ -64,6 +64,8 @@ def _dialog_stub(language="pl", multi=False, priority=BALANCED, recommended="sma
     dialog._simple_decoding_language.side_effect = (
         lambda: _sd().SettingsDialog._simple_decoding_language(dialog)
     )
+    # Disk lookups are covered separately; here the derived variant stands.
+    dialog._on_disk_stand_in.side_effect = lambda variant, size, language: variant
     return dialog
 
 
@@ -461,3 +463,72 @@ def test_restoring_after_auto_detect_falls_back_to_a_real_language(settings_dial
     dialog._set_combo_active_id_or_first.assert_called_once_with(
         dialog.simple_language_combo, "en-us"
     )
+
+
+# --- reuse what is on disk instead of downloading a sibling ---------------
+
+
+def _with_disk(settings_dialog, downloaded):
+    return (
+        patch.object(
+            settings_dialog,
+            "is_whispercpp_model_downloaded",
+            side_effect=lambda name: name in downloaded,
+        ),
+        patch.object(
+            settings_dialog,
+            "get_whispercpp_model_variants",
+            return_value=["base", "base.en", "base-q5_1", "base.en-q5_1", "base-q8_0"],
+        ),
+    )
+
+
+def test_a_same_size_weight_on_disk_stands_in_for_a_missing_sibling(settings_dialog, dialog_class):
+    """Reported: switching the other-languages switch off went from base to
+    base.en and sat through a 141 MB modal download for the same size."""
+    on_disk, variants = _with_disk(settings_dialog, ["base"])
+    with on_disk, variants:
+        chosen = dialog_class._on_disk_stand_in(Mock(), "base.en", "base", "en-us")
+    assert chosen == "base"
+
+
+def test_the_derived_variant_is_kept_when_it_is_already_on_disk(settings_dialog, dialog_class):
+    on_disk, variants = _with_disk(settings_dialog, ["base", "base.en"])
+    with on_disk, variants:
+        assert dialog_class._on_disk_stand_in(Mock(), "base.en", "base", "en-us") == "base.en"
+
+
+def test_english_only_weights_never_stand_in_for_another_language(settings_dialog, dialog_class):
+    on_disk, variants = _with_disk(settings_dialog, ["base.en"])
+    with on_disk, variants:
+        assert dialog_class._on_disk_stand_in(Mock(), "base", "base", "pl") == "base"
+
+
+def test_english_only_weights_never_stand_in_for_detection(settings_dialog, dialog_class):
+    on_disk, variants = _with_disk(settings_dialog, ["base.en"])
+    with on_disk, variants:
+        assert dialog_class._on_disk_stand_in(Mock(), "base", "base", "auto") == "base"
+
+
+def test_nothing_of_that_size_on_disk_means_the_derived_variant_and_a_download(
+    settings_dialog, dialog_class
+):
+    on_disk, variants = _with_disk(settings_dialog, ["medium.en"])
+    with on_disk, variants:
+        assert dialog_class._on_disk_stand_in(Mock(), "base.en", "base", "en-us") == "base.en"
+
+
+def test_a_plain_weight_is_preferred_over_a_quantized_one(settings_dialog, dialog_class):
+    on_disk, variants = _with_disk(settings_dialog, ["base-q5_1", "base"])
+    with on_disk, variants:
+        assert dialog_class._on_disk_stand_in(Mock(), "base.en", "base", "en-us") == "base"
+
+
+def test_simple_mode_consults_the_disk_before_settling_on_a_variant(settings_dialog, dialog_class):
+    dialog = _dialog_stub(language="en-us", multi=False, priority=BALANCED, recommended="small")
+    dialog._on_disk_stand_in.side_effect = lambda variant, size, language: "small"
+
+    dialog_class._apply_simple_choice(dialog)
+
+    dialog._on_disk_stand_in.assert_called_once_with("small.en", "small", "en-us")
+    dialog.model_variant_combo.set_active_id.assert_called_once_with("small")

--- a/tests/test_simple_model_settings.py
+++ b/tests/test_simple_model_settings.py
@@ -52,6 +52,8 @@ def _dialog_stub(language="pl", multi=False, priority=BALANCED, recommended="sma
     dialog._initializing = False
     dialog._simple_syncing = False
     dialog._applying_settings = False
+    # A Mock attribute is truthy, which would trip the steering guard.
+    dialog._simple_driving = False
     dialog.language = language
     dialog.simple_language_combo.get_active_id.return_value = language
     dialog.simple_multi_switch.get_active.return_value = multi
@@ -210,3 +212,85 @@ def test_auto_detect_shows_up_as_the_other_languages_switch(settings_dialog, dia
     dialog_class._sync_simple_from_advanced(dialog)
 
     dialog.simple_multi_switch.set_active.assert_called_once_with(True)
+
+
+# --- regressions reported from the installed build -----------------------
+
+
+def test_the_steering_guard_is_held_for_the_whole_pick(settings_dialog, dialog_class):
+    """Picking a language froze the window: each steered combo re-applied.
+
+    _apply_simple_choice sets engine, language, size and variant, and every one of
+    those handlers ends in _auto_apply_settings, so one pick reconfigured the engine
+    up to four times on the UI thread. The guard has to be held for the whole of the
+    steering and released before the single apply that follows.
+    """
+    dialog = _dialog_stub()
+    held = []
+    dialog._apply_simple_choice.side_effect = lambda: held.append(dialog._simple_driving)
+
+    dialog_class._on_simple_choice_changed(dialog)
+
+    assert held == [True], "guard was not held while the controls were being steered"
+    assert dialog._simple_driving is False, "guard was not released afterwards"
+    dialog._auto_apply_settings.assert_called_once()
+
+
+def test_auto_apply_is_suppressed_while_simple_mode_is_steering(settings_dialog, dialog_class):
+    """The guard itself: nothing runs while the controls are being pointed."""
+    dialog = Mock()
+    dialog._applying_settings = False
+    dialog._initializing = False
+    dialog._test_active = False
+    dialog._populating_models = False
+    dialog._simple_driving = True
+
+    dialog_class._auto_apply_settings(dialog)
+
+    dialog.get_selected_settings.assert_not_called()
+
+
+def test_the_simple_language_box_accepts_typing(settings_dialog, dialog_class):
+    """A list of thirty-plus languages you cannot type into is not usable."""
+    dialog = Mock()
+    dialog._initializing = False
+    dialog._simple_syncing = False
+    dialog.simple_language_combo.get_active_id.return_value = None
+    dialog.simple_language_combo.get_child.return_value.get_text.return_value = "Pol"
+
+    with patch.object(settings_dialog, "_combo_text_rows", return_value=[("pl", "Polish")]):
+        dialog_class._commit_or_restore_simple_language_entry(dialog)
+
+    dialog.simple_language_combo.set_active_id.assert_called_once_with("pl")
+
+
+def test_unresolvable_typing_restores_the_previous_language(settings_dialog, dialog_class):
+    """Typing nonsense must not leave the box in a state the config never had."""
+    dialog = Mock()
+    dialog._initializing = False
+    dialog._simple_syncing = False
+    dialog.language = "pl"
+    dialog.simple_language_combo.get_active_id.return_value = None
+    dialog.simple_language_combo.get_child.return_value.get_text.return_value = "zzzz"
+
+    with patch.object(settings_dialog, "_combo_text_rows", return_value=[("pl", "Polish")]):
+        dialog_class._commit_or_restore_simple_language_entry(dialog)
+
+    dialog._set_combo_active_id_or_first.assert_called_once_with(dialog.simple_language_combo, "pl")
+
+
+def test_restoring_after_auto_detect_falls_back_to_a_real_language(settings_dialog, dialog_class):
+    """ "auto" is the switch, not an entry in this list, so it cannot be restored."""
+    dialog = Mock()
+    dialog._initializing = False
+    dialog._simple_syncing = False
+    dialog.language = "auto"
+    dialog.simple_language_combo.get_active_id.return_value = None
+    dialog.simple_language_combo.get_child.return_value.get_text.return_value = ""
+
+    with patch.object(settings_dialog, "_combo_text_rows", return_value=[("pl", "Polish")]):
+        dialog_class._commit_or_restore_simple_language_entry(dialog)
+
+    dialog._set_combo_active_id_or_first.assert_called_once_with(
+        dialog.simple_language_combo, "en-us"
+    )


### PR DESCRIPTION
Refs #779

**Stacked on #798** — the first commit here is that branch's picker; merge #798 first and this rebases to nine commits on its own.

The Speech Model page asked four questions, two of which cannot be answered without knowing the hardware. The app already computed both; it printed the answer beside the pickers instead of using it.

**What the page looks like now**

- **What you dictate** — main language (seeded from the keyboard layout by #796), a switch for dictating whole texts in other languages, and a priority: fastest / balanced / most accurate, relative to what hardware detection recommends.
- The info card under it, so a priority or language change shows what it picked and what it costs.
- **Advanced** — an island under that, collapsed to a header by default, expanding in place with today's engine / size / specialization / language rows, the unused downloads and the remote server. Remembered in `show_advanced`.

**How it behaves**

- Simple mode steers the existing controls and applies once, so the four downstream handlers do not each reload the engine (that froze the window on every pick).
- The switch reveals a second list whose first entry is "Any language (auto-detect)"; naming a specific second language means the same to the engine, which takes one language or none. Two English entries still pin English.
- Opening simple mode reads the priority back from the size already configured, so switching never changes the loaded model on its own; a change made in the advanced rows is read back into the simple answers.
- Before settling on a variant, simple mode looks at the disk: a same-size weight that can serve the language stands in rather than downloading a sibling (flipping the switch used to fetch base.en next to base, 141 MB, behind a modal). English-only weights never stand in for another language or for detection.
- Advanced is an island rather than a second window: a toplevel transient for the dialog crashed KWin 6.7 (`findModal` recursion, KDE Bug 483265), and standing alone it could not be raised above the dialog.

**Testing:** `tests/test_simple_model_settings.py` (44) and `tests/test_language_list_filtering.py` (14). Each mechanism was checked red: the derivation, the steering guard, the second-language visibility, the island handlers, the on-disk stand-in. Exercised on real GTK 3.24 for the picker, the island and the visibility pattern. Full suite: no new failures against main.

Not in scope: the privacy question from #779 (simple mode always picks local whisper.cpp; the cloud engine stays in Advanced), and the fallback-language question the issue leaves to maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKVa2qTLQYMCHffjp97yqT
