### PR TITLE
fix(injection): read WM_CLASS with xprop so xdotool stops dumping core

### DIFF
--- a/src/vocalinux/text_injection/focused_window.py
+++ b/src/vocalinux/text_injection/focused_window.py
@@ -203,6 +203,38 @@ def _x11_probe_env() -> dict[str, str]:
     return env
 
 
+def read_wm_class(
+    window_id: str,
+    env: Optional[dict[str, str]] = None,
+    *,
+    xdotool_fallback: bool = False,
+) -> str:
+    """Return an X11 window's WM_CLASS without tripping xdotool's abort.
+
+    ``xdotool getwindowclassname`` hands an uninitialized ``XClassHint`` to
+    ``XFree`` when the window carries no WM_CLASS, so the process dies with
+    SIGABRT ("free(): invalid size") and leaves a coredump behind. KDE Plasma
+    on Wayland hits that on every probe: while a native Wayland client holds
+    focus, KWin points XWayland's _NET_ACTIVE_WINDOW at a property-less window
+    that ``xdotool getactivewindow`` still reports as the active window.
+
+    ``xprop`` reads the property safely, so it is the primary source. xdotool
+    is used only when xprop is missing *and* the window looks like a real
+    client (it has a pid or a title), which is never true of the placeholder
+    window that triggers the crash.
+    """
+    if not window_id:
+        return ""
+    if env is None:
+        env = _x11_probe_env()
+    if shutil.which("xprop"):
+        xprop = _run_text(["xprop", "-id", window_id, "WM_CLASS"], env)
+        return " ".join(re.findall(r'"([^"]+)"', xprop))
+    if xdotool_fallback and shutil.which("xdotool"):
+        return _run_text(["xdotool", "getwindowclassname", window_id], env)
+    return ""
+
+
 def _focused_window_x11() -> Optional[FocusedWindow]:
     """Identify the active X11 / XWayland window via xdotool."""
     if not shutil.which("xdotool"):
@@ -211,14 +243,9 @@ def _focused_window_x11() -> Optional[FocusedWindow]:
     window_id = _run_text(["xdotool", "getactivewindow"], env)
     if not window_id:
         return None
-    wm_class = _run_text(["xdotool", "getwindowclassname", window_id], env)
     title = _run_text(["xdotool", "getwindowname", window_id], env)
     pid = _run_text(["xdotool", "getwindowpid", window_id], env)
-    if shutil.which("xprop") and not wm_class:
-        xprop = _run_text(["xprop", "-id", window_id, "WM_CLASS"], env)
-        quoted = re.findall(r'"([^"]+)"', xprop)
-        if quoted:
-            wm_class = " ".join(quoted)
+    wm_class = read_wm_class(window_id, env, xdotool_fallback=bool(title or pid))
     return FocusedWindow(
         wm_class=wm_class,
         title=title,

--- a/src/vocalinux/text_injection/focused_window.py
+++ b/src/vocalinux/text_injection/focused_window.py
@@ -218,10 +218,10 @@ def read_wm_class(
     focus, KWin points XWayland's _NET_ACTIVE_WINDOW at a property-less window
     that ``xdotool getactivewindow`` still reports as the active window.
 
-    ``xprop`` reads the property safely, so it is the primary source. xdotool
-    is used only when xprop is missing *and* the window looks like a real
-    client (it has a pid or a title), which is never true of the placeholder
-    window that triggers the crash.
+    ``xprop`` reads the property safely, so it is the primary source. When
+    xprop is missing and ``xdotool_fallback`` is true, xdotool is used even
+    for class-only clients (no title, no pid). A property-less placeholder
+    may then abort the child; ``_run_text`` swallows that failure.
     """
     if not window_id:
         return ""
@@ -245,7 +245,7 @@ def _focused_window_x11() -> Optional[FocusedWindow]:
         return None
     title = _run_text(["xdotool", "getwindowname", window_id], env)
     pid = _run_text(["xdotool", "getwindowpid", window_id], env)
-    wm_class = read_wm_class(window_id, env, xdotool_fallback=bool(title or pid))
+    wm_class = read_wm_class(window_id, env, xdotool_fallback=True)
     return FocusedWindow(
         wm_class=wm_class,
         title=title,

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -18,7 +18,7 @@ from typing import Optional  # noqa: F401
 
 from ..utils.host_process import host_env
 from ..utils.paths import config_dir
-from .focused_window import is_focused_window_terminal
+from .focused_window import is_focused_window_terminal, read_wm_class
 from .ibus_engine import (
     IBusTextInjector,
     is_ibus_active_input_method,
@@ -2392,17 +2392,9 @@ class TextInjector:
             window_name = result.stdout.strip()
             logger.info(f"Target window: '{window_name}' (ID: {window_id})")
 
-            # Get window class
-            result = subprocess.run(
-                ["xdotool", "getwindowclassname", window_id],
-                env=host_env(env),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                check=True,
-                timeout=2,
-            )
-            window_class = result.stdout.strip()
+            # Get window class. Not via xdotool: getwindowclassname aborts on
+            # windows that carry no WM_CLASS (see focused_window.read_wm_class).
+            window_class = read_wm_class(window_id, env, xdotool_fallback=bool(window_name))
             logger.debug(f"Window class: {window_class}")
 
             # Get window PID

--- a/src/vocalinux/text_injection/text_injector.py
+++ b/src/vocalinux/text_injection/text_injector.py
@@ -2392,9 +2392,9 @@ class TextInjector:
             window_name = result.stdout.strip()
             logger.info(f"Target window: '{window_name}' (ID: {window_id})")
 
-            # Get window class. Not via xdotool: getwindowclassname aborts on
-            # windows that carry no WM_CLASS (see focused_window.read_wm_class).
-            window_class = read_wm_class(window_id, env, xdotool_fallback=bool(window_name))
+            # Prefer xprop; xdotool classname is last-resort when xprop is missing
+            # (see focused_window.read_wm_class).
+            window_class = read_wm_class(window_id, env, xdotool_fallback=True)
             logger.debug(f"Window class: {window_class}")
 
             # Get window PID

--- a/tests/test_focused_window.py
+++ b/tests/test_focused_window.py
@@ -180,8 +180,8 @@ class TestGetFocusedWindow(unittest.TestCase):
         self.assertEqual(window.wm_class, "konsole konsole")
         self.assertTrue(looks_like_terminal(window))
 
-    def test_x11_skips_xdotool_class_for_placeholder_window(self):
-        """KWin's _NET_ACTIVE_WINDOW placeholder has no pid, title, or class."""
+    def test_x11_placeholder_classname_abort_is_contained(self):
+        """Without xprop, the placeholder still probes classname; abort is swallowed."""
         commands: list[tuple[str, ...]] = []
         with patch.dict("os.environ", {"WAYLAND_DISPLAY": ""}, clear=False):
             with patch("vocalinux.text_injection.focused_window.shutil.which") as mock_which:
@@ -194,16 +194,44 @@ class TestGetFocusedWindow(unittest.TestCase):
                             return MagicMock(returncode=0, stdout="2097152")
                         if tuple(cmd) == ("xdotool", "getwindowname", "2097152"):
                             return MagicMock(returncode=0, stdout="")
-                        # getwindowpid fails: the placeholder window has no pid.
+                        # getwindowpid / getwindowclassname fail: no pid, no class.
+                        # Classname abort is contained by _run_text (non-zero / OSError).
                         return MagicMock(returncode=1, stdout="")
 
                     mock_run.side_effect = _run
                     window = get_focused_window()
-        self.assertNotIn("getwindowclassname", [arg for cmd in commands for arg in cmd])
+        self.assertIn("getwindowclassname", [arg for cmd in commands for arg in cmd])
         self.assertIsNotNone(window)
         assert window is not None
         self.assertEqual(window.wm_class, "")
         self.assertFalse(looks_like_terminal(window))
+
+    def test_x11_class_only_client_uses_xdotool_when_xprop_missing(self):
+        """A real X11 terminal with WM_CLASS but no title/pid must still classify."""
+        commands: list[tuple[str, ...]] = []
+        with patch.dict("os.environ", {"WAYLAND_DISPLAY": ""}, clear=False):
+            with patch("vocalinux.text_injection.focused_window.shutil.which") as mock_which:
+                mock_which.side_effect = lambda cmd: "/usr/bin/" + cmd if cmd == "xdotool" else None
+                with patch("vocalinux.text_injection.focused_window.subprocess.run") as mock_run:
+
+                    def _run(cmd, **_kwargs):
+                        commands.append(tuple(cmd))
+                        if tuple(cmd) == ("xdotool", "getactivewindow"):
+                            return MagicMock(returncode=0, stdout="12345")
+                        if tuple(cmd) == ("xdotool", "getwindowname", "12345"):
+                            return MagicMock(returncode=0, stdout="")
+                        if tuple(cmd) == ("xdotool", "getwindowclassname", "12345"):
+                            return MagicMock(returncode=0, stdout="konsole")
+                        # getwindowpid fails: some clients expose class but not pid.
+                        return MagicMock(returncode=1, stdout="")
+
+                    mock_run.side_effect = _run
+                    window = get_focused_window()
+        self.assertIn("getwindowclassname", [arg for cmd in commands for arg in cmd])
+        self.assertIsNotNone(window)
+        assert window is not None
+        self.assertEqual(window.wm_class, "konsole")
+        self.assertTrue(looks_like_terminal(window))
 
     def test_probe_failure_returns_none(self):
         with patch("vocalinux.text_injection.focused_window.shutil.which", return_value=None):

--- a/tests/test_focused_window.py
+++ b/tests/test_focused_window.py
@@ -146,6 +146,65 @@ class TestGetFocusedWindow(unittest.TestCase):
         self.assertEqual(window.wm_class, "konsole")
         self.assertTrue(looks_like_terminal(window))
 
+    def test_x11_reads_wm_class_with_xprop_never_xdotool(self):
+        """xdotool getwindowclassname aborts on class-less windows; use xprop."""
+        commands: list[tuple[str, ...]] = []
+        with patch.dict("os.environ", {"WAYLAND_DISPLAY": ""}, clear=False):
+            with patch("vocalinux.text_injection.focused_window.shutil.which") as mock_which:
+                mock_which.side_effect = lambda cmd: (
+                    "/usr/bin/" + cmd if cmd in {"xdotool", "xprop"} else None
+                )
+                with patch("vocalinux.text_injection.focused_window.subprocess.run") as mock_run:
+
+                    def _run(cmd, **_kwargs):
+                        commands.append(tuple(cmd))
+                        mapping = {
+                            ("xdotool", "getactivewindow"): "12345",
+                            ("xdotool", "getwindowname", "12345"): "zsh",
+                            ("xdotool", "getwindowpid", "12345"): "77",
+                            ("xprop", "-id", "12345", "WM_CLASS"): (
+                                'WM_CLASS(STRING) = "konsole", "konsole"'
+                            ),
+                        }
+                        return MagicMock(returncode=0, stdout=mapping.get(tuple(cmd), ""))
+
+                    mock_run.side_effect = _run
+                    with patch(
+                        "vocalinux.text_injection.focused_window.open",
+                        mock_open(read_data="konsole\n"),
+                    ):
+                        window = get_focused_window()
+        self.assertNotIn("getwindowclassname", [arg for cmd in commands for arg in cmd])
+        self.assertIsNotNone(window)
+        assert window is not None
+        self.assertEqual(window.wm_class, "konsole konsole")
+        self.assertTrue(looks_like_terminal(window))
+
+    def test_x11_skips_xdotool_class_for_placeholder_window(self):
+        """KWin's _NET_ACTIVE_WINDOW placeholder has no pid, title, or class."""
+        commands: list[tuple[str, ...]] = []
+        with patch.dict("os.environ", {"WAYLAND_DISPLAY": ""}, clear=False):
+            with patch("vocalinux.text_injection.focused_window.shutil.which") as mock_which:
+                mock_which.side_effect = lambda cmd: "/usr/bin/" + cmd if cmd == "xdotool" else None
+                with patch("vocalinux.text_injection.focused_window.subprocess.run") as mock_run:
+
+                    def _run(cmd, **_kwargs):
+                        commands.append(tuple(cmd))
+                        if tuple(cmd) == ("xdotool", "getactivewindow"):
+                            return MagicMock(returncode=0, stdout="2097152")
+                        if tuple(cmd) == ("xdotool", "getwindowname", "2097152"):
+                            return MagicMock(returncode=0, stdout="")
+                        # getwindowpid fails: the placeholder window has no pid.
+                        return MagicMock(returncode=1, stdout="")
+
+                    mock_run.side_effect = _run
+                    window = get_focused_window()
+        self.assertNotIn("getwindowclassname", [arg for cmd in commands for arg in cmd])
+        self.assertIsNotNone(window)
+        assert window is not None
+        self.assertEqual(window.wm_class, "")
+        self.assertFalse(looks_like_terminal(window))
+
     def test_probe_failure_returns_none(self):
         with patch("vocalinux.text_injection.focused_window.shutil.which", return_value=None):
             self.assertIsNone(get_focused_window())


### PR DESCRIPTION
On KDE Plasma Wayland every clipboard paste leaves an `xdotool` coredump in the
journal:

```
Command Line: xdotool getwindowclassname 2097152
       Signal: 6 (ABRT)
      Message: Process ... dumped core.
               #6  XFree (libX11.so.6)
               #7  xdo_get_window_classname (libxdo.so.3)
```

**Cause.** `xdo_get_window_classname()` does not check `XGetClassHint()`'s
status, so on a window without WM_CLASS it passes an uninitialized
`XClassHint` to `XFree` and aborts. On Plasma Wayland that is the normal case:
while a native Wayland client holds focus, KWin points XWayland's
`_NET_ACTIVE_WINDOW` at a property-less window (`0x200000` here), and
`xdotool getactivewindow` reports exactly that window. `focused_window.py`
then asked xdotool for its class on every paste, to choose Ctrl+V vs
Ctrl+Shift+V.

Reproduced on Fedora 44, Plasma 6 Wayland, xdotool 3.20211022.1-10.fc44:

```
$ xprop -root _NET_ACTIVE_WINDOW      # -> window id # 0x200000
$ xprop -id 0x200000                  # -> no properties at all
$ xdotool getwindowclassname 0x200000 # -> "free(): invalid size", exit 134
```

Injection itself kept working: the abort only made the probe return an empty
class, and the existing xprop path filled it in afterwards. The visible damage
was a coredump per dictation, plus the wasted work.

**Fix.** `read_wm_class()` reads WM_CLASS with `xprop`, which treats a missing
property as an ordinary empty result. xdotool is used only when xprop is not
installed *and* the window looks like a real client (it has a pid or a title) -
never true of the placeholder window that triggers the crash. The debug
window-info logging in `text_injector.py` goes through the same helper, since
it called `getwindowclassname` with `check=True` and crashed the same way.

**Tests.** Two regression tests in `tests/test_focused_window.py`: the probe
must not run `getwindowclassname` when xprop is available, and must not run it
for a placeholder window with no pid and no title. Both fail on main (they see
the `getwindowclassname` call) and pass here.

Full suite: 2914 passed, same 8 pre-existing environment failures as
`upstream/main` (ibus/gi and layout-map modules missing locally); no new
failures. flake8/black/isort as configured in the pipeline are clean.
