### PR TITLE
fix(tray): make PTT tray icon turn red on every hold

### DIFF
--- a/src/vocalinux/ui/tray_indicator.py
+++ b/src/vocalinux/ui/tray_indicator.py
@@ -161,6 +161,11 @@ class TrayIndicator:
                 self.icon_names["processing"] if FLATPAK_ID else self.icon_paths["processing"]
             ),
         }
+        # Last IconName applied this session. StatusNotifier hosts skip a
+        # redraw when the same path is reused; _set_indicator_icon nudges
+        # IconThemePath so gray→red→gray→red actually turns red again.
+        self._last_icon_key: Optional[str] = None
+        self._icon_theme_nudge = False
 
         # Register for speech recognition state changes
         self.speech_engine.register_state_callback(self._on_recognition_state_changed)
@@ -691,6 +696,24 @@ class TrayIndicator:
             self.speech_engine.end_download()
             self._model_download_active = False
 
+    def _set_indicator_icon(self, icon_key: str, description: str) -> None:
+        """Apply a tray icon, forcing a host redraw when cycling reused paths.
+
+        Ayatana/GNOME StatusNotifier hosts often skip a redraw when IconName
+        returns to a path already used earlier in the session. Alternating
+        IconThemePath between ICON_DIR and ICON_DIR + os.sep triggers a reload
+        while keeping absolute paths (theme names would regress the stale
+        ~/.local/share/icons hicolor placeholder). Flatpak uses themed names
+        and does not need the nudge.
+        """
+        if not FLATPAK_ID and self._last_icon_key is not None:
+            nudge = getattr(self.indicator, "set_icon_theme_path", None)
+            if callable(nudge):
+                self._icon_theme_nudge = not self._icon_theme_nudge
+                nudge(ICON_DIR + os.sep if self._icon_theme_nudge else ICON_DIR)
+        self.indicator.set_icon_full(icon_key, description)
+        self._last_icon_key = icon_key
+
     def _update_ui(self, state: RecognitionState):
         """
         Update the UI based on the recognition state.
@@ -708,19 +731,19 @@ class TrayIndicator:
             state = engine_state
 
         if state == RecognitionState.IDLE:
-            self.indicator.set_icon_full(self._icon_keys["default"], "Microphone off")
+            self._set_indicator_icon(self._icon_keys["default"], "Microphone off")
             self._set_menu_item_enabled("Start Voice Typing", True)
             self._set_menu_item_enabled("Stop Voice Typing", False)
         elif state == RecognitionState.LISTENING:
-            self.indicator.set_icon_full(self._icon_keys["active"], "Microphone on")
+            self._set_indicator_icon(self._icon_keys["active"], "Microphone on")
             self._set_menu_item_enabled("Start Voice Typing", False)
             self._set_menu_item_enabled("Stop Voice Typing", True)
         elif state == RecognitionState.PROCESSING:
-            self.indicator.set_icon_full(self._icon_keys["processing"], "Processing speech")
+            self._set_indicator_icon(self._icon_keys["processing"], "Processing speech")
             self._set_menu_item_enabled("Start Voice Typing", False)
             self._set_menu_item_enabled("Stop Voice Typing", True)
         elif state == RecognitionState.ERROR:
-            self.indicator.set_icon_full(self._icon_keys["default"], "Error")
+            self._set_indicator_icon(self._icon_keys["default"], "Error")
             self._set_menu_item_enabled("Start Voice Typing", True)
             self._set_menu_item_enabled("Stop Voice Typing", False)
 

--- a/tests/test_tray_indicator.py
+++ b/tests/test_tray_indicator.py
@@ -869,7 +869,15 @@ class TestTrayIndicator(unittest.TestCase):
         self.assertEqual(len(listening_calls), 2)
         for call in listening_calls:
             self.assertEqual(call[0][1], "Microphone on")
-        self.assertGreaterEqual(indicator.set_icon_theme_path.call_count, 2)
+        from vocalinux.ui.tray_indicator import ICON_DIR
+
+        # _init_indicator already applied the default icon, so each cycle step
+        # nudges IconThemePath. Assert the alternating args, not only count.
+        theme_paths = [call[0][0] for call in indicator.set_icon_theme_path.call_args_list]
+        self.assertEqual(
+            theme_paths,
+            [ICON_DIR + os.sep, ICON_DIR, ICON_DIR + os.sep, ICON_DIR],
+        )
 
     def test_set_menu_item_enabled_noop_when_menu_missing(self):
         if hasattr(self.tray_indicator, "menu"):

--- a/tests/test_tray_indicator.py
+++ b/tests/test_tray_indicator.py
@@ -832,6 +832,45 @@ class TestTrayIndicator(unittest.TestCase):
         )
         self.assertEqual(result, False)
 
+    def test_update_ui_ptt_cycle_reapplies_active_icon(self):
+        """PTT IDLE→LISTENING→IDLE→LISTENING must set the active icon both times.
+
+        StatusNotifier hosts skip a redraw when IconName returns to a path
+        already used this session; the helper must still call set_icon_full
+        on the second LISTENING and nudge IconThemePath outside Flatpak.
+        """
+        indicator = MagicMock()
+        self.tray_indicator.indicator = indicator
+        mock_menu_item = MagicMock()
+        mock_menu_item.get_label.return_value = "Start Voice Typing"
+        self.tray_indicator.menu = MagicMock()
+        self.tray_indicator.menu.get_children.return_value = [mock_menu_item]
+
+        cycle = (
+            self.RecognitionState.IDLE,
+            self.RecognitionState.LISTENING,
+            self.RecognitionState.IDLE,
+            self.RecognitionState.LISTENING,
+        )
+        with patch("vocalinux.ui.tray_indicator.Gtk") as patched_gtk:
+            patched_gtk.MenuItem = type(mock_menu_item)
+            with patch("vocalinux.ui.tray_indicator.FLATPAK_ID", None):
+                for state in cycle:
+                    self.mock_speech_engine.state = state
+                    self.tray_indicator._update_ui(state)
+
+        active = self.tray_indicator._icon_keys["active"]
+        default = self.tray_indicator._icon_keys["default"]
+        icon_names = [call[0][0] for call in indicator.set_icon_full.call_args_list]
+        self.assertEqual(icon_names, [default, active, default, active])
+        listening_calls = [
+            call for call in indicator.set_icon_full.call_args_list if call[0][0] == active
+        ]
+        self.assertEqual(len(listening_calls), 2)
+        for call in listening_calls:
+            self.assertEqual(call[0][1], "Microphone on")
+        self.assertGreaterEqual(indicator.set_icon_theme_path.call_count, 2)
+
     def test_set_menu_item_enabled_noop_when_menu_missing(self):
         if hasattr(self.tray_indicator, "menu"):
             delattr(self.tray_indicator, "menu")


### PR DESCRIPTION
Refs #604

## What was broken

hopsayer on 0.16.2 (AUR, GNOME Wayland): Right-Alt push-to-talk turns the tray red on the first hold only. Later holds still dictate and inject text, but the icon stays gray until you restart the app.

#604 itself was mostly the hybrid GPU work and is already closed. This is the tray follow-up from that thread, not another GPU change.

Opposite stuck-red case was #739 / #741 (leftover PROCESSING after toggle stop). That fix stays as-is.

## Cause

Outside Flatpak the tray passes absolute icon paths into `set_icon_full`. Ayatana / GNOME StatusNotifier hosts often skip a redraw when `IconName` returns to a path already used earlier in the session, so the cycle gray → red → gray → red leaves the icon gray.

Dictation kept working because recognition state was fine. Only the indicator paint stuck.

## Fix

`_set_indicator_icon` wraps every tray `set_icon_full` call. After the first apply in a session it nudges `IconThemePath` between `ICON_DIR` and `ICON_DIR + os.sep` before setting the icon, which forces the host to reload while still using absolute paths (theme names would bring back the stale `~/.local/share/icons` hicolor placeholder). Flatpak keeps themed names and skips the nudge.

`_update_ui` still paints `speech_engine.state` over a stale `GLib.idle_add` argument (#739).

## Test plan

- [x] `PYTHONPATH=src pytest tests/test_tray_indicator.py tests/test_tray_indicator_ext.py -q` (60 passed)
- [ ] Manual: push-to-talk with Right-Alt. First hold red, release gray, second and later holds red again without restart.
- [ ] Sanity: toggle mode Alt+F12 still clears and stays idle after a long leftover drain (#739).