### PR TITLE
fix(web): homepage VocaWin card still said v0.1.0-beta.1

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -958,7 +958,7 @@ export default function HomePage() {
               </div>
               <h3>VocaWin</h3>
               <p>
-                Unsigned Windows speech-to-text, v0.1.0-beta.1. SmartScreen may
+                Unsigned Windows speech-to-text, v0.1.1-beta. SmartScreen may
                 warn about an unknown publisher.
               </p>
             </a>


### PR DESCRIPTION
## Description

Homepage family strip still showed VocaWin at `v0.1.0-beta.1`. PRODUCT.md and the Win release are on `v0.1.1-beta`, so the card was stale.

One string change in `web/src/app/page.tsx`. Unsigned / SmartScreen line stays. Other family cards, Vocalinux spelling, and the Linux site look are untouched.

## Related issue

Fixes #811

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor
- [ ] Tests
- [ ] Packaging / CI

## Checklist

- [x] Code follows project style (Black, isort, flake8)
- [x] Documentation updated when user-facing behavior or install steps change
- [ ] Tests added or updated for the change
- [ ] Local tests pass (`pytest`)
- [x] Conventional commit message style

## Notes for reviewers

Known limit: README family table still says `v0.1.0-beta.1`. Out of scope for #811 (homepage card / `web/` only).