### PR TITLE
fix(snap): load About SVG icons under core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,6 +68,15 @@ apps:
       PATH: $SNAP/usr/bin:$SNAP/bin:$PATH
       # PortAudio opens ALSA first. Point at snap-local config that routes to Pulse.
       ALSA_CONFIG_PATH: $SNAP/etc/asound.conf
+      # core24 gnome-46-2404: desktop-launch rebuilds gdk-pixbuf-loaders.cache
+      # by running query-loaders, which picks the SVG loader from the first
+      # LD_LIBRARY_PATH entry ending in /$CRAFT_ARCH_TRIPLET. Stage-packages
+      # (via libavcodec and friends) put a gdk-pixbuf tree without
+      # libpixbufloader_svg.so at $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET, ahead of
+      # gnome-platform. About page and other GdkPixbuf SVG loads then fail
+      # with "Image type svg is not supported".
+      # https://forum.snapcraft.io/t/missing-svg-support-for-gtk3-in-core24/48851
+      LD_LIBRARY_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET:$LD_LIBRARY_PATH
 
 # Make ALSA data/plugins visible at the paths libasound expects.
 layout:

--- a/tests/test_snap_packaging.py
+++ b/tests/test_snap_packaging.py
@@ -31,6 +31,22 @@ def test_snapcraft_recipe_and_gui_assets() -> None:
     assert SNAP_PNG.stat().st_size > 0
 
 
+def test_snap_puts_gnome_platform_first_on_ld_library_path() -> None:
+    """core24 gdk-pixbuf finds libpixbufloader_svg.so only if gnome-platform wins.
+
+    Stage-packages pull a second gdk-pixbuf (no SVG loader) into
+    $SNAP/usr/lib/<triplet>. desktop-launch's query-loaders walks the first
+    LD_LIBRARY_PATH entry that ends in that triplet, so gnome-platform must
+    come first or About-page SVGs fail with "Image type svg is not supported".
+    """
+    doc = yaml.safe_load(SNAPCRAFT_YAML.read_text(encoding="utf-8"))
+    env = (doc.get("apps") or {}).get("vocalinux", {}).get("environment") or {}
+    ld_path = env.get("LD_LIBRARY_PATH")
+    assert isinstance(ld_path, str)
+    assert ld_path.startswith("$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET:")
+    assert ld_path.endswith(":$LD_LIBRARY_PATH")
+
+
 def test_snap_strips_pygobject_and_uses_gnome_gi() -> None:
     """Pip must not build PyGObject; GI comes from the gnome extension."""
     text = SNAPCRAFT_YAML.read_text(encoding="utf-8")


### PR DESCRIPTION
## Description

The edge snap (rev 7) ships the SVG files, but Settings -> About cannot decode them:

```
Failed to load About icon: ... Couldn't recognize the image file format for file ".../vocalinux.svg"
Failed to load About mark github: ... Image type "svg" is not supported
```

Same for discord, x, mail, and the family platform marks.

gnome-46-2404 has `libpixbufloader_svg.so`. desktop-launch rebuilds `~/snap/vocalinux/common/.cache/gdk-pixbuf-loaders.cache` with `gdk-pixbuf-query-loaders`, which takes the SVG loader from the first `LD_LIBRARY_PATH` entry that ends in the arch triplet. Stage-packages (libavcodec and friends) put a second gdk-pixbuf without that loader at `$SNAP/usr/lib/<triplet>`, ahead of gnome-platform. The cache has no SVG, and GdkPixbuf gives up.

This is the known core24 GTK3 gap: https://forum.snapcraft.io/t/missing-svg-support-for-gtk3-in-core24/48851

Fix: prepend `$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET` to `LD_LIBRARY_PATH`. On the installed edge snap, with that order, `PixbufLoader.new_with_type("svg")` works and `vocalinux.svg` loads at 460x460. Regenerating the cache alone is not enough: the snap's older librsvg then fails with `undefined symbol: rsvg_handle_get_pixbuf_and_error`.

The published 0.16.2 snap stays broken until we rebuild and push a new revision.

## Related issue

Follow-up to #48 / #519. Dogfood on edge 0.16.2 rev 7.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor
- [x] Tests
- [x] Packaging / CI

## Checklist

- [x] Code follows project style (Black, isort, flake8)
- [x] Documentation updated when user-facing behavior or install steps change
- [x] Tests added or updated for the change
- [x] Local tests pass (`pytest`): `tests/test_snap_packaging.py`
- [x] Conventional commit message style

## Screenshots (if applicable)

N/A. Needs a snap rebuild to confirm in Settings -> About.

## Notes for reviewers

- After merge, `snapcraft pack` or the next `publish-snap` on a `v*` tag is what ships this to edge.
- Staging `librsvg2-common` is not enough. query-loaders still looks at the first triplet dir, and the snap's librsvg 2.50 cannot satisfy gnome-platform's loader (needs 2.61).
- Prepending gnome-platform is also what the existing comment already wanted: do not let `$SNAP/usr/lib` win over the platform GLib/GTK.
